### PR TITLE
Feature/mst

### DIFF
--- a/Problems/P/P_MINIMUMSPANNINGTREE/MINIMUMSPANNINGTREE_Class.cs
+++ b/Problems/P/P_MINIMUMSPANNINGTREE/MINIMUMSPANNINGTREE_Class.cs
@@ -1,0 +1,78 @@
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using API.Problems.P.P_MINIMUMSPANNINGTREE.Solvers;
+using API.Problems.P.P_MINIMUMSPANNINGTREE.Verifiers;
+using API.DummyClasses;
+using SPADE;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace API.Problems.P.P_MINIMUMSPANNINGTREE;
+
+class P_MINIMUMSPANNINGTREE : IGraphProblem<KruskalSolver, MinimumSpanningTreeVerifier, DummyVisualization, UtilCollectionGraph>
+{
+    public string problemName { get; } = "Minimum Spanning Tree";
+    public string problemLink { get; } = "https://en.wikipedia.org/wiki/Minimum_spanning_tree";
+    public string formalDefinition { get; } = "Given a weighted undirected graph G = (V, E, w), find a subset T \u2286 E such that T is a spanning tree of G and the sum of weights in T is minimum.";
+    public string problemDefinition { get; } = "Find a minimum-weight spanning tree in a weighted, undirected graph.";
+    public string source { get; } = "N/A";
+    public string sourceLink { get; } = "https://en.wikipedia.org/wiki/Minimum_spanning_tree";
+    public string wikiName { get; } = "";
+    public static string _defaultInstance { get; } = "({1,2,3,4},{({1,2},1),({2,3},2),({3,4},1),({1,4},2),({1,3},3)})";
+    public string defaultInstance { get; } = _defaultInstance;
+    public string instance { get; set; } = string.Empty;
+    public string[] contributors { get; } = { "Andreas Kramer", "Val Kimbrough" };
+
+    private List<string> _nodes = new List<string>();
+    private List<(string source, string destination, int weight)> _edges = new List<(string source, string destination, int weight)>();
+
+    public KruskalSolver defaultSolver { get; } = new KruskalSolver();
+    public MinimumSpanningTreeVerifier defaultVerifier { get; } = new MinimumSpanningTreeVerifier();
+    public DummyVisualization defaultVisualization { get; } = new DummyVisualization();
+    public UtilCollectionGraph graph { get; set; }
+
+    public List<string> nodes
+    {
+        get => _nodes;
+        set => _nodes = value;
+    }
+
+    public List<(string source, string destination, int weight)> edges
+    {
+        get => _edges;
+        set => _edges = value;
+    }
+
+    public P_MINIMUMSPANNINGTREE() : this(_defaultInstance) { }
+
+    public P_MINIMUMSPANNINGTREE(string instanceString)
+    {
+        instance = instanceString;
+
+        StringParser mstParser = new("{(N,E) | N is set, E subset {(e, w) | e is N unorderedcross N, w is int}}");
+        mstParser.parse(instanceString);
+
+        nodes = mstParser["N"].ToList().Select(node => node.ToString()).ToList();
+        edges = mstParser["E"].ToList().Select(edge =>
+        {
+            List<UtilCollection> endpoints = edge[0].ToList();
+            return (endpoints[0].ToString(), endpoints[1].ToString(), int.Parse(edge[1].ToString()));
+        }).ToList();
+
+        ValidateInstance(nodes, mstParser["E"]);
+        graph = new UtilCollectionGraph(mstParser["N"], mstParser["E"]);
+    }
+
+    private static void ValidateInstance(List<string> nodes, UtilCollection edgeCollection)
+    {
+        HashSet<string> nodeSet = nodes.ToHashSet();
+        foreach (UtilCollection rawEdge in edgeCollection.ToList())
+        {
+            List<UtilCollection> endpoints = rawEdge[0].ToList();
+            string u = endpoints[0].ToString();
+            string v = endpoints[1].ToString();
+            if (!nodeSet.Contains(u) || !nodeSet.Contains(v))
+                throw new InvalidOperationException("MST instance contains an edge with a vertex that is not in the node set.");
+        }
+    }
+}

