### PR TITLE
add a skeleton quantum circuit visualizer API and implement for Deutsch

### DIFF
--- a/Interfaces/JSON_Objects/API_QUANTUMCIRCUIT.cs
+++ b/Interfaces/JSON_Objects/API_QUANTUMCIRCUIT.cs
@@ -1,0 +1,8 @@
+
+namespace API.Interfaces.JSON_Objects;
+
+class API_QUANTUMCIRCUIT : API_JSON
+{
+    public string? solution { get; set; }
+    public string? circuit { get; set; }
+}

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -1,0 +1,35 @@
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Problems.NPComplete.NPC_DEUTSCH;
+
+class DeutschDefaultVisualization : IVisualization<DEUTSCH>
+{
+    public string visualizationName { get; } = "Deutsch problem visualization";
+    public string visualizationDefinition { get; } = "This is a default visualization for the Deutsch problem";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Jason L. Wright" };
+    public string visualizationType { get; } = "Quantum Circuit";
+
+    // --- Methods Including Constructors ---
+    public DeutschDefaultVisualization()
+    {
+
+    }
+    public API_JSON visualize(DEUTSCH instance)
+    {
+        return new API_QUANTUMCIRCUIT();
+
+    }
+
+    public API_JSON SolvedVisualization(DEUTSCH instance, string solution)
+    {
+        var qc = new API_QUANTUMCIRCUIT();
+        qc.solution = solution;
+
+        // XXX for now, just return a hardcoded circuit, eventually we'll
+        // XXX fetch it out of the instance
+
+        qc.circuit = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[2];\ncreg c[1];\nx q[1];\nh q[0];\nh q[1];\ncx q[0],q[1];\nx q[1];\nh q[0];\nmeasure q[0] -> c[0];";
+        return qc;
+    }
+}


### PR DESCRIPTION
This is a hardcoded json interface for the backend for Deutsch. Basically, this creates a QuantumCircuit JSON API consisting of two elements: solution and circuit. Either or both of these fields may be null (not yet solved, no corresponding circuit).

As a hack, it always returns the same QASM 2.0 circuit (will be fixed when we can round trip the circuit from quantumsolver backend.