### PR TITLE
check for nulled strings and skip them

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Graph.cs
+++ b/AdditionalControllers/Navigation/Nav_Graph.cs
@@ -53,7 +53,9 @@ class ProblemGraph {
     
         if(problems != null){
 
-            foreach(string? problem in problems ){
+            foreach(var problem in problems ){
+                if (problem == null)
+                    continue;
                 // Console.WriteLine("ProblemNode:  "+problem);
                 string[] splitStr = problem.Split('_');
                 this.graph.Add(splitStr[1].ToLower(), parseReducesTo(problem));
@@ -277,44 +279,45 @@ class ProblemGraph {
 
         try{
 
-                 subdirs = Directory.GetDirectories(projectSourcePath+ @"Problems/" + problemTypeDirectory + "/" + chosenProblem + "/ReduceTo")
-                            .Select(Path.GetFileName)
-                            .ToArray();
+            subdirs = Directory.GetDirectories(projectSourcePath+ @"Problems/" + problemTypeDirectory + "/" + chosenProblem + "/ReduceTo")
+                      .Select(Path.GetFileName)
+                      .ToArray();
 
-        
-
-            foreach(string problemDirName in subdirs) {
-
+            foreach(var problemDirName in subdirs) {
+                if (problemDirName is null)
+                    continue;
                 string[] splitStr = problemDirName.Split('_');
                 string newName = splitStr[1];
                 subdirsNoPrefix.Add(newName);
            }
            
 
-        }  catch (System.IO.DirectoryNotFoundException dirNotFoundException){
-           // Console.WriteLine( " directory not found, exception was thrown in Nav_Reductions.cs");
-            // Console.WriteLine(dirNotFoundException.StackTrace);
+        }  catch (System.IO.DirectoryNotFoundException){
 
         } finally{
 
         }
 
         for(int i = 0; i < subdirs.Length; i++){
-            string problemName = subdirsNoPrefix[i].ToString();
+            var subdirObject = subdirsNoPrefix[i];
+            if (subdirObject is null)
+                continue;
+            var problemName = subdirObject.ToString();
+            if (problemName is null)
+                continue;
 
-                string?[] subfiles = Directory.GetFiles(projectSourcePath+ @"Problems/" + problemTypeDirectory + "/" + chosenProblem + "/ReduceTo/" + subdirs[i])
-                            .Select(Path.GetFileName)
-                            .ToArray();
+            string?[] subfiles = Directory.GetFiles(projectSourcePath+ @"Problems/" + problemTypeDirectory + "/" + chosenProblem + "/ReduceTo/" + subdirs[i])
+                                 .Select(Path.GetFileName)
+                                 .ToArray();
 
-                // string reductionMethods = "";
-                // foreach(string? method in subfiles){
-                //     reductionMethods += method+", "; 
-                // }
-                dict.Add(problemName.ToLower(), subfiles.ToList());
-
-                // reductionMethods = reductionMethods.TrimEnd(',').Trim();
-                // problemsReducedTo.Add(new ProblemNode(subdirsNoPrefix[i].ToString(), reductionMethods));
-
+            // safely any nulls
+            List<string> subfilesList = new List<string>();
+            foreach (var file in subfiles) {
+                if (file is null)
+                    continue;
+                subfilesList.Add(file);
+            }
+            dict.Add(problemName.ToLower(), subfilesList);
         }
            
 

--- a/AdditionalControllers/Navigation/Nav_Problems.cs
+++ b/AdditionalControllers/Navigation/Nav_Problems.cs
@@ -76,8 +76,10 @@ public class NPC_ProblemsController : ControllerBase {
                             .ToArray();
 
         ArrayList jsonedList = new ArrayList();
-        foreach(string problemInstance in subdirs){
-        string jsonPair = $"{{\"{objectPrefix}\" : \"{problemInstance}\"}}";
+        foreach(var problemInstance in subdirs){
+            if (problemInstance is null)
+                continue;
+            string jsonPair = $"{{\"{objectPrefix}\" : \"{problemInstance}\"}}";
             jsonedList.Add(jsonPair);
         }
         
@@ -111,7 +113,9 @@ public class NPC_ProblemsRefactorController : ControllerBase {
                         .ToArray();
 
         ArrayList subdirsNoPrefix = new ArrayList();
-        foreach(string problemDirName in subdirs){
+        foreach(var problemDirName in subdirs){
+            if (problemDirName is null)
+                continue;
             string[] splitStr = problemDirName.Split('_');
             string newName = splitStr[1];
             subdirsNoPrefix.Add(newName);
@@ -143,8 +147,10 @@ public class NPC_ProblemsRefactorController : ControllerBase {
                             .ToArray();
 
         ArrayList jsonedList = new ArrayList();
-        foreach(string problemInstance in subdirs){
-        string jsonPair = $"{{\"{objectPrefix}\" : \"{problemInstance}\"}}";
+        foreach(var problemInstance in subdirs){
+            if (problemInstance is null)
+                continue;
+            string jsonPair = $"{{\"{objectPrefix}\" : \"{problemInstance}\"}}";
             jsonedList.Add(jsonPair);
         }
         

--- a/AdditionalControllers/Navigation/Nav_Reductions.cs
+++ b/AdditionalControllers/Navigation/Nav_Reductions.cs
@@ -160,7 +160,9 @@ public class Problem_ReductionsRefactorController : ControllerBase {
                             .ToArray();
 
         ArrayList subdirsNoPrefix = new ArrayList();
-        foreach(string problemDirName in subdirs){
+        foreach(var problemDirName in subdirs){
+            if (problemDirName is null)
+                continue;
             string[] splitStr = problemDirName.Split('_');
             string newName = splitStr[1];
             subdirsNoPrefix.Add(newName);
@@ -265,8 +267,10 @@ public class PossibleReductionsRefactorController : ControllerBase {
                                 .ToArray();
 
             ArrayList subFilesList = new ArrayList();
-            foreach (string file in subfiles)
+            foreach (var file in subfiles)
             {
+                if (file is null)
+                    continue;
                 string fileNoExt = file.Split('.')[0];
                 subFilesList.Add(fileNoExt);
             }

--- a/AdditionalControllers/Navigation/Nav_Solvers.cs
+++ b/AdditionalControllers/Navigation/Nav_Solvers.cs
@@ -113,8 +113,10 @@ public class Problem_SolversRefactorController : ControllerBase {
 
             ArrayList subFilesList = new ArrayList();
 
-            foreach (string file in subfiles)
+            foreach (var file in subfiles)
             {
+                if (file is null)
+                    continue;
                 string fileNoExt = file.Split('.')[0]; //gets the file without the file extension
                 subFilesList.Add(fileNoExt);
             }

--- a/AdditionalControllers/Navigation/Nav_Verifiers.cs
+++ b/AdditionalControllers/Navigation/Nav_Verifiers.cs
@@ -123,8 +123,10 @@ public class Problem_VerifiersRefactorController : ControllerBase {
 
             ArrayList subFilesList = new ArrayList();
 
-            foreach (string file in subfiles)
+            foreach (var file in subfiles)
             {
+                if (file is null)
+                    continue;
                 string fileNoExt = file.Split('.')[0]; //gets the file without the file extension
                 subFilesList.Add(fileNoExt);
             }

--- a/AdditionalControllers/Navigation/Nav_Visualizations.cs
+++ b/AdditionalControllers/Navigation/Nav_Visualizations.cs
@@ -123,8 +123,10 @@ public class Problem_VisualizationsRefactorController : ControllerBase {
 
             ArrayList subFilesList = new ArrayList();
 
-            foreach (string file in subfiles)
+            foreach (var file in subfiles)
             {
+                if (file is null)
+                    continue;
                 string fileNoExt = file.Split('.')[0]; //gets the file without the file extension
                 subFilesList.Add(fileNoExt);
             }


### PR DESCRIPTION
This fixes all of the compiler warnings in `AdditionalControllers/Navigation/`. The big culprit was not checking for null strings in the results for `GetDirectories`. The only non-trivial change is to `Nav_Graph.cs` which required a several step process to handle null results.

My goal is to get to the point where I can actually use the compiler output and see new warnings I create: 151 warnings to go (138 of those come from microqiskit, tbf).