--- a/Problems/P/P_MINIMUMSPANNINGTREE/Solvers/KruskalSolver.cs
+++ b/Problems/P/P_MINIMUMSPANNINGTREE/Solvers/KruskalSolver.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using API.Problems.P.P_MINIMUMSPANNINGTREE;
+using SPADE;
+
+namespace API.Problems.P.P_MINIMUMSPANNINGTREE.Solvers;
+
+class KruskalSolver : ISolver<P_MINIMUMSPANNINGTREE>
+{
+    public string solverName { get; } = "Kruskal's Algorithm";
+    public string solverDefinition { get; } = "Finds a minimum spanning tree by sorting edges by weight and adding each edge if it joins two different components.";
+    public string source { get; } = "https://en.wikipedia.org/wiki/Kruskal%27s_algorithm";
+    public string[] contributors { get; } = { "Andreas Kramer" };
+    public bool timerHasExpired { get; set; }
+
+    public string solve(P_MINIMUMSPANNINGTREE problem)
+    {
+        List<string> nodes = problem.graph.Nodes.ToList().Select(n => n.ToString()).Distinct().ToList();
+        var edges = ExtractEdges(problem.graph);
+
+        if (nodes.Count == 0)
+            return "{}";
+
+        UnionFind<string> uf = new(nodes);
+        List<(string u, string v, int weight)> selected = new();
+
+        foreach (var edge in edges.OrderBy(e => e.weight).ThenBy(e => CanonicalKey(e.u, e.v)))
+        {
+            if (timerHasExpired)
+                return "{}";
+
+            if (uf.Find(edge.u) != uf.Find(edge.v))
+            {
+                uf.Union(edge.u, edge.v);
+                selected.Add(edge);
+                if (selected.Count == nodes.Count - 1)
+                    break;
+            }
+        }
+
+        if (selected.Count != nodes.Count - 1)
+            return "{}";
+
+        return EdgeListToCertificate(selected);
+    }
+
+    internal static List<(string u, string v, int weight)> ExtractEdges(UtilCollectionGraph graph)
+    {
+        var edges = new List<(string u, string v, int weight)>();
+        foreach (UtilCollection rawEdge in graph.Edges.ToList())
+        {
+            if (rawEdge.Count() != 2)
+                continue;
+
+            bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+            bool secondLooksLikeCollection = LooksLikeCollection(rawEdge[1]);
+            if (!firstLooksLikeCollection || secondLooksLikeCollection)
+                continue;
+
+            UtilCollection endpoints = rawEdge[0];
+            int weight = int.Parse(rawEdge[1].ToString());
+            if (endpoints.IsOrdered())
+            {
+                edges.Add((endpoints[0].ToString(), endpoints[1].ToString(), weight));
+            }
+            else
+            {
+                var cast = endpoints.ToList();
+                if (cast.Count == 1)
+                {
+                    string node = cast[0].ToString();
+                    edges.Add((node, node, weight));
+                }
+                else
+                {
+                    edges.Add((cast[0].ToString(), cast[1].ToString(), weight));
+                }
+            }
+        }
+        return edges;
+    }
+
+    internal static string EdgeListToCertificate(List<(string u, string v, int weight)> edges)
+    {
+        if (edges == null || edges.Count == 0)
+            return "{}";
+
+        var sorted = edges
+            .Select(edge => (u: edge.u, v: edge.v))
+            .Select(edge => (u: edge.u, v: edge.v, key: CanonicalKey(edge.u, edge.v)))
+            .OrderBy(edge => edge.key)
+            .Select(edge => $"{{{CanonicalFirst(edge.u, edge.v)},{CanonicalSecond(edge.u, edge.v)}}}")
+            .ToList();
+
+        return "{" + string.Join(",", sorted) + "}";
+    }
+
+    internal static string CanonicalKey(string u, string v)
+    {
+        return string.CompareOrdinal(u, v) <= 0 ? $"{u}|{v}" : $"{v}|{u}";
+    }
+
+    internal static string CanonicalFirst(string u, string v)
+    {
+        return string.CompareOrdinal(u, v) <= 0 ? u : v;
+    }
+
+    internal static string CanonicalSecond(string u, string v)
+    {
+        return string.CompareOrdinal(u, v) <= 0 ? v : u;
+    }
+
+    private static bool LooksLikeCollection(UtilCollection u)
+    {
+        string s = u.ToString().TrimStart();
+        return s.StartsWith("{") || s.StartsWith("(");
+    }
+
+    private class UnionFind<T>
+    {
+        private readonly Dictionary<T, T> parent = new();
+        private readonly Dictionary<T, int> rank = new();
+
+        public UnionFind(IEnumerable<T> items)
+        {
+            foreach (T item in items)
+            {
+                parent[item] = item;
+                rank[item] = 0;
+            }
+        }
+
+        public T Find(T item)
+        {
+            if (!parent.ContainsKey(item))
+                throw new InvalidOperationException("Item is not part of this union-find structure.");
+
+            if (!EqualityComparer<T>.Default.Equals(parent[item], item))
+                parent[item] = Find(parent[item]);
+            return parent[item];
+        }
+
+        public void Union(T a, T b)
+        {
+            T rootA = Find(a);
+            T rootB = Find(b);
+            if (EqualityComparer<T>.Default.Equals(rootA, rootB))
+                return;
+
+            if (rank[rootA] < rank[rootB])
+                parent[rootA] = rootB;
+            else if (rank[rootA] > rank[rootB])
+                parent[rootB] = rootA;
+            else
+            {
+                parent[rootB] = rootA;
+                rank[rootA]++;
+            }
+        }
+    }
+}

