### PR TITLE
simplify the handling of quantumsolver URL (in appsettings.json)

### DIFF
--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniQuantumSolver.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniQuantumSolver.cs
@@ -17,26 +17,13 @@ class BernsteinVaziraniQuantumSolver : ISolver<BERNSTEINVAZIRANI> {
     public string[] contributors {get;} = { "Grant Gardner" };
     public bool timerHasExpired { get; set; }
 
-    // Configuration: Change this to switch between servers
-    private readonly QuantumServerAPI.ServerEnvironment _serverEnvironment;
-
     // --- Constructors ---
 
     /// <summary>
-    /// Creates a new BernsteinVaziraniQuantumSolver using the ISU AWS server by default
+    /// Creates a new BernsteinVaziraniQuantumSolver
     /// </summary>
     public BernsteinVaziraniQuantumSolver()
     {
-        _serverEnvironment = QuantumServerAPI.ServerEnvironment.ISU_AWS;
-    }
-
-    /// <summary>
-    /// Creates a new BernsteinVaziraniQuantumSolver with specified server environment
-    /// </summary>
-    /// <param name="environment">The server environment to use</param>
-    public BernsteinVaziraniQuantumSolver(QuantumServerAPI.ServerEnvironment environment)
-    {
-        _serverEnvironment = environment;
     }
 
     // --- Methods ---
@@ -49,7 +36,7 @@ class BernsteinVaziraniQuantumSolver : ISolver<BERNSTEINVAZIRANI> {
             bool[] requestBody = problem.funcValues.ToArray();
 
             // Create the API client
-            var client = new QuantumServerAPI(_serverEnvironment);
+            var client = new QuantumServerAPI();
 
             // Make the API call to the quantum endpoint
             string response = client.PostAsync("/bernstein-vazirani-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniD3Visualization.cs
@@ -66,7 +66,7 @@ class BernsteinVaziraniD3Visualization : IVisualization<BERNSTEINVAZIRANI>
         try
         {
             bool[] requestBody = instance.funcValues.ToArray();
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
             string response = client.PostAsync("/bernstein-vazirani-quantum", requestBody).Result;
 
             using JsonDocument doc = JsonDocument.Parse(response);

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Visualizations/BernsteinVaziraniDefaultVisualization.cs
@@ -42,7 +42,7 @@ class BernsteinVaziraniDefaultVisualization : IVisualization<BERNSTEINVAZIRANI>
             bool[] requestBody = instance.funcValues.ToArray();
 
             // Create the API client
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
 
             // Make the API call to get the full response including QASM
             string response = client.PostAsync("/bernstein-vazirani-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_DEUTSCH/Solvers/DeutschQuantumSolver.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Solvers/DeutschQuantumSolver.cs
@@ -14,29 +14,16 @@ class DeutschQuantumSolver : ISolver<DEUTSCH> {
     public string solverName { get; } = "Deutsch Problem Quantum API Solver";
     public string solverDefinition { get; } = "This solver constructs a quantum circuit for f(x) and then uses phase kickback to determine whether the oracle is constant or balanced with a single invocation of a quantum simulator (qiskit)";
     public string source { get; } = "https://arxiv.org/abs/quant-ph/9708016";
-    public string[] contributors {get;} = { "Grant Gardner" };
-
-    // Configuration: Change this to switch between servers
-    private readonly QuantumServerAPI.ServerEnvironment _serverEnvironment;
+    public string[] contributors { get; } = { "Grant Gardner" };
     public bool timerHasExpired { get; set; }
 
     // --- Constructors ---
 
     /// <summary>
-    /// Creates a new DeutschQuantumSolver using the ISU AWS server by default
+    /// Creates a new DeutschQuantumSolver
     /// </summary>
-    public DeutschQuantumSolver() 
+    public DeutschQuantumSolver()
     {
-        _serverEnvironment = QuantumServerAPI.ServerEnvironment.ISU_AWS;
-    }
-
-    /// <summary>
-    /// Creates a new DeutschQuantumSolver with specified server environment
-    /// </summary>
-    /// <param name="environment">The server environment to use</param>
-    public DeutschQuantumSolver(QuantumServerAPI.ServerEnvironment environment)
-    {
-        _serverEnvironment = environment;
     }
 
     // --- Methods ---
@@ -49,7 +36,7 @@ class DeutschQuantumSolver : ISolver<DEUTSCH> {
             bool[] requestBody = problem.funcValues;
 
             // Create the API client
-            var client = new QuantumServerAPI(_serverEnvironment);
+            var client = new QuantumServerAPI();
 
             // Make the API call to the quantum endpoint
             string response = client.PostAsync("/deutsch-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschD3Visualization.cs
@@ -66,7 +66,7 @@ class DeutschD3Visualization : IVisualization<DEUTSCH>
         try
         {
             bool[] requestBody = instance.funcValues;
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
             string response = client.PostAsync("/deutsch-quantum", requestBody).Result;
 
             using JsonDocument doc = JsonDocument.Parse(response);

--- a/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCH/Visualizations/DeutschDefaultVisualization.cs
@@ -43,7 +43,7 @@ class DeutschDefaultVisualization : IVisualization<DEUTSCH>
             bool[] requestBody = instance.funcValues;
 
             // Create the API client
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
 
             // Make the API call to get the full response including QASM
             string response = client.PostAsync("/deutsch-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Solvers/DeutschJozsaQuantumSolver.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Solvers/DeutschJozsaQuantumSolver.cs
@@ -17,26 +17,13 @@ class DeutschJozsaQuantumSolver : ISolver<DEUTSCHJOZSA> {
     public string[] contributors {get;} = { "Grant Gardner" };
     public bool timerHasExpired { get; set; }
 
-    // Configuration: Change this to switch between servers
-    private readonly QuantumServerAPI.ServerEnvironment _serverEnvironment;
-
     // --- Constructors ---
 
     /// <summary>
-    /// Creates a new DeutschJozsaQuantumSolver using the ISU AWS server by default
+    /// Creates a new DeutschJozsaQuantumSolver
     /// </summary>
     public DeutschJozsaQuantumSolver()
     {
-        _serverEnvironment = QuantumServerAPI.ServerEnvironment.ISU_AWS;
-    }
-
-    /// <summary>
-    /// Creates a new DeutschJozsaQuantumSolver with specified server environment
-    /// </summary>
-    /// <param name="environment">The server environment to use</param>
-    public DeutschJozsaQuantumSolver(QuantumServerAPI.ServerEnvironment environment)
-    {
-        _serverEnvironment = environment;
     }
 
     // --- Methods ---
@@ -49,7 +36,7 @@ class DeutschJozsaQuantumSolver : ISolver<DEUTSCHJOZSA> {
             bool[] requestBody = problem.w.Select(val => val != 0).ToArray();
 
             // Create the API client
-            var client = new QuantumServerAPI(_serverEnvironment);
+            var client = new QuantumServerAPI();
 
             // Make the API call to the quantum endpoint
             string response = client.PostAsync("/deutsch-jozsa-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaD3Visualization.cs
@@ -66,7 +66,7 @@ class DeutschJozsaD3Visualization : IVisualization<DEUTSCHJOZSA>
         try
         {
             bool[] requestBody = instance.w.Select(v => v != 0).ToArray();
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
             string response = client.PostAsync("/deutsch-jozsa-quantum", requestBody).Result;
 
             using JsonDocument doc = JsonDocument.Parse(response);

--- a/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_DEUTSCHJOZSA/Visualizations/DeutschJozsaDefaultVisualization.cs
@@ -42,7 +42,7 @@ class DeutschJozsaDefaultVisualization : IVisualization<DEUTSCHJOZSA>
             bool[] requestBody = instance.w.Select(val => val != 0).ToArray();
 
             // Create the API client
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
 
             // Make the API call to get the full response including QASM
             string response = client.PostAsync("/deutsch-jozsa-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_PRIMEFACTOR/Solvers/ShorsQuantumSolver.cs
+++ b/Problems/NPComplete/NPC_PRIMEFACTOR/Solvers/ShorsQuantumSolver.cs
@@ -22,26 +22,13 @@ class ShorsQuantumSolver : ISolver<PRIMEFACTOR> {
     public string[] contributors { get; } = { "Grant Gardner", "George Lake", "Jason Wright" };
     public bool timerHasExpired { get; set; }
 
-    // Configuration: Change this to switch between servers
-    private readonly QuantumServerAPI.ServerEnvironment _serverEnvironment;
-
     // --- Constructors ---
 
     /// <summary>
-    /// Creates a new ShorsQuantumSolver using the ISU AWS server by default
+    /// Creates a new ShorsQuantumSolver
     /// </summary>
     public ShorsQuantumSolver()
     {
-        _serverEnvironment = QuantumServerAPI.ServerEnvironment.ISU_AWS;
-    }
-
-    /// <summary>
-    /// Creates a new ShorsQuantumSolver with specified server environment
-    /// </summary>
-    /// <param name="environment">The server environment to use</param>
-    public ShorsQuantumSolver(QuantumServerAPI.ServerEnvironment environment)
-    {
-        _serverEnvironment = environment;
     }
 
     // --- Methods ---
@@ -54,7 +41,7 @@ class ShorsQuantumSolver : ISolver<PRIMEFACTOR> {
             int numberToFactor = int.Parse(problem.instance);
 
             // Create the API client
-            var client = new QuantumServerAPI(_serverEnvironment);
+            var client = new QuantumServerAPI();
 
             // Make the API call to the prime-factorization-quantum endpoint
             // The API expects just the raw number as the body (e.g., "15")

--- a/Problems/NPComplete/NPC_PRIMEFACTOR/Visualizations/ShorsDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_PRIMEFACTOR/Visualizations/ShorsDefaultVisualization.cs
@@ -34,7 +34,7 @@ class ShorsDefaultVisualization : IVisualization<PRIMEFACTOR>
             int numberToFactor = int.Parse(instance.instance);
 
             // Create the API client
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
 
             // Make the API call to get the full response including QASM
             // The API expects just the raw number as the body

--- a/Problems/NPComplete/NPC_SAT/Solvers/SATGroverSolver.cs
+++ b/Problems/NPComplete/NPC_SAT/Solvers/SATGroverSolver.cs
@@ -19,9 +19,6 @@ class SATGroverSolver : ISolver
     public string[] contributors {get;} = { "Jason L. Wright" };
     public bool timerHasExpired { get; set; }
 
-    // Configuration: Change this to switch between servers
-    private readonly QuantumServerAPI.ServerEnvironment _serverEnvironment;
-
     // --- Constructors ---
 
     /// <summary>
@@ -29,16 +26,6 @@ class SATGroverSolver : ISolver
     /// </summary>
     public SATGroverSolver()
     {
-        _serverEnvironment = QuantumServerAPI.ServerEnvironment.ISU_AWS;
-    }
-
-    /// <summary>
-    /// Creates a new BernsteinVaziraniQuantumSolver with specified server environment
-    /// </summary>
-    /// <param name="environment">The server environment to use</param>
-    public SATGroverSolver(QuantumServerAPI.ServerEnvironment environment)
-    {
-        _serverEnvironment = environment;
     }
 
     public class JSON_Sat_Problem
@@ -59,7 +46,7 @@ class SATGroverSolver : ISolver
             var requestBody = new JSON_Sat_Problem(problemInstance);
 
             // Create the API client
-            var client = new QuantumServerAPI(_serverEnvironment);
+            var client = new QuantumServerAPI();
 
             // Make the API call to the quantum endpoint
             string response = client.PostAsync("/sat-quantum", requestBody).Result;
@@ -90,7 +77,7 @@ class SATGroverSolver : ISolver
             var requestBody = new JSON_Sat_Problem(problem.instance);
 
             // Create the API client
-            var client = new QuantumServerAPI(_serverEnvironment);
+            var client = new QuantumServerAPI();
 
             // Make the API call to the quantum endpoint
             string response = client.PostAsync("/sat-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_SAT/Visualizations/SATGroverVisualization.cs
+++ b/Problems/NPComplete/NPC_SAT/Visualizations/SATGroverVisualization.cs
@@ -43,7 +43,7 @@ class SATGroverVisualization : IVisualization<SAT>
             var requestBody = new SATGroverSolver.JSON_Sat_Problem(instance.instance);
 
             // Create the API client
-            var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
+            var client = new QuantumServerAPI();
 
             // Make the API call to get the full response including QASM
             string response = client.PostAsync("/sat-quantum", requestBody).Result;

--- a/Problems/NPComplete/NPC_UNSTRUCTUREDSEARCH/Solvers/UnstructuredGroverSolver.cs
+++ b/Problems/NPComplete/NPC_UNSTRUCTUREDSEARCH/Solvers/UnstructuredGroverSolver.cs
@@ -12,17 +12,9 @@ class UnstructuredGroverSolver : ISolver<UNSTRUCTUREDSEARCH> {
     public string[] contributors { get; } = { "Jason L. Wright" };
     public bool timerHasExpired { get; set; }
 
-    private readonly QuantumServerAPI.ServerEnvironment _serverEnvironment;
-
     // --- Methods Including Constructors ---
     public UnstructuredGroverSolver()
     {
-        _serverEnvironment = QuantumServerAPI.ServerEnvironment.ISU_AWS;
-    }
-
-    public UnstructuredGroverSolver(QuantumServerAPI.ServerEnvironment environment)
-    {
-        _serverEnvironment = environment;
     }
 
     static public int PowerOfTwo(int n)
@@ -84,7 +76,7 @@ class UnstructuredGroverSolver : ISolver<UNSTRUCTUREDSEARCH> {
             var requestBody = new JSON_Sat_Problem(problemInstance);
 
             // Create the API client
-            var client = new QuantumServerAPI(_serverEnvironment);
+            var client = new QuantumServerAPI();
 
             // Make the API call to the quantum endpoint
             string response = client.PostAsync("/sat-quantum", requestBody).Result;

--- a/Program.cs
+++ b/Program.cs
@@ -1,11 +1,13 @@
 using System.Reflection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.OpenApi.Models;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Configuration.GetSection("QuantumSolver").Get<QuantumSolverSettings>();
+builder.Services.Configure<QuantumSolverSettings>(
+    builder.Configuration.GetSection("QuantumSolver"));
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -38,6 +40,10 @@ var app = builder.Build();
 
 app.UseStaticFiles();
 
+QuantumSolverSettingsGlobal.QuantumSolver = app.Services
+    .GetRequiredService<IOptionsMonitor<QuantumSolverSettings>>()
+    .CurrentValue;
+
 // Somewhat of a security concern. But since we are not doing POSTS im not concerned about it
 app.Use((context, next) =>
     {
@@ -64,4 +70,3 @@ app.MapControllers();
 
 
 app.Run();
-

--- a/QuantumSolverSettings.cs
+++ b/QuantumSolverSettings.cs
@@ -4,26 +4,15 @@ using Microsoft.AspNetCore.Authentication;
 /// Manages configuration settings for the Quantum Solver service.
 /// Provides a default base URL and allows customization through constructors.
 /// </summary>
+public static class QuantumSolverSettingsGlobal
+{
+    public static QuantumSolverSettings QuantumSolver { get; internal set; } = null!;
+}
+
 public class QuantumSolverSettings
 {
-    private static string defaultBaseURL = "http://towel.aws.cose.isu.edu:8080";
-
     /// <summary>
     /// Gets or sets the base URL for the Quantum Solver service.
     /// </summary>
-    public static string BaseURL { get; set; } = defaultBaseURL;
-
-    /// <summary>
-    /// Initializes a new instance with the default base URL.
-    /// </summary>
-    public QuantumSolverSettings() : this(defaultBaseURL) {
-    }
-    
-    /// <summary>
-    /// Initializes a new instance with a custom base URL.
-    /// </summary>
-    /// <param name="input">The base URL to use for the Quantum Solver service.</param>
-    public QuantumSolverSettings(string input) {
-        QuantumSolverSettings.BaseURL = input;
-    }
+    public string BaseURL { get; set; } = "http://localhost:27100";
 }

--- a/Tools/QUANTUM_API_README.md
+++ b/Tools/QUANTUM_API_README.md
@@ -11,19 +11,12 @@ The `QuantumServerAPI` class provides a reusable HTTP client for making POST req
 
 ## Features
 
-✅ Switch between ISU AWS and local servers with enum
+✅ Switch between servers in appsettings.json
 ✅ Reusable POST methods with JSON serialization
 ✅ Support for typed and untyped responses
 ✅ Automatic error handling and timeouts
 ✅ Simple, clean API
 ✅ Integration with quantum algorithm solvers and visualizations
-
-## Server Configurations
-
-```csharp
-ServerEnvironment.ISU_AWS  → http://towel.aws.cose.isu.edu:8080
-ServerEnvironment.LOCAL    → http://127.0.0.1:5000
-```
 
 ## Basic Usage
 
@@ -42,20 +35,7 @@ bool[] body = new[] { true, false };
 string response = await client.PostAsync("/deutsch-quantum", body);
 ```
 
-### 2. Switch Between Servers
-
-```csharp
-// Use ISU AWS server
-var isuClient = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
-
-// Use local server
-var localClient = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.LOCAL);
-
-// Use custom URL
-var customClient = new QuantumServerAPI("http://custom-server.com:3000");
-```
-
-### 3. Typed Response
+### 2. Typed Response
 
 ```csharp
 // Define response type
@@ -76,7 +56,7 @@ if (result != null)
 }
 ```
 
-### 4. Raw JSON String
+### 3. Raw JSON String
 
 ```csharp
 var client = new QuantumServerAPI();
@@ -89,13 +69,11 @@ string response = await client.PostRawJsonAsync("/deutsch-quantum", jsonBody);
 The `DeutschQuantumSolver` class uses the Quantum API:
 
 ```csharp
-// Default constructor uses ISU_AWS
+// Default constructor
 var solver = new DeutschQuantumSolver();
 
 // Or specify environment
-var localSolver = new DeutschQuantumSolver(
-    QuantumServerAPI.ServerEnvironment.LOCAL
-);
+var localSolver = new DeutschQuantumSolver();
 
 // Use it
 DEUTSCH problem = new DEUTSCH("(0,1)");
@@ -169,23 +147,6 @@ curl -X POST http://127.0.0.1:5000/deutsch-quantum \
 
 ## Configuration
 
-### Changing Server Environment
-
-**In DeutschQuantumSolver:**
-```csharp
-// Default is ISU_AWS
-public DeutschQuantumSolver()
-{
-    _serverEnvironment = QuantumServerAPI.ServerEnvironment.ISU_AWS;
-}
-```
-
-**In DeutschDefaultVisualization:**
-```csharp
-// Line 37 in DeutschDefaultVisualization.cs
-var client = new QuantumServerAPI(QuantumServerAPI.ServerEnvironment.ISU_AWS);
-```
-
 ### Timeouts
 
 Default timeout is **30 seconds**. To change, modify in `QuantumServerAPI.cs`:
@@ -213,7 +174,7 @@ public string solve(DEUTSCH problem)
     try
     {
         bool[] requestBody = problem.funcValues;
-        var client = new QuantumServerAPI(_serverEnvironment);
+        var client = new QuantumServerAPI();
         string response = client.PostAsync("/deutsch-quantum", requestBody).Result;
 
         // Parse and return answer

--- a/Tools/QuantumServerAPI.cs
+++ b/Tools/QuantumServerAPI.cs
@@ -1,56 +1,27 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 
 namespace API.Tools;
 
 /// <summary>
 /// Client for making HTTP requests to external API servers.
-/// Supports switching between different server environments.
 /// </summary>
 public class QuantumServerAPI
 {
-    // --- Server Configuration ---
-    public enum ServerEnvironment
-    {
-        ISU_AWS,
-        LOCAL
-    }
-
-    private static readonly Dictionary<ServerEnvironment, string> ServerUrls = new()
-    {
-        { ServerEnvironment.ISU_AWS, "http://towel.aws.cose.isu.edu:8080" },
-        { ServerEnvironment.LOCAL, "http://127.0.0.1:5000" }
-    };
-
     // --- Fields ---
     private readonly HttpClient _httpClient;
-    private readonly ServerEnvironment _environment;
     private readonly string _baseUrl;
 
     // --- Constructor ---
-    
+
     /// <summary>
     /// Creates a new QuantumServerAPI instance.
     /// </summary>
-    /// <param name="environment">The server environment to use (ISU_AWS or LOCAL)</param>
-    public QuantumServerAPI(ServerEnvironment environment = ServerEnvironment.ISU_AWS)
+    public QuantumServerAPI()
     {
-        _environment = environment;
-        _baseUrl = ServerUrls[environment];
-        _httpClient = new HttpClient
-        {
-            BaseAddress = new Uri(_baseUrl),
-            Timeout = TimeSpan.FromSeconds(30)
-        };
-    }
-
-    /// <summary>
-    /// Creates a new QuantumServerAPI with a custom base URL.
-    /// </summary>
-    /// <param name="customBaseUrl">Custom base URL for the API server</param>
-    public QuantumServerAPI(string customBaseUrl)
-    {
-        _baseUrl = customBaseUrl;
+        _baseUrl = QuantumSolverSettingsGlobal.QuantumSolver.BaseURL;
         _httpClient = new HttpClient
         {
             BaseAddress = new Uri(_baseUrl),
@@ -137,11 +108,6 @@ public class QuantumServerAPI
     /// Gets the current base URL being used.
     /// </summary>
     public string GetBaseUrl() => _baseUrl;
-
-    /// <summary>
-    /// Gets the current environment (if applicable).
-    /// </summary>
-    public ServerEnvironment? GetEnvironment() => _environment;
 
     // --- Dispose ---
     public void Dispose()

--- a/appsettings.json
+++ b/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "QuantumSolver": {
-    "BaseURL": "http://towel.aws.cose.isu.edu:8080"
+    "BaseURL": "http://localhost:27100"
   }
 }


### PR DESCRIPTION
OK there's a lot going on here. The QuantumServerAPI had hardcoded URLs and a enum system, etc. This moves that logic away and uses settings stored in appsettings.json to determine the right URL for the solver API server.