### PR TITLE
disable timebound solvers for now (may cause threadpool starvation)

### DIFF
--- a/Interfaces/SolverInterface.cs
+++ b/Interfaces/SolverInterface.cs
@@ -39,22 +39,7 @@ interface ISolver<T> : ISolver where T : IProblem {
         if (problemInstance == null)
             throw new ArgumentException($"Could not create problem instance for {problem}.");
 
-        string result = "no solution found";
-        Thread thread = new Thread(() => result = solve(problemInstance));
-
-        // start the thread
-        ResetTimer();
-        thread.Start();
-
-        // after 5 seconds w/out finishing, tell the thread it's time
-        // is up and wait for it to finish up.
-        // XXX make the solution time configurable
-        if (thread.Join(new TimeSpan(0, 0, 5)) == false)
-        {
-            TimerExpired();
-            thread.Join();
-        }
-        return result;
+        return solve(problemInstance);
     }
 
     string solve(T problem);


### PR DESCRIPTION
This is a minimal diff that gets us back to pre-timebound solvers functionality.