--- a/Problems/P/P_MINIMUMSPANNINGTREE/Solvers/PrimSolver.cs
+++ b/Problems/P/P_MINIMUMSPANNINGTREE/Solvers/PrimSolver.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using API.Interfaces;
+using API.Problems.P.P_MINIMUMSPANNINGTREE;
+
+namespace API.Problems.P.P_MINIMUMSPANNINGTREE.Solvers;
+
+class PrimSolver : ISolver<P_MINIMUMSPANNINGTREE>
+{
+    public string solverName { get; } = "Prim's Algorithm";
+    public string solverDefinition { get; } = "Finds a minimum spanning tree by repeatedly adding the lowest-weight edge that connects the growing tree to a new vertex.";
+    public string source { get; } = "https://en.wikipedia.org/wiki/Prim%27s_algorithm";
+    public string[] contributors { get; } = { "Val Kimbrough" };
+    public bool timerHasExpired { get; set; }
+
+    public string solve(P_MINIMUMSPANNINGTREE problem)
+    {
+        List<string> nodes = problem.graph.Nodes.ToList().Select(n => n.ToString()).Distinct().OrderBy(n => n).ToList();
+        var edges = KruskalSolver.ExtractEdges(problem.graph);
+
+        if (nodes.Count == 0)
+            return "{}";
+
+        var adjacency = BuildAdjacency(nodes, edges);
+        var visited = new HashSet<string> { nodes[0] };
+        var selected = new List<(string u, string v, int weight)>();
+
+        while (selected.Count < nodes.Count - 1)
+        {
+            if (timerHasExpired)
+                return "{}";
+
+            var candidateEdges = visited
+                .SelectMany(node => adjacency[node])
+                .Where(edge => !visited.Contains(edge.to))
+                .ToList();
+
+            if (candidateEdges.Count == 0)
+                return "{}";
+
+            var nextEdge = candidateEdges
+                .OrderBy(edge => edge.weight)
+                .ThenBy(edge => KruskalSolver.CanonicalKey(edge.from, edge.to))
+                .ThenBy(edge => edge.to)
+                .First();
+
+            selected.Add((nextEdge.from, nextEdge.to, nextEdge.weight));
+            visited.Add(nextEdge.to);
+        }
+
+        return KruskalSolver.EdgeListToCertificate(selected);
+    }
+
+    private static Dictionary<string, List<(string from, string to, int weight)>> BuildAdjacency(
+        List<string> nodes,
+        List<(string u, string v, int weight)> edges)
+    {
+        var adjacency = nodes.ToDictionary(node => node, _ => new List<(string from, string to, int weight)>());
+
+        foreach (var edge in edges)
+        {
+            if (edge.u == edge.v || !adjacency.ContainsKey(edge.u) || !adjacency.ContainsKey(edge.v))
+                continue;
+
+            adjacency[edge.u].Add((edge.u, edge.v, edge.weight));
+            adjacency[edge.v].Add((edge.v, edge.u, edge.weight));
+        }
+
+        return adjacency;
+    }
+}

