### PR TITLE
Complementary PR for Frontend PR #53

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -128,6 +128,22 @@ public class ProblemProvider : ControllerBase
         return Newtonsoft.Json.JsonConvert.SerializeObject(ProblemInstance(problem, problemInstance));
     }
 
+    private static bool IsEmptyVisualization(API_JSON item)
+    {
+        if (item is API_empty) return true;
+
+        if (item is API_QUANTUMCIRCUIT circuit)
+        {
+            bool hasSolution = !string.IsNullOrWhiteSpace(circuit.solution);
+            bool hasQasm = !string.IsNullOrWhiteSpace(circuit.qasm);
+            bool hasD3 = circuit.d3.HasValue && circuit.d3.Value.ValueKind != JsonValueKind.Undefined && circuit.d3.Value.ValueKind != JsonValueKind.Null;
+
+            return !(hasSolution || hasQasm || hasD3);
+        }
+
+        return false;
+    }
+
     private string getVisualize(IVisualization visualization, List<string> steps, string solution, string instance)
     {
         var options = new JsonSerializerOptions
@@ -140,9 +156,15 @@ public class ProblemProvider : ControllerBase
         List<API_JSON> apiSteps = visualization.StepsVisualization(instance, steps);
         API_JSON solutionJson = visualization.SolvedVisualization(instance, solution);
 
-        List<API_JSON> list = new List<API_JSON> { visual };
-        list.AddRange(apiSteps);
-        if (solution.GetType() != typeof(API_empty)) list.Add(solutionJson);
+        List<API_JSON> list = new List<API_JSON>();
+
+        if (!IsEmptyVisualization(visual))
+            list.Add(visual);
+
+        list.AddRange(apiSteps.Where(step => !IsEmptyVisualization(step)));
+
+        if (!IsEmptyVisualization(solutionJson))
+            list.Add(solutionJson);
 
         return JsonSerializer.Serialize(list, options);
     }

--- a/Interfaces/JSON_Objects/API_D3CIRCUIT.cs
+++ b/Interfaces/JSON_Objects/API_D3CIRCUIT.cs
@@ -1,8 +1,0 @@
-using API.Interfaces.JSON_Objects;
-
-namespace API.Interfaces.JSON_Objects;
-
-class API_D3CIRCUIT : API_JSON
-{
-    public string payload { get; set; } = "";
-}

--- a/Interfaces/JSON_Objects/API_D3CIRCUIT.cs
+++ b/Interfaces/JSON_Objects/API_D3CIRCUIT.cs
@@ -1,0 +1,8 @@
+using API.Interfaces.JSON_Objects;
+
+namespace API.Interfaces.JSON_Objects;
+
+class API_D3CIRCUIT : API_JSON
+{
+    public string payload { get; set; } = "";
+}

--- a/Interfaces/JSON_Objects/API_QUANTUMCIRCUIT.cs
+++ b/Interfaces/JSON_Objects/API_QUANTUMCIRCUIT.cs
@@ -1,8 +1,61 @@
-
 namespace API.Interfaces.JSON_Objects;
 
-class API_QUANTUMCIRCUIT : API_JSON
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+/// <summary>
+/// Supported output formats for quantum circuit visualizations.
+/// </summary>
+public enum QuantumCircuitFormat
 {
+    /// <summary>
+    /// Raw OpenQASM string representation.
+    /// </summary>
+    QASM,
+
+    /// <summary>
+    /// Structured JSON payload for D3-based visualization.
+    /// </summary>
+    D3
+}
+
+/// <summary>
+/// Common response object for quantum circuit visualizations.
+/// A visualization may provide either a QASM string or a structured D3 payload.
+/// </summary>
+public sealed class API_QUANTUMCIRCUIT : API_JSON
+{
+    /// <summary>
+    /// The solution to the quantum problem
+    /// </summary>
     public string? solution { get; set; }
+
+    /// <summary>
+    /// Indicates which circuit representation is populated.
+    /// </summary>
+    public QuantumCircuitFormat format { get; set; }
+
+    /// <summary>
+    /// Raw OpenQASM circuit string.
+    /// Used by QASM-based visualizations.
+    /// </summary>
+    public string? qasm { get; set; }
+
+    /// <summary>
+    /// Structured circuit payload for D3-based visualizations.
+    /// </summary>
+    public JsonElement? d3 { get; set; }
+
+    /// <summary>
+    /// Optional metadata associated with the visualization.
+    /// </summary>
+    public Dictionary<string, object?>? metadata { get; set; }
+
+    /// <summary>
+    /// Legacy circuit field retained for backward compatibility.
+    /// Prefer <see cref="qasm"/> or <see cref="d3"/>.
+    /// </summary>
+    [Obsolete("Use qasm or d3 instead of circuit.")]
     public string? circuit { get; set; }
 }

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
@@ -13,7 +13,7 @@ class BernsteinVaziraniD3Visualization : IVisualization<BERNSTEINVAZIRANI>
     public string visualizationDefinition { get; } =
         "Constructs a quantum circuit to recover the secret bit string with a single oracle query.";
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Andreas Kramer" };
+    public string[] contributors { get; } = { "Andreas Kramer, Courtney Bodily, Rakesh Itani" };
     public string visualizationType { get; } = "Quantum Circuit D3";
 
     public BernsteinVaziraniD3Visualization() { }

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
@@ -11,7 +11,7 @@ class BernsteinVaziraniD3Visualization : IVisualization<BERNSTEINVAZIRANI>
 {
     public string visualizationName { get; } = "Bernstein-Vazirani Quantum Circuit (D3)";
     public string visualizationDefinition { get; } =
-        "Constructs a quantum circuit to recover the secret bit string with a single oracle query.";
+        "Builds the Bernstein-Vazirani circuit with ancilla, highlights the oracle that encodes the secret string, and shows how a single query plus phase kickback reveals the hidden bits in D3.js.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Andreas Kramer, Courtney Bodily, Rakesh Itani" };
     public string visualizationType { get; } = "Quantum Circuit D3";

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
@@ -4,28 +4,29 @@ using System.Linq;
 using System.Text.Json;
 using API.Interfaces;
 using API.Interfaces.JSON_Objects;
-using API.Problems.NPComplete.NPC_DEUTSCH;
+using API.Problems.NPComplete.NPC_BERNSTEINVAZIRANI;
 using API.Tools;
 
-class DeutschD3Visualization : IVisualization<DEUTSCH>
+class BernsteinVaziraniD3Visualization : IVisualization<BERNSTEINVAZIRANI>
 {
-    public string visualizationName { get; } = "Deutsch Quantum Circuit (D3)";
-    public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
+    public string visualizationName { get; } = "Bernstein-Vazirani Quantum Circuit (D3)";
+    public string visualizationDefinition { get; } =
+        "Constructs a quantum circuit to recover the secret bit string with a single oracle query.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Andreas Kramer" };
     public string visualizationType { get; } = "Quantum Circuit D3";
 
