### PR TITLE
update test frameworks

### DIFF
--- a/API.csproj
+++ b/API.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="SPADE" Version="0.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
       <Content Include="Problems\**" CopyToPublishDirectory="PreserveNewest" />
-       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
update the test frameworks to the latest supported by xunit version 2. This gets rid of a dependency on Newtonsoft.Json 9.0.1 which has a known serious vulnerability.