### PR TITLE
add .DS_Store files and .idea directory to the ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/
 bin/Debug/net6.0/API.exe
 Redux.sln
 global.json
+.DS_Store
+.idea/


### PR DESCRIPTION
merge this after #32 has been modified and merged without its cruft. This will prevent future folks from trying to commit MacOS droppings and intellij configs.