-    public DeutschD3Visualization() { }
+    public BernsteinVaziraniD3Visualization() { }
 
     private sealed class D3GateOp
     {
         public string id { get; set; } = "";
-        public string type { get; set; } = "";          // "h", "x", "cx", "m", "oracle", ...
+        public string type { get; set; } = "";
         public string[] targets { get; set; } = Array.Empty<string>();
-        public string[]? classical { get; set; }        // only for measurement
-        public double[]? @params { get; set; }          // for rz/ry/rx/u3 etc. later
-        public string? label { get; set; }              // used by oracle/block
-        public double time { get; set; }                // assigned by scheduler (offset for measurements)
+        public string[]? classical { get; set; }
+        public double[]? @params { get; set; }
+        public string? label { get; set; }
+        public double time { get; set; }
     }
 
     private sealed class D3Payload
@@ -33,41 +34,40 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         public string[] qubits { get; set; } = Array.Empty<string>();
         public string[] classical { get; set; } = Array.Empty<string>();
         public List<D3GateOp> gates { get; set; } = new();
-        public List<D3Overlay> overlays { get; set; } = new();    
+        public List<D3Overlay> overlays { get; set; } = new();
         public Dictionary<string, object?> metadata { get; set; } = new();
     }
 
     private sealed class D3Overlay
     {
         public string id { get; set; } = "";
-        public string type { get; set; } = "stage";     // e.g. "oracle", "stage"
-        public string label { get; set; } = "";         
+        public string type { get; set; } = "stage";
+        public string label { get; set; } = "";
         public int timeStart { get; set; }
-        public int timeEnd { get; set; }                
-        public string[] targets { get; set; } = Array.Empty<string>(); // optional
+        public int timeEnd { get; set; }
+        public string[] targets { get; set; } = Array.Empty<string>();
     }
 
-
-    public API_JSON visualize(DEUTSCH instance)
+    public API_JSON visualize(BERNSTEINVAZIRANI instance)
     {
         return BuildVisualization(instance, solution: null);
     }
 
-    public API_JSON SolvedVisualization(DEUTSCH instance, string solution)
+    public API_JSON SolvedVisualization(BERNSTEINVAZIRANI instance, string solution)
     {
         return BuildVisualization(instance, solution);
     }
 
-    private API_JSON BuildVisualization(DEUTSCH instance, string? solution)
+    private API_JSON BuildVisualization(BERNSTEINVAZIRANI instance, string? solution)
     {
         string circuitJson = BuildStaticD3Payload(instance, solution);
         string? answerFromApi = null;
 
         try
         {
-            bool[] requestBody = instance.funcValues;
+            bool[] requestBody = instance.funcValues.ToArray();
             var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
-            string response = client.PostAsync("/deutsch-quantum", requestBody).Result;
+            string response = client.PostAsync("/bernstein-vazirani-quantum", requestBody).Result;
 
             using JsonDocument doc = JsonDocument.Parse(response);
             JsonElement root = doc.RootElement;
@@ -84,7 +84,7 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         }
         catch
         {
-            // fallback to static payload in circuitJson
+            // fall back to static payload
         }
 
         JsonElement d3Element;
@@ -98,17 +98,13 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             solution = finalSolution,
             format = QuantumCircuitFormat.D3,
             d3 = d3Element,
-
-            // Optional: carry metadata at top level too
             metadata = new Dictionary<string, object?>
             {
-                ["oracleType"] = answerFromApi
-                    ?? ((instance.funcValues[0] == instance.funcValues[1]) ? "constant" : "balanced")
-            },
+                ["secretString"] = finalSolution,
+                ["oracleType"] = "linear"
+            }
         };
     }
-
-    // QASM -> ops -> ASAP schedule
 
     private sealed class Op
     {
@@ -119,7 +115,7 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         public double[]? Params { get; init; }
     }
 
-    private string BuildD3FromQasm(string qasm, string? answer, DEUTSCH instance, string? solution)
+    private string BuildD3FromQasm(string qasm, string? answer, BERNSTEINVAZIRANI instance, string? solution)
     {
         var qubits = new List<string>();
         var classical = new List<string>();
@@ -179,7 +175,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
                 continue;
             }
 
-            // Generic "gate args;" lines
             if (line.Contains(' '))
             {
                 string noSemi = line.TrimEnd(';');
@@ -189,7 +184,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
                 string gateToken = tokens[0].Trim();
                 string argsPart = tokens[1].Trim();
 
-                // Parse parameters if gateToken like "rz(0.5)" or "u3(a,b,c)"
                 string gateType = gateToken;
                 double[]? gateParams = null;
 
@@ -206,7 +200,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
                                           .Select(s => s.Trim())
                                           .ToArray();
 
-                        // Best effort parse: numeric parameters (for your D3 label rendering)
                         var parsed = new List<double>();
                         foreach (var p in parts)
                         {
@@ -235,81 +228,71 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             }
         }
 
-        // Schedule for same-column gates
         List<D3GateOp> gates = ScheduleOpsAsap(ops);
 
-        // Build payload
         var payload = new D3Payload
         {
-            qubits = qubits.Count > 0 ? qubits.ToArray() : new[] { "q0", "q1" },
-            classical = classical.Count > 0 ? classical.ToArray() : new[] { "c0" },
+            qubits = qubits.Count > 0 ? qubits.ToArray() : BuildDefaultQubits(instance),
+            classical = classical.Count > 0 ? classical.ToArray() : BuildDefaultClassical(instance),
             gates = gates,
             metadata = new Dictionary<string, object?>
             {
-                ["solution"] = solution,
-                ["oracleType"] = answer ?? ((instance.funcValues[0] == instance.funcValues[1]) ? "constant" : "balanced")
+                ["solution"] = solution ?? answer,
+                ["oracleType"] = "linear"
             }
         };
 
-        var uf = DetectDeutschOracleStage(payload);
+        var uf = DetectOracleStage(payload);
         if (uf != null)
             payload.overlays.Add(uf);
 
         return JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
     }
 