--- a/Problems/P/P_MINIMUMSPANNINGTREE/Verifiers/MinimumSpanningTreeVerifier.cs
+++ b/Problems/P/P_MINIMUMSPANNINGTREE/Verifiers/MinimumSpanningTreeVerifier.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Problems.P.P_MINIMUMSPANNINGTREE.Solvers;
+using API.Problems.P.P_MINIMUMSPANNINGTREE;
+using SPADE;
+
+namespace API.Problems.P.P_MINIMUMSPANNINGTREE.Verifiers;
+
+class MinimumSpanningTreeVerifier : IVerifier<P_MINIMUMSPANNINGTREE>
+{
+    public string verifierName { get; } = "Minimum Spanning Tree Verifier";
+    public string verifierDefinition { get; } = "Verifies that a proposed edge set is a valid minimum spanning tree for the input graph.";
+    public string source { get; } = "https://en.wikipedia.org/wiki/Minimum_spanning_tree";
+    public string[] contributors { get; } = { "Andreas Kramer", "Val Kimbrough" };
+    private string _certificate = string.Empty;
+    public string certificate => _certificate;
+
+    public bool verify(P_MINIMUMSPANNINGTREE problem, string solution)
+    {
+        _certificate = solution ?? string.Empty;
+        var nodes = problem.graph.Nodes.ToList().Select(n => n.ToString()).Distinct().ToList();
+        if (nodes.Count == 0)
+            return string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}";
+
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return nodes.Count <= 1;
+
+        List<string> parsedNodes = GraphParser.parseNodeListWithStringFunctions(solution);
+        if (parsedNodes.Count == 0)
+            return false;
+
+        var uniqueEdges = ParseCertificateEdges(solution);
+        if (nodes.Count == 1 && uniqueEdges.Count == 0)
+            return true;
+
+        if (uniqueEdges.Count != nodes.Count - 1)
+            return false;
+
+        var graphEdges = BuildGraphEdgeMap(problem.graph);
+        foreach (var edge in uniqueEdges)
+        {
+            if (!graphEdges.ContainsKey(edge))
+                return false;
+        }
+
+        if (!IsAcyclicAndSpanning(uniqueEdges, nodes))
+            return false;
+
+        string optimal = new KruskalSolver().solve(problem);
+        if (optimal == "{}")
+            return false;
+
+        var certificateWeight = TotalWeight(uniqueEdges, graphEdges);
+        var optimalWeight = TotalWeight(ParseCertificateEdges(optimal), graphEdges);
+        return certificateWeight == optimalWeight;
+    }
+
+    private static HashSet<(string u, string v)> ParseCertificateEdges(string certificate)
+    {
+        var edgePairs = GraphParser.parseUndirectedEdgeListWithStringFunctions(certificate);
+        var uniqueEdges = new HashSet<(string u, string v)>();
+
+        foreach (var pair in edgePairs)
+        {
+            string u = pair.Key;
+            string v = pair.Value;
+            var canonical = CanonicalPair(u, v);
+            uniqueEdges.Add(canonical);
+        }
+
+        return uniqueEdges;
+    }
+
+    private static Dictionary<(string u, string v), int> BuildGraphEdgeMap(UtilCollectionGraph graph)
+    {
+        var map = new Dictionary<(string u, string v), int>();
+        foreach (UtilCollection rawEdge in graph.Edges.ToList())
+        {
+            if (rawEdge.Count() != 2)
+                continue;
+
+            bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+            bool secondLooksLikeCollection = LooksLikeCollection(rawEdge[1]);
+            if (!firstLooksLikeCollection || secondLooksLikeCollection)
+                continue;
+
+            UtilCollection endpoints = rawEdge[0];
+            int weight = int.Parse(rawEdge[1].ToString());
+            string u;
+            string v;
+            if (endpoints.IsOrdered())
+            {
+                u = endpoints[0].ToString();
+                v = endpoints[1].ToString();
+            }
+            else
+            {
+                var cast = endpoints.ToList();
+                if (cast.Count == 1)
+                {
+                    u = cast[0].ToString();
+                    v = cast[0].ToString();
+                }
+                else
+                {
+                    u = cast[0].ToString();
+                    v = cast[1].ToString();
+                }
+            }
+
+            var canonical = CanonicalPair(u, v);
+            if (!map.ContainsKey(canonical) || weight < map[canonical])
+                map[canonical] = weight;
+        }
+        return map;
+    }
+
+    private static bool IsAcyclicAndSpanning(HashSet<(string u, string v)> edges, List<string> nodes)
+    {
+        var uf = new UnionFind<string>(nodes);
+        foreach (var edge in edges)
+        {
+            if (uf.Find(edge.u) == uf.Find(edge.v))
+                return false;
+            uf.Union(edge.u, edge.v);
+        }
+
+        string root = uf.Find(nodes[0]);
+        return nodes.All(node => uf.Find(node).Equals(root));
+    }
+
+    private static int TotalWeight(HashSet<(string u, string v)> edges, Dictionary<(string u, string v), int> weights)
+    {
+        int total = 0;
+        foreach (var edge in edges)
+        {
+            total += weights[edge];
+        }
+        return total;
+    }
+
+    private static (string u, string v) CanonicalPair(string u, string v)
+    {
+        return string.CompareOrdinal(u, v) <= 0 ? (u, v) : (v, u);
+    }
+
+    private static bool LooksLikeCollection(UtilCollection u)
+    {
+        string s = u.ToString().TrimStart();
+        return s.StartsWith("{") || s.StartsWith("(");
+    }
+
+    private class UnionFind<T>
+    {
+        private readonly Dictionary<T, T> parent = new();
+        private readonly Dictionary<T, int> rank = new();
+
+        public UnionFind(IEnumerable<T> items)
+        {
+            foreach (T item in items)
+            {
+                parent[item] = item;
+                rank[item] = 0;
+            }
+        }
+
+        public T Find(T item)
+        {
+            if (!parent.ContainsKey(item))
+                throw new InvalidOperationException("Item is not part of this union-find structure.");
+
+            if (!EqualityComparer<T>.Default.Equals(parent[item], item))
+                parent[item] = Find(parent[item]);
+            return parent[item];
+        }
+
+        public void Union(T a, T b)
+        {
+            T rootA = Find(a);
+            T rootB = Find(b);
+            if (EqualityComparer<T>.Default.Equals(rootA, rootB))
+                return;
+
+            if (rank[rootA] < rank[rootB])
+                parent[rootA] = rootB;
+            else if (rank[rootA] > rank[rootB])
+                parent[rootB] = rootA;
+            else
+            {
+                parent[rootB] = rootA;
+                rank[rootA]++;
+            }
+        }
+    }
+}

--- a/redux-tests/Problems/P_MINIMUMSPANNINGTREE/MINIMUMSPANNINGTREE_Tests.cs
+++ b/redux-tests/Problems/P_MINIMUMSPANNINGTREE/MINIMUMSPANNINGTREE_Tests.cs
@@ -1,0 +1,122 @@
+using System;
+using Xunit;
+using API.Interfaces.Graphs.GraphParser;
+using API.Problems.P.P_MINIMUMSPANNINGTREE;
+using API.Problems.P.P_MINIMUMSPANNINGTREE.Solvers;
+using API.Problems.P.P_MINIMUMSPANNINGTREE.Verifiers;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class MINIMUMSPANNINGTREE_Tests
+{
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Default_Instantiation()
+    {
+        P_MINIMUMSPANNINGTREE problem = new P_MINIMUMSPANNINGTREE();
+        Assert.Equal(P_MINIMUMSPANNINGTREE._defaultInstance, problem.instance);
+        Assert.Equal(P_MINIMUMSPANNINGTREE._defaultInstance, problem.defaultInstance);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Solver_Simple_Triangle()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new KruskalSolver().solve(problem);
+        Assert.Equal("{{1,2},{2,3}}", solution);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Verifier_Accepts_Optimal_Triangle()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        bool result = new MinimumSpanningTreeVerifier().verify(problem, "{{1,2},{2,3}}");
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Solver_Unique_MST()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},10)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new KruskalSolver().solve(problem);
+        Assert.Equal("{{1,2},{2,3}}", solution);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Verifier_Accepts_Multiple_Valid_MSTs()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},1),({1,3},1)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        var verifier = new MinimumSpanningTreeVerifier();
+
+        Assert.True(verifier.verify(problem, "{{1,2},{2,3}}"));
+        Assert.True(verifier.verify(problem, "{{1,2},{1,3}}"));
+        Assert.True(verifier.verify(problem, "{{1,3},{2,3}}"));
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Verifier_Rejects_Cycle()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},1),({1,3},1)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        bool result = new MinimumSpanningTreeVerifier().verify(problem, "{{1,2},{2,3},{1,3}}" );
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Verifier_Rejects_Disconnected_Certificate()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        bool result = new MinimumSpanningTreeVerifier().verify(problem, "{{1,2}}" );
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Verifier_Rejects_Too_Many_Edges()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},1),({1,3},1)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        bool result = new MinimumSpanningTreeVerifier().verify(problem, "{{1,2},{2,3},{1,3}}" );
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Verifier_Rejects_Edge_Not_In_Graph()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        bool result = new MinimumSpanningTreeVerifier().verify(problem, "{{1,2},{1,3}}" );
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Solver_Handles_Equal_Weight_Edges()
+    {
+        string instance = "({1,2,3,4},{({1,2},1),({2,3},1),({3,4},1),({1,4},1),({2,4},1)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new KruskalSolver().solve(problem);
+        Assert.Equal(3, GraphParser.parseUndirectedEdgeListWithStringFunctions(solution).Count / 2);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Solver_Supports_Single_Vertex()
+    {
+        string instance = "({1},{})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new KruskalSolver().solve(problem);
+        Assert.Equal("{}", solution);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Solver_Returns_Empty_For_Disconnected_Graph()
+    {
+        string instance = "({1,2,3},{({1,2},1)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new KruskalSolver().solve(problem);
+        Assert.Equal("{}", solution);
+    }
+}

--- a/redux-tests/Problems/P_MINIMUMSPANNINGTREE/MINIMUMSPANNINGTREE_Tests.cs
+++ b/redux-tests/Problems/P_MINIMUMSPANNINGTREE/MINIMUMSPANNINGTREE_Tests.cs
@@ -28,11 +28,30 @@ public class MINIMUMSPANNINGTREE_Tests
     }
 
     [Fact]
+    public void MINIMUMSPANNINGTREE_PrimSolver_Simple_Triangle()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new PrimSolver().solve(problem);
+        Assert.Equal("{{1,2},{2,3}}", solution);
+    }
+
+    [Fact]
     public void MINIMUMSPANNINGTREE_Verifier_Accepts_Optimal_Triangle()
     {
         string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
         var problem = new P_MINIMUMSPANNINGTREE(instance);
         bool result = new MinimumSpanningTreeVerifier().verify(problem, "{{1,2},{2,3}}");
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_Verifier_Accepts_PrimSolver_Certificate()
+    {
+        string instance = "({1,2,3,4},{({1,2},1),({2,3},2),({3,4},1),({1,4},2),({1,3},3)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new PrimSolver().solve(problem);
+        bool result = new MinimumSpanningTreeVerifier().verify(problem, solution);
         Assert.True(result);
     }
 
@@ -103,6 +122,15 @@ public class MINIMUMSPANNINGTREE_Tests
     }
 
     [Fact]
+    public void MINIMUMSPANNINGTREE_PrimSolver_Handles_Equal_Weight_Edges()
+    {
+        string instance = "({1,2,3,4},{({1,2},1),({2,3},1),({3,4},1),({1,4},1),({2,4},1)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new PrimSolver().solve(problem);
+        Assert.Equal(3, GraphParser.parseUndirectedEdgeListWithStringFunctions(solution).Count / 2);
+    }
+
+    [Fact]
     public void MINIMUMSPANNINGTREE_Solver_Supports_Single_Vertex()
     {
         string instance = "({1},{})";
@@ -112,11 +140,29 @@ public class MINIMUMSPANNINGTREE_Tests
     }
 
     [Fact]
+    public void MINIMUMSPANNINGTREE_PrimSolver_Supports_Single_Vertex()
+    {
+        string instance = "({1},{})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new PrimSolver().solve(problem);
+        Assert.Equal("{}", solution);
+    }
+
+    [Fact]
     public void MINIMUMSPANNINGTREE_Solver_Returns_Empty_For_Disconnected_Graph()
     {
         string instance = "({1,2,3},{({1,2},1)})";
         var problem = new P_MINIMUMSPANNINGTREE(instance);
         string solution = new KruskalSolver().solve(problem);
+        Assert.Equal("{}", solution);
+    }
+
+    [Fact]
+    public void MINIMUMSPANNINGTREE_PrimSolver_Returns_Empty_For_Disconnected_Graph()
+    {
+        string instance = "({1,2,3},{({1,2},1)})";
+        var problem = new P_MINIMUMSPANNINGTREE(instance);
+        string solution = new PrimSolver().solve(problem);
         Assert.Equal("{}", solution);
     }
 }


### PR DESCRIPTION
In this PR Val and I add the following:

- P_MINIMUMSPANNINGTREE problem instance parsing and validation
- KruskalSolver for MST construction
- PrimSolver as an additional MST solver
- MinimumSpanningTreeVerifier to validate spanning-tree structure and minimum total weight
- Unit tests under redux-tests/Problems/P_MINIMUMSPANNINGTREE covering:
  - default instantiation
  - Kruskal and Prim on simple/unique MST cases
  - verifier acceptance of valid MSTs
  - equal-weight graphs
  - single-vertex graphs
  - disconnected graphs
  - invalid certificates (cycles, missing edges, and non-graph edges)

Validation:
- MST test suite passes
- Full project test suite passes locally (181/181)