-    private static D3Overlay? DetectDeutschOracleStage(D3Payload payload)
+    private static D3Overlay? DetectOracleStage(D3Payload payload)
     {
-        // Expect q0,q1 exist, but don’t hard-fail if naming differs
+        // Heuristic: first full layer of H on data+ancilla, then next full layer of H on data only
         var qubits = payload.qubits ?? Array.Empty<string>();
         if (qubits.Length < 2) return null;
 
-        string q0 = qubits[0];
-        string q1 = qubits[1];
+        string ancilla = qubits.Last();
+        var dataQubits = qubits.Take(qubits.Length - 1).ToArray();
 
-        // Helper predicates
-        static bool IsHOn(D3GateOp g, string q) =>
+        bool IsHOn(D3GateOp g, string q) =>
             string.Equals(g.type, "h", StringComparison.OrdinalIgnoreCase) &&
-            g.targets != null && g.targets.Length == 1 &&
+            g.targets != null &&
+            g.targets.Length == 1 &&
             string.Equals(g.targets[0], q, StringComparison.Ordinal);
 
-        // 1) Find all times that have H on q0 and H on q1
-        var timesWithHq0 = payload.gates.Where(g => IsHOn(g, q0)).Select(g => g.time).ToHashSet();
-        var timesWithHq1 = payload.gates.Where(g => IsHOn(g, q1)).Select(g => g.time).ToHashSet();
+        var timesWithAllH = payload.gates
+            .Where(g => IsHOn(g, g.targets.FirstOrDefault() ?? string.Empty))
+            .GroupBy(g => g.time)
+            .OrderBy(g => g.Key)
+            .Select(grp => new
+            {
+                Time = grp.Key,
+                Targets = grp.Select(g => g.targets[0]).ToHashSet()
+            })
+            .ToList();
 
-        var prepTimes = timesWithHq0.Intersect(timesWithHq1).OrderBy(t => t).ToList();
-        if (prepTimes.Count == 0) return null;
+        double? tPrep = timesWithAllH.FirstOrDefault(t => dataQubits.All(q => t.Targets.Contains(q)) && t.Targets.Contains(ancilla))?.Time;
+        if (tPrep == null) return null;
 
-        // Choose the last "prep H layer" that happens before the final measurement
-        // In Deutsch, it’s typically the only shared-H layer before the oracle.
-        double tPrep = prepTimes.Last();
-
-        // 2) Find the next H on q0 AFTER tPrep (post-oracle H)
-        double? tPost = payload.gates
-            .Where(g => IsHOn(g, q0) && g.time > tPrep)
-            .Select(g => (double?)g.time)
-            .OrderBy(t => t)
-            .FirstOrDefault();
-
+        double? tPost = timesWithAllH.FirstOrDefault(t => t.Time > tPrep && dataQubits.All(q => t.Targets.Contains(q)) && !t.Targets.Contains(ancilla))?.Time;
         if (tPost == null) return null;
 
-        // 3) Oracle region is strictly between (tPrep, tPost)
-        double tStart = tPrep + 1;
+        double tStart = tPrep.Value + 1;
         double tEnd = tPost.Value - 1;
 
         if (tEnd < tStart)
         {
-            // Sometimes the oracle collapses to exactly one column and your schedule might put post-H immediately next.
-            // In that case, treat oracle as the single column tPrep+1 if it exists.
-            double candidate = tPrep + 1;
+            double candidate = tPrep.Value + 1;
             bool exists = payload.gates.Any(g => Math.Abs(g.time - candidate) < 1e-9);
             if (!exists) return null;
-
             tStart = candidate;
             tEnd = candidate;
         }
 
-        // Only create overlay if there is at least one gate in the region
         bool hasOracleOps = payload.gates.Any(g => g.time >= tStart && g.time <= tEnd);
         if (!hasOracleOps) return null;
 
@@ -320,10 +303,9 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             label = "U_f",
             timeStart = (int)Math.Round(tStart),
             timeEnd = (int)Math.Round(tEnd),
-            targets = new[] { q0, q1 }
+            targets = qubits.ToArray()
         };
     }
-
 
     private static List<D3GateOp> ScheduleOpsAsap(List<Op> ops)
     {
@@ -359,11 +341,10 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
 
             foreach (var r in resources) layerUsed.Add(r);
 
-            // Emit typed gate (no anonymous objects)
             gates.Add(new D3GateOp
             {
                 id = op.Id,
-                type = op.Type,                
+                type = op.Type,
                 targets = op.Targets,
                 classical = (op.Type == "m") ? (op.Classical ?? Array.Empty<string>()) : null,
                 @params = (op.Params != null && op.Params.Length > 0) ? op.Params : null,
@@ -391,7 +372,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         }
     }
 
-
     private static string NormalizeQubit(string qasmRef)
     {
         string trimmed = qasmRef.Trim();
@@ -409,10 +389,48 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         return trimmed.TrimEnd(';');
     }
 
-    private string BuildStaticD3Payload(DEUTSCH instance, string? solution)
+    private string BuildStaticD3Payload(BERNSTEINVAZIRANI instance, string? solution)
     {
-        bool[] f = instance.funcValues;
-        bool isConstant = (f[0] == f[1]);
+        string[] qubits = BuildDefaultQubits(instance);
+        string[] classical = BuildDefaultClassical(instance);
+
+        var gates = new List<object>();
+
+        string ancilla = qubits.Last();
+
+        // Prepare ancilla in |1>
+        gates.Add(new { id = "x0", type = "x", targets = new[] { ancilla }, time = 0 });
+
+        // Hadamard on all qubits
+        for (int i = 0; i < qubits.Length; i++)
+        {
+            gates.Add(new { id = $"h{i}", type = "h", targets = new[] { qubits[i] }, time = 1 });
+        }
+
+        // Oracle column placeholder
+        int oracleTime = 2;
+        gates.Add(new { id = "oracle", type = "oracle", targets = qubits.ToArray(), label = "U_f", time = oracleTime });
+
+        // Hadamard on data qubits
+        int postHTime = 3;
+        for (int i = 0; i < qubits.Length - 1; i++)
+        {
+            gates.Add(new { id = $"h_post_{i}", type = "h", targets = new[] { qubits[i] }, time = postHTime });
+        }
+
+        // Measurements on data qubits
+        int measureTime = 4;
+        for (int i = 0; i < qubits.Length - 1; i++)
+        {
+            gates.Add(new
+            {
+                id = $"m{i}",
+                type = "m",
+                targets = new[] { qubits[i] },
+                classical = new[] { classical[i] },
+                time = measureTime + i * 0.01
+            });
+        }
 
         var overlays = new[]
         {
@@ -420,47 +438,44 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             {
                 type = "oracle",
                 label = "U_f",
-                timeStart = 2,
-                timeEnd = 2,
-                targets = new[] { "q0", "q1" }
+                timeStart = oracleTime,
+                timeEnd = oracleTime,
+                targets = qubits
             }
         };
 
         var payload = new
         {
-            qubits = new[] { "q0", "q1" },
-            classical = new[] { "c0" },
-            gates = new object[]
-            {
-                new { id = "x0",  type = "x",  targets = new[] { "q1" },            time = 0 },
-
-                // same-column H gates
-                new { id = "h0",  type = "h",  targets = new[] { "q0" },            time = 1 },
-                new { id = "h1",  type = "h",  targets = new[] { "q1" },            time = 1 },
-
-                isConstant
-                    ? new { id = "x1",  type = "x",  targets = new[] { "q1" },       time = 2 }
-                    : new { id = "cx1", type = "cx", targets = new[] { "q0", "q1" }, time = 2 },
-
-                new { id = "h2",  type = "h",  targets = new[] { "q0" },            time = 3 },
-
-                new
-                {
-                    id = "m0",
-                    type = "m",
-                    targets = new[] { "q0" },
-                    classical = new[] { "c0" },
-                    time = 4
-                }
-            },
+            qubits,
+            classical,
+            gates,
             overlays,
             metadata = new
             {
                 solution,
-                oracleType = isConstant ? "constant" : "balanced"
+                oracleType = "linear"
             }
         };
 
         return JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static string[] BuildDefaultQubits(BERNSTEINVAZIRANI instance)
+    {
+        int dataCount = Math.Max(1, instance.NBits);
+        var qubits = new List<string>();
+        for (int i = 0; i < dataCount; i++)
+            qubits.Add($"q{i}");
+        qubits.Add($"q{dataCount}"); // ancilla
+        return qubits.ToArray();
+    }
+
+    private static string[] BuildDefaultClassical(BERNSTEINVAZIRANI instance)
+    {
+        int dataCount = Math.Max(1, instance.NBits);
+        var classical = new List<string>();
+        for (int i = 0; i < dataCount; i++)
+            classical.Add($"c{i}");
+        return classical.ToArray();
     }
 }

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
@@ -9,7 +9,7 @@ class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
     public string visualizationName { get; } = "Bernstein-Vazirani problem visualization";
     public string visualizationDefinition { get; } = "This is a default visualization for the Bernstein-Vazirani problem";
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Grant Gardner" };
+    public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Rakesh Itani, Grant Gardner" };
     public string visualizationType { get; } = "Quantum Circuit Q.js";
 
     // --- Methods Including Constructors ---

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
@@ -9,8 +9,8 @@ class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
     public string visualizationName { get; } = "Bernstein-Vazirani problem visualization";
     public string visualizationDefinition { get; } = "This is a default visualization for the Bernstein-Vazirani problem";
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Grant Gardner" };
-    public string visualizationType { get; } = "Quantum Circuit";
+    public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Grant Gardner" };
+    public string visualizationType { get; } = "Quantum Circuit Q";
 
     // --- Methods Including Constructors ---
     public BernsteinVaziraniDefaultVisualization()
@@ -19,14 +19,22 @@ class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
     }
     public API_JSON visualize(BERNSTEINVAZIRANI instance)
     {
-        return new API_QUANTUMCIRCUIT();
+        return new API_QUANTUMCIRCUIT
+        {
+            format = QuantumCircuitFormat.QASM,
+            qasm = "",
+            solution = ""
+        };
 
     }
 
     public API_JSON SolvedVisualization(BERNSTEINVAZIRANI instance, string solution)
     {
-        var qc = new API_QUANTUMCIRCUIT();
-        qc.solution = solution;
+        var qc = new API_QUANTUMCIRCUIT
+        {
+            solution = solution,
+            format = QuantumCircuitFormat.QASM
+        };
 
         try
         {
@@ -45,13 +53,13 @@ class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
 
             if (root.TryGetProperty("qasm", out JsonElement qasmElement))
             {
-                qc.circuit = qasmElement.GetString() ?? "";
+                qc.qasm = qasmElement.GetString() ?? "";
             }
         }
         catch (Exception)
         {
             // If API call fails, leave circuit empty
-            qc.circuit = "";
+            qc.qasm = "";
         }
 
         return qc;

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
 {
     public string visualizationName { get; } = "Bernstein-Vazirani Quantum Circuit (Q)";
-    public string visualizationDefinition { get; } = "This is a default visualization for the Bernstein-Vazirani problem";
+    public string visualizationDefinition { get; } = "Requests QASM for the Bernstein-Vazirani circuit (Hadamards, oracle, measure data qubits) to show how one query recovers the hidden bit string for Q.js rendering.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Rakesh Itani, Grant Gardner" };
     public string visualizationType { get; } = "Quantum Circuit Q.js";

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
 {
-    public string visualizationName { get; } = "Bernstein-Vazirani problem visualization";
+    public string visualizationName { get; } = "Bernstein-Vazirani Quantum Circuit (Q)";
     public string visualizationDefinition { get; } = "This is a default visualization for the Bernstein-Vazirani problem";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Rakesh Itani, Grant Gardner" };

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
@@ -10,7 +10,7 @@ class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
     public string visualizationDefinition { get; } = "This is a default visualization for the Bernstein-Vazirani problem";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Grant Gardner" };
-    public string visualizationType { get; } = "Quantum Circuit Q";
+    public string visualizationType { get; } = "Quantum Circuit Q.js";
 
     // --- Methods Including Constructors ---
     public BernsteinVaziraniDefaultVisualization()

--- a/Problems/NPComplete/NPC_DEUTSCH/Solvers/DeutschQuantumSolver.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Solvers/DeutschQuantumSolver.cs
@@ -11,7 +11,7 @@ namespace API.Problems.NPComplete.NPC_DEUTSCH.Solvers;
 class DeutschQuantumSolver : ISolver<DEUTSCH> {
 
     // --- Fields ---
-    public string solverName { get; } = "Deutsch quantum solver";
+    public string solverName { get; } = "Deutsch Problem Quantum API Solver";
     public string solverDefinition { get; } = "This solver constructs a quantum circuit for f(x) and then uses phase kickback to determine whether the oracle is constant or balanced with a single invocation of a quantum simulator (qiskit)";
     public string source { get; } = "https://arxiv.org/abs/quant-ph/9708016";
     public string[] contributors {get;} = { "Grant Gardner" };

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Problems.NPComplete.NPC_DEUTSCH;
+
+class DeutschD3Visualization : IVisualization<DEUTSCH>
+{
+    public string visualizationName { get; } = "Quantum Circuit (D3)";
+    public string visualizationDefinition { get; } = "Deutsch circuit formatted for D3 rendering";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Andreas Kramer" };
+    public string visualizationType { get; } = "Quantum Circuit D3";
+
+    public DeutschD3Visualization() { }
+
+    public API_JSON visualize(DEUTSCH instance)
+    {
+        return BuildD3Payload(instance, solution: null);
+    }
+
+    public API_JSON SolvedVisualization(DEUTSCH instance, string solution)
+    {
+        return BuildD3Payload(instance, solution);
+    }
+
+    private API_JSON BuildD3Payload(DEUTSCH instance, string? solution)
+    {
+        bool[] f = instance.funcValues;
+        bool isConstant = (f[0] == f[1]);
+
+        var payload = new
+        {
+            qubits = new[] { "q0", "q1" },
+            classical = new[] { "c0" },
+            gates = new object[]
+            {
+                new { id = "x0",  type = "x",  targets = new[] { "q1" },              time = 0 },
+
+                new { id = "h0",  type = "h",  targets = new[] { "q0" },              time = 1 },
+                new { id = "h1",  type = "h",  targets = new[] { "q1" },              time = 1 },
+
+                isConstant
+                    ? new { id = "x1",  type = "x",  targets = new[] { "q1" },         time = 2 }
+                    : new { id = "cx1", type = "cx", targets = new[] { "q0", "q1" },   time = 2 },
+
+                new { id = "h2",  type = "h",  targets = new[] { "q0" },              time = 3 },
+
+                new
+                {
+                    id = "m0",
+                    type = "m",
+                    targets = new[] { "q0" },
+                    classical = new[] { "c0" },
+                    time = 4
+                }
+            },
+
+
+            metadata = new
+            {
+                solution,
+                oracleType = isConstant ? "constant" : "balanced"
+            }
+        };
+
+        return new API_D3CIRCUIT
+        {
+            payload = JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true })
+        };
+    }
+}
+

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
@@ -12,7 +12,7 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
     public string visualizationName { get; } = "Deutsch Quantum Circuit (D3)";
     public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Andreas Kramer" };
+    public string[] contributors { get; } = { "Andreas Kramer, Courtney Bodily, Rakesh Itani" };
     public string visualizationType { get; } = "Quantum Circuit D3";
 
     public DeutschD3Visualization() { }

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
@@ -10,8 +10,8 @@ using API.Tools;
 class DeutschD3Visualization : IVisualization<DEUTSCH>
 {
     public string visualizationName { get; } = "Deutsch Quantum Circuit (D3)";
-    public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
-    public string source { get; } = "";
+    public string visualizationDefinition { get; } = "Builds a two-qubit Deutsch circuit, highlights the oracle block, and illustrates how interference distinguishes constant vs. balanced functions in one query using D3.js.";
+    public string source { get; } = "https://d3js.org/";
     public string[] contributors { get; } = { "Andreas Kramer, Courtney Bodily, Rakesh Itani" };
     public string visualizationType { get; } = "Quantum Circuit D3";
 

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 class DeutschDefaultVisualization : IVisualization<DEUTSCH>
 {
     public string visualizationName { get; } = "Deutsch Quantum Circuit (Q)";
-    public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
+    public string visualizationDefinition { get; } = "Requests the QASM for the two-qubit Deutsch circuit, showing the oracle call and measurement that separates constant vs. balanced functions in one query for Q.js rendering.";
 
     public string source { get; } = "";
     public string[] contributors { get; } = { "Jason L. Wright", "Grant Gardner, Courtney Bodily, Andreas Kramer, Rakesh Itani" };

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -10,7 +10,7 @@ class DeutschDefaultVisualization : IVisualization<DEUTSCH>
     public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
 
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Jason L. Wright", "Grant Gardner, Andreas Kramer" };
+    public string[] contributors { get; } = { "Jason L. Wright", "Grant Gardner, Courtney Bodily, Andreas Kramer, Rakesh Itani" };
     public string visualizationType { get; } = "Quantum Circuit Q.js";
 
     // --- Methods Including Constructors ---

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 class DeutschDefaultVisualization : IVisualization<DEUTSCH>
 {
-    public string visualizationName { get; } = "Deutsch Quantum Circuit (Q.js)";
+    public string visualizationName { get; } = "Deutsch Quantum Circuit (Q)";
     public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
 
     public string source { get; } = "";

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -6,12 +6,12 @@ using System.Text.Json;
 
 class DeutschDefaultVisualization : IVisualization<DEUTSCH>
 {
-    public string visualizationName { get; } = "Deutsch Quantum Circuit (Q)";
+    public string visualizationName { get; } = "Deutsch Quantum Circuit (Q.js)";
     public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
 
     public string source { get; } = "";
     public string[] contributors { get; } = { "Jason L. Wright", "Grant Gardner, Andreas Kramer" };
-    public string visualizationType { get; } = "Quantum Circuit Q";
+    public string visualizationType { get; } = "Quantum Circuit Q.js";
 
     // --- Methods Including Constructors ---
     public DeutschDefaultVisualization()

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -4,7 +4,7 @@ using API.Problems.NPComplete.NPC_DEUTSCH;
 
 class DeutschDefaultVisualization : IVisualization<DEUTSCH>
 {
-    public string visualizationName { get; } = "Deutsch problem visualization";
+    public string visualizationName { get; } = "Quantum Circuit (Q)";
     public string visualizationDefinition { get; } = "This is a default visualization for the Deutsch problem";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Jason L. Wright" };

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -6,12 +6,12 @@ using System.Text.Json;
 
 class DeutschDefaultVisualization : IVisualization<DEUTSCH>
 {
-    public string visualizationName { get; } = "Quantum Circuit (Q)";
+    public string visualizationName { get; } = "Deutsch Quantum Circuit (Q)";
     public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
 
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Jason L. Wright", "Grant Gardner" };
-    public string visualizationType { get; } = "Quantum Circuit";
+    public string[] contributors { get; } = { "Jason L. Wright", "Grant Gardner, Andreas Kramer" };
+    public string visualizationType { get; } = "Quantum Circuit Q";
 
     // --- Methods Including Constructors ---
     public DeutschDefaultVisualization()
@@ -20,14 +20,22 @@ class DeutschDefaultVisualization : IVisualization<DEUTSCH>
     }
     public API_JSON visualize(DEUTSCH instance)
     {
-        return new API_QUANTUMCIRCUIT();
+        return new API_QUANTUMCIRCUIT
+        {
+            format = QuantumCircuitFormat.QASM,
+            qasm = "",
+            solution = ""
+        };
 
     }
 
     public API_JSON SolvedVisualization(DEUTSCH instance, string solution)
     {
-        var qc = new API_QUANTUMCIRCUIT();
-        qc.solution = solution;
+        var qc = new API_QUANTUMCIRCUIT
+        {
+            solution = solution,
+            format = QuantumCircuitFormat.QASM
+        };
 
         try
         {
@@ -46,13 +54,13 @@ class DeutschDefaultVisualization : IVisualization<DEUTSCH>
 
             if (root.TryGetProperty("qasm", out JsonElement qasmElement))
             {
-                qc.circuit = qasmElement.GetString() ?? "";
+                qc.qasm = qasmElement.GetString() ?? "";
             }
         }
         catch (Exception)
         {
             // If API call fails, leave circuit empty
-            qc.circuit = "";
+            qc.qasm = "";
         }
 
         return qc;

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
@@ -4,28 +4,29 @@ using System.Linq;
 using System.Text.Json;
 using API.Interfaces;
 using API.Interfaces.JSON_Objects;
-using API.Problems.NPComplete.NPC_DEUTSCH;
+using API.Problems.NPComplete.NPC_DEUTSCHJOZSA;
 using API.Tools;
 
-class DeutschD3Visualization : IVisualization<DEUTSCH>
+class DeutschJozsaD3Visualization : IVisualization<DEUTSCHJOZSA>
 {
-    public string visualizationName { get; } = "Deutsch Quantum Circuit (D3)";
-    public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
+    public string visualizationName { get; } = "Deutsch-Jozsa Quantum Circuit (D3)";
+    public string visualizationDefinition { get; } =
+        "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Andreas Kramer" };
     public string visualizationType { get; } = "Quantum Circuit D3";
 
-    public DeutschD3Visualization() { }
+    public DeutschJozsaD3Visualization() { }
 
     private sealed class D3GateOp
     {
         public string id { get; set; } = "";
-        public string type { get; set; } = "";          // "h", "x", "cx", "m", "oracle", ...
+        public string type { get; set; } = "";
         public string[] targets { get; set; } = Array.Empty<string>();
-        public string[]? classical { get; set; }        // only for measurement
-        public double[]? @params { get; set; }          // for rz/ry/rx/u3 etc. later
-        public string? label { get; set; }              // used by oracle/block
-        public double time { get; set; }                // assigned by scheduler (offset for measurements)
+        public string[]? classical { get; set; }
+        public double[]? @params { get; set; }
+        public string? label { get; set; }
+        public double time { get; set; }
     }
 
     private sealed class D3Payload
@@ -33,41 +34,40 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         public string[] qubits { get; set; } = Array.Empty<string>();
         public string[] classical { get; set; } = Array.Empty<string>();
         public List<D3GateOp> gates { get; set; } = new();
-        public List<D3Overlay> overlays { get; set; } = new();    
+        public List<D3Overlay> overlays { get; set; } = new();
         public Dictionary<string, object?> metadata { get; set; } = new();
     }
 
     private sealed class D3Overlay
     {
         public string id { get; set; } = "";
-        public string type { get; set; } = "stage";     // e.g. "oracle", "stage"
-        public string label { get; set; } = "";         
+        public string type { get; set; } = "stage";
+        public string label { get; set; } = "";
         public int timeStart { get; set; }
-        public int timeEnd { get; set; }                
-        public string[] targets { get; set; } = Array.Empty<string>(); // optional
+        public int timeEnd { get; set; }
+        public string[] targets { get; set; } = Array.Empty<string>();
     }
 
-
-    public API_JSON visualize(DEUTSCH instance)
+    public API_JSON visualize(DEUTSCHJOZSA instance)
     {
         return BuildVisualization(instance, solution: null);
     }
 
-    public API_JSON SolvedVisualization(DEUTSCH instance, string solution)
+    public API_JSON SolvedVisualization(DEUTSCHJOZSA instance, string solution)
     {
         return BuildVisualization(instance, solution);
     }
 
-    private API_JSON BuildVisualization(DEUTSCH instance, string? solution)
+    private API_JSON BuildVisualization(DEUTSCHJOZSA instance, string? solution)
     {
         string circuitJson = BuildStaticD3Payload(instance, solution);
         string? answerFromApi = null;
 
         try
         {
-            bool[] requestBody = instance.funcValues;
+            bool[] requestBody = instance.w.Select(v => v != 0).ToArray();
             var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
-            string response = client.PostAsync("/deutsch-quantum", requestBody).Result;
+            string response = client.PostAsync("/deutsch-jozsa-quantum", requestBody).Result;
 
             using JsonDocument doc = JsonDocument.Parse(response);
             JsonElement root = doc.RootElement;
@@ -84,7 +84,7 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         }
         catch
         {
-            // fallback to static payload in circuitJson
+            // fall back to the static payload
         }
 
         JsonElement d3Element;
@@ -98,17 +98,12 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             solution = finalSolution,
             format = QuantumCircuitFormat.D3,
             d3 = d3Element,
-
-            // Optional: carry metadata at top level too
             metadata = new Dictionary<string, object?>
             {
-                ["oracleType"] = answerFromApi
-                    ?? ((instance.funcValues[0] == instance.funcValues[1]) ? "constant" : "balanced")
-            },
+                ["oracleType"] = answerFromApi ?? (IsConstant(instance) ? "constant" : "balanced")
+            }
         };
     }
-
-    // QASM -> ops -> ASAP schedule
 
     private sealed class Op
     {
@@ -119,7 +114,7 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         public double[]? Params { get; init; }
     }
 
-    private string BuildD3FromQasm(string qasm, string? answer, DEUTSCH instance, string? solution)
+    private string BuildD3FromQasm(string qasm, string? answer, DEUTSCHJOZSA instance, string? solution)
     {
         var qubits = new List<string>();
         var classical = new List<string>();
@@ -179,7 +174,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
                 continue;
             }
 
-            // Generic "gate args;" lines
             if (line.Contains(' '))
             {
                 string noSemi = line.TrimEnd(';');
@@ -189,7 +183,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
                 string gateToken = tokens[0].Trim();
                 string argsPart = tokens[1].Trim();
 
-                // Parse parameters if gateToken like "rz(0.5)" or "u3(a,b,c)"
                 string gateType = gateToken;
                 double[]? gateParams = null;
 
@@ -206,7 +199,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
                                           .Select(s => s.Trim())
                                           .ToArray();
 
-                        // Best effort parse: numeric parameters (for your D3 label rendering)
                         var parsed = new List<double>();
                         foreach (var p in parts)
                         {
@@ -235,81 +227,77 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             }
         }
 
-        // Schedule for same-column gates
         List<D3GateOp> gates = ScheduleOpsAsap(ops);
 
-        // Build payload
         var payload = new D3Payload
         {
-            qubits = qubits.Count > 0 ? qubits.ToArray() : new[] { "q0", "q1" },
-            classical = classical.Count > 0 ? classical.ToArray() : new[] { "c0" },
+            qubits = qubits.Count > 0 ? qubits.ToArray() : BuildDefaultQubits(instance),
+            classical = classical.Count > 0 ? classical.ToArray() : BuildDefaultClassical(instance),
             gates = gates,
             metadata = new Dictionary<string, object?>
             {
                 ["solution"] = solution,
-                ["oracleType"] = answer ?? ((instance.funcValues[0] == instance.funcValues[1]) ? "constant" : "balanced")
+                ["oracleType"] = answer ?? (IsConstant(instance) ? "constant" : "balanced")
             }
         };
 
-        var uf = DetectDeutschOracleStage(payload);
+        var uf = DetectDeutschJozsaOracleStage(payload);
         if (uf != null)
             payload.overlays.Add(uf);
 
         return JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
     }
 
-    private static D3Overlay? DetectDeutschOracleStage(D3Payload payload)
+    private static D3Overlay? DetectDeutschJozsaOracleStage(D3Payload payload)
     {
-        // Expect q0,q1 exist, but don’t hard-fail if naming differs
         var qubits = payload.qubits ?? Array.Empty<string>();
         if (qubits.Length < 2) return null;
 
-        string q0 = qubits[0];
-        string q1 = qubits[1];
+        // Assume last qubit is ancilla; others are data qubits
+        var dataQubits = qubits.Take(qubits.Length - 1).ToArray();
+        if (dataQubits.Length == 0) return null;
 
-        // Helper predicates
-        static bool IsHOn(D3GateOp g, string q) =>
+        bool IsHOn(D3GateOp g, string q) =>
             string.Equals(g.type, "h", StringComparison.OrdinalIgnoreCase) &&
-            g.targets != null && g.targets.Length == 1 &&
+            g.targets != null &&
+            g.targets.Length == 1 &&
             string.Equals(g.targets[0], q, StringComparison.Ordinal);
 
-        // 1) Find all times that have H on q0 and H on q1
-        var timesWithHq0 = payload.gates.Where(g => IsHOn(g, q0)).Select(g => g.time).ToHashSet();
-        var timesWithHq1 = payload.gates.Where(g => IsHOn(g, q1)).Select(g => g.time).ToHashSet();
+        // Find earliest layer where all data qubits get H (ignore ancilla H)
+        var hByTime = payload.gates
+            .Where(g => g.targets != null &&
+                        g.targets.Length == 1 &&
+                        dataQubits.Contains(g.targets[0]) &&
+                        IsHOn(g, g.targets[0]))
+            .GroupBy(g => g.time)
+            .OrderBy(g => g.Key);
 
-        var prepTimes = timesWithHq0.Intersect(timesWithHq1).OrderBy(t => t).ToList();
-        if (prepTimes.Count == 0) return null;
+        double? tPrep = hByTime
+            .FirstOrDefault(grp => grp.Select(g => g.targets[0]).Distinct().Count() == dataQubits.Length)?
+            .Key;
 
-        // Choose the last "prep H layer" that happens before the final measurement
-        // In Deutsch, it’s typically the only shared-H layer before the oracle.
-        double tPrep = prepTimes.Last();
+        if (tPrep == null) return null;
 
-        // 2) Find the next H on q0 AFTER tPrep (post-oracle H)
-        double? tPost = payload.gates
-            .Where(g => IsHOn(g, q0) && g.time > tPrep)
-            .Select(g => (double?)g.time)
-            .OrderBy(t => t)
-            .FirstOrDefault();
+        // Next layer after tPrep where all data qubits get H again
+        double? tPost = hByTime
+            .FirstOrDefault(grp => grp.Key > tPrep &&
+                                   grp.Select(g => g.targets[0]).Distinct().Count() == dataQubits.Length)?
+            .Key;
 
         if (tPost == null) return null;
 
-        // 3) Oracle region is strictly between (tPrep, tPost)
-        double tStart = tPrep + 1;
+        double tStart = tPrep.Value + 1;
         double tEnd = tPost.Value - 1;
 
         if (tEnd < tStart)
         {
-            // Sometimes the oracle collapses to exactly one column and your schedule might put post-H immediately next.
-            // In that case, treat oracle as the single column tPrep+1 if it exists.
-            double candidate = tPrep + 1;
+            double candidate = tPrep.Value + 1;
             bool exists = payload.gates.Any(g => Math.Abs(g.time - candidate) < 1e-9);
             if (!exists) return null;
-
             tStart = candidate;
             tEnd = candidate;
         }
 
-        // Only create overlay if there is at least one gate in the region
         bool hasOracleOps = payload.gates.Any(g => g.time >= tStart && g.time <= tEnd);
         if (!hasOracleOps) return null;
 
@@ -320,10 +308,9 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             label = "U_f",
             timeStart = (int)Math.Round(tStart),
             timeEnd = (int)Math.Round(tEnd),
-            targets = new[] { q0, q1 }
+            targets = qubits.ToArray()
         };
     }
-
 
     private static List<D3GateOp> ScheduleOpsAsap(List<Op> ops)
     {
@@ -359,11 +346,10 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
 
             foreach (var r in resources) layerUsed.Add(r);
 
-            // Emit typed gate (no anonymous objects)
             gates.Add(new D3GateOp
             {
                 id = op.Id,
-                type = op.Type,                
+                type = op.Type,
                 targets = op.Targets,
                 classical = (op.Type == "m") ? (op.Classical ?? Array.Empty<string>()) : null,
                 @params = (op.Params != null && op.Params.Length > 0) ? op.Params : null,
@@ -391,7 +377,6 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         }
     }
 
-
     private static string NormalizeQubit(string qasmRef)
     {
         string trimmed = qasmRef.Trim();
@@ -409,10 +394,56 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         return trimmed.TrimEnd(';');
     }
 
-    private string BuildStaticD3Payload(DEUTSCH instance, string? solution)
+    private string BuildStaticD3Payload(DEUTSCHJOZSA instance, string? solution)
     {
-        bool[] f = instance.funcValues;
-        bool isConstant = (f[0] == f[1]);
+        int dataCount = Math.Max(1, instance.n);
+        string[] qubits = BuildDefaultQubits(instance);
+        string[] classical = BuildDefaultClassical(instance);
+
+        var gates = new List<object>();
+        // Ancilla assumed to be last qubit
+        string ancilla = qubits.Last();
+
+        // X on ancilla
+        gates.Add(new { id = "x0", type = "x", targets = new[] { ancilla }, time = 0 });
+
+        // H on all qubits (data + ancilla)
+        for (int i = 0; i < qubits.Length; i++)
+        {
+            gates.Add(new { id = $"h{i}", type = "h", targets = new[] { qubits[i] }, time = 1 });
+        }
+
+        // Placeholder oracle column
+        int oracleTime = 2;
+        if (IsConstant(instance))
+        {
+            gates.Add(new { id = "oracle_const", type = "i", targets = new[] { ancilla }, label = "U_f", time = oracleTime });
+        }
+        else
+        {
+            gates.Add(new { id = "oracle_bal", type = "cx", targets = new[] { qubits[0], ancilla }, label = "U_f", time = oracleTime });
+        }
+
+        // H on data qubits
+        int postHTime = 3;
+        for (int i = 0; i < dataCount; i++)
+        {
+            gates.Add(new { id = $"h_post_{i}", type = "h", targets = new[] { qubits[i] }, time = postHTime });
+        }
+
+        // Measure data qubits
+        int measureTime = 4;
+        for (int i = 0; i < dataCount; i++)
+        {
+            gates.Add(new
+            {
+                id = $"m{i}",
+                type = "m",
+                targets = new[] { qubits[i] },
+                classical = new[] { classical[i] },
+                time = measureTime + i * 0.01
+            });
+        }
 
         var overlays = new[]
         {
@@ -420,47 +451,51 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
             {
                 type = "oracle",
                 label = "U_f",
-                timeStart = 2,
-                timeEnd = 2,
-                targets = new[] { "q0", "q1" }
+                timeStart = oracleTime,
+                timeEnd = oracleTime,
+                targets = qubits
             }
         };
 
         var payload = new
         {
-            qubits = new[] { "q0", "q1" },
-            classical = new[] { "c0" },
-            gates = new object[]
-            {
-                new { id = "x0",  type = "x",  targets = new[] { "q1" },            time = 0 },
-
-                // same-column H gates
-                new { id = "h0",  type = "h",  targets = new[] { "q0" },            time = 1 },
-                new { id = "h1",  type = "h",  targets = new[] { "q1" },            time = 1 },
-
-                isConstant
-                    ? new { id = "x1",  type = "x",  targets = new[] { "q1" },       time = 2 }
-                    : new { id = "cx1", type = "cx", targets = new[] { "q0", "q1" }, time = 2 },
-
-                new { id = "h2",  type = "h",  targets = new[] { "q0" },            time = 3 },
-
-                new
-                {
-                    id = "m0",
-                    type = "m",
-                    targets = new[] { "q0" },
-                    classical = new[] { "c0" },
-                    time = 4
-                }
-            },
+            qubits,
+            classical,
+            gates,
             overlays,
             metadata = new
             {
                 solution,
-                oracleType = isConstant ? "constant" : "balanced"
+                oracleType = IsConstant(instance) ? "constant" : "balanced"
             }
         };
 
         return JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static bool IsConstant(DEUTSCHJOZSA instance)
+    {
+        if (instance.w.Count == 0) return true;
+        int first = instance.w[0];
+        return instance.w.All(v => v == first);
+    }
+
+    private static string[] BuildDefaultQubits(DEUTSCHJOZSA instance)
+    {
+        int dataCount = Math.Max(1, instance.n);
+        var qubits = new List<string>();
+        for (int i = 0; i < dataCount; i++)
+            qubits.Add($"q{i}");
+        qubits.Add($"q{dataCount}"); // ancilla
+        return qubits.ToArray();
+    }
+
+    private static string[] BuildDefaultClassical(DEUTSCHJOZSA instance)
+    {
+        int dataCount = Math.Max(1, instance.n);
+        var classical = new List<string>();
+        for (int i = 0; i < dataCount; i++)
+            classical.Add($"c{i}");
+        return classical.ToArray();
     }
 }

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
@@ -11,7 +11,7 @@ class DeutschJozsaD3Visualization : IVisualization<DEUTSCHJOZSA>
 {
     public string visualizationName { get; } = "Deutsch-Jozsa Quantum Circuit (D3)";
     public string visualizationDefinition { get; } =
-        "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
+        "Builds an n-qubit Deutsch-Jozsa circuit with Hadamard prep, highlights the oracle, and shows how one query distinguishes constant vs. balanced functions via interference using D3.js.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Andreas Kramer, Courtney Bodily, Rakesh Itani" };
     public string visualizationType { get; } = "Quantum Circuit D3";

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
@@ -13,7 +13,7 @@ class DeutschJozsaD3Visualization : IVisualization<DEUTSCHJOZSA>
     public string visualizationDefinition { get; } =
         "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Andreas Kramer" };
+    public string[] contributors { get; } = { "Andreas Kramer, Courtney Bodily, Rakesh Itani" };
     public string visualizationType { get; } = "Quantum Circuit D3";
 
     public DeutschJozsaD3Visualization() { }

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
@@ -10,7 +10,7 @@ class DeutschJozsaDefaultVisualization : IVisualization<DEUTSCHJOZSA>
     public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Grant Gardner" };
-    public string visualizationType { get; } = "Quantum Circuit Q";
+    public string visualizationType { get; } = "Quantum Circuit Q.js";
 
     // --- Methods Including Constructors ---
     public DeutschJozsaDefaultVisualization()

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 class DeutschJozsaDefaultVisualization : IVisualization<DEUTSCHJOZSA>
 {
     public string visualizationName { get; } = "Deutsch-Jozsa Quantum Circuit (Q)";
-    public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
+    public string visualizationDefinition { get; } = "Requests the QASM for the Deutsch-Jozsa circuit (data qubits plus ancilla), showing the oracle and measurements that separate constant vs. balanced functions in one query for Q.js.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Rakesh Itani, Grant Gardner" };
     public string visualizationType { get; } = "Quantum Circuit Q.js";

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
@@ -9,7 +9,7 @@ class DeutschJozsaDefaultVisualization : IVisualization<DEUTSCHJOZSA>
     public string visualizationName { get; } = "Deutsch-Jozsa Quantum Circuit (Q)";
     public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Grant Gardner" };
+    public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Rakesh Itani, Grant Gardner" };
     public string visualizationType { get; } = "Quantum Circuit Q.js";
 
     // --- Methods Including Constructors ---

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
@@ -6,11 +6,11 @@ using System.Text.Json;
 
 class DeutschJozsaDefaultVisualization : IVisualization<DEUTSCHJOZSA>
 {
-    public string visualizationName { get; } = "Deutsch-Jozsa problem visualization";
-    public string visualizationDefinition { get; } = "This is a default visualization for the Deutsch-Jozsa problem";
+    public string visualizationName { get; } = "Deutsch-Jozsa Quantum Circuit (Q)";
+    public string visualizationDefinition { get; } = "Constructs a quantum circuit to represent the oracle and then simulates the circuit to find the solution.";
     public string source { get; } = "";
-    public string[] contributors { get; } = { "Grant Gardner" };
-    public string visualizationType { get; } = "Quantum Circuit";
+    public string[] contributors { get; } = { "Courtney Bodily, Andreas Kramer, Grant Gardner" };
+    public string visualizationType { get; } = "Quantum Circuit Q";
 
     // --- Methods Including Constructors ---
     public DeutschJozsaDefaultVisualization()
@@ -19,14 +19,22 @@ class DeutschJozsaDefaultVisualization : IVisualization<DEUTSCHJOZSA>
     }
     public API_JSON visualize(DEUTSCHJOZSA instance)
     {
-        return new API_QUANTUMCIRCUIT();
+        return new API_QUANTUMCIRCUIT
+        {
+            format = QuantumCircuitFormat.QASM,
+            qasm = "",
+            solution = ""
+        };
 
     }
 
     public API_JSON SolvedVisualization(DEUTSCHJOZSA instance, string solution)
     {
-        var qc = new API_QUANTUMCIRCUIT();
-        qc.solution = solution;
+        var qc = new API_QUANTUMCIRCUIT
+        {
+            solution = solution,
+            format = QuantumCircuitFormat.QASM
+        };
 
         try
         {
@@ -45,13 +53,13 @@ class DeutschJozsaDefaultVisualization : IVisualization<DEUTSCHJOZSA>
 
             if (root.TryGetProperty("qasm", out JsonElement qasmElement))
             {
-                qc.circuit = qasmElement.GetString() ?? "";
+                qc.qasm = qasmElement.GetString() ?? "";
             }
         }
         catch (Exception)
         {
             // If API call fails, leave circuit empty
-            qc.circuit = "";
+            qc.qasm = "";
         }
 
         return qc;


### PR DESCRIPTION
- Interfaces/JSON_Objects/API_QUANTUMCIRCUIT.cs now models quantum outputs with format (QASM vs D3), a d3 JSON payload slot, and optional metadata alongside the legacy circuit field, enabling richer frontend rendering.

- New D3 circuit builders for each quantum problem: Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs, .../NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs, and .../NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs. They call the quantum API, parse returned QASM to build D3-ready payloads (qubits/classical arrays, gate list with ASAP scheduling and measurement offsets, overlays that mark oracle regions), and fall back to static sample circuits if the API call fails. Each returns an API_QUANTUMCIRCUIT with the D3 payload plus oracle/solution metadata.

- Default QASM-only visualizations remain for each problem (DeutschDefaultVisualization.cs, DeutschJozsaDefaultVisualization.cs, BernsteinVaziraniDefaultVisualization.cs), but now also pull QASM from the quantum API so the frontend can render actual circuits instead of placeholders.

- AdditionalControllers/ProblemProvider.cs now filters out empty visualizations via IsEmptyVisualization and composes the base visualization, step visualizations, and solved visualization into one JSON array so D3/QASM payloads are only returned when populated.