### PR TITLE
feat: Dynamic contributor profiles with GitHub username support

### DIFF
--- a/AdditionalControllers/Navigation/ContributerProfile.cs
+++ b/AdditionalControllers/Navigation/ContributerProfile.cs
@@ -12,34 +12,35 @@ using System.Linq;
 public class ContributorProfileController : ControllerBase {
 #pragma warning restore CS1591
 
-    ///Retrieve a contributor's full profile including their personal details and all contributions to the project</summary>
-    /// <param name="contributorName">The name of the contributor whose profile you want to view</param>
-    /// <response code="200">Successfully returns the contributor's complete profile with all their work</response>
+    /// <summary>Pull up everything we know about a contributor — their personal info plus every problem, solver, and reduction they've touched</summary>
+    /// <param name="contributorName">Just pass in their full name, e.g. "Himanshu Jha"</param>
+    /// <response code="200">Got it — here's their full profile</response>
     [ProducesResponseType(typeof(ContributorPortfolio), 200)]
     [HttpGet("{contributorName}")]
     public IActionResult GetContributorProfile(string contributorName) {
         try {
             string projectSourcePath = ProjectSourcePath.Value;
-            
-            // Load personal information from the contributor database
+
+            // Grab their bio, email, GitHub, etc. from contributorInfo.json
             var contributorInfo = GetContributorInfo(contributorName);
-            
-            // Find all NP-Complete problems this contributor worked on
+
+            // Walk the Problems folder and see which NP-Complete problems they worked on
             var allProblems = GetAllProblems(projectSourcePath, contributorName);
-            
-            // Find all solvers this contributor created
+
+            // Same idea — check every Solvers subfolder for their name
             var allSolvers = GetAllSolvers(projectSourcePath, contributorName);
-            
-            // Find all problem reductions this contributor created
+
+            // And every ReduceTo subfolder for reductions they wrote
             var allReductions = GetAllReductions(projectSourcePath, contributorName);
-            
-            // Combine all contributions and create their profile
+
+            // Bundle everything together into one tidy portfolio object
             var portfolio = new ContributorPortfolio {
                 ContributorName = contributorName,
                 Email = contributorInfo?.Email ?? "Not specified",
                 Education = contributorInfo?.Education ?? "Not specified",
                 Major = contributorInfo?.Major ?? "Not specified",
                 Bio = contributorInfo?.Bio ?? "Not specified",
+                GithubUsername = contributorInfo?.GithubUsername ?? "",
                 ProblemsContributed = allProblems.ToList(),
                 SolversCreated = allSolvers.ToList(),
                 ReductionsCreated = allReductions.ToList(),
@@ -53,20 +54,79 @@ public class ContributorProfileController : ControllerBase {
         }
     }
 
-    /// <summary>Get a list of all contributors in the system</summary>
-    /// <response code="200">Successfully returns the list of all contributor names</response>
+    /// <summary>Just the names please — returns every contributor name from contributorInfo.json so the About Us page can build its list without any hardcoding</summary>
+    /// <response code="200">An array of names in the same order they appear in the JSON file</response>
+    [ProducesResponseType(typeof(string[]), 200)]
+    [HttpGet("names")]
+    public IActionResult GetContributorNames() {
+        try {
+            string infoFilePath = Path.Combine(ProjectSourcePath.Value, "wwwroot", "contributorInfo.json");
+
+            if (!System.IO.File.Exists(infoFilePath)) {
+                return NotFound(new { message = "contributorInfo.json not found" });
+            }
+
+            string jsonContent = System.IO.File.ReadAllText(infoFilePath);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var allContributors = JsonSerializer.Deserialize<Dictionary<string, ContributorInfo>>(jsonContent, options);
+
+            if (allContributors == null) {
+                return Ok(Array.Empty<string>());
+            }
+
+            return Ok(allContributors.Keys.ToArray());
+        }
+        catch (Exception ex) {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>One call to rule them all — returns each contributor's name and GitHub username together so the frontend can render the list and tooltips in a single fetch</summary>
+    /// <response code="200">Array of { name, githubUsername } — githubUsername is an empty string if the contributor hasn't added theirs yet</response>
+    [ProducesResponseType(typeof(ContributorDirectoryEntry[]), 200)]
+    [HttpGet("directory")]
+    public IActionResult GetContributorDirectory() {
+        try {
+            string infoFilePath = Path.Combine(ProjectSourcePath.Value, "wwwroot", "contributorInfo.json");
+
+            if (!System.IO.File.Exists(infoFilePath)) {
+                return NotFound(new { message = "contributorInfo.json not found" });
+            }
+
+            string jsonContent = System.IO.File.ReadAllText(infoFilePath);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var allContributors = JsonSerializer.Deserialize<Dictionary<string, ContributorInfo>>(jsonContent, options);
+
+            if (allContributors == null) {
+                return Ok(Array.Empty<ContributorDirectoryEntry>());
+            }
+
+            var directory = allContributors.Select(kvp => new ContributorDirectoryEntry {
+                Name = kvp.Key,
+                GithubUsername = kvp.Value.GithubUsername ?? ""
+            }).ToArray();
+
+            return Ok(directory);
+        }
+        catch (Exception ex) {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>Returns all the problem folder names — mostly used for internal tooling, not the About Us page</summary>
+    /// <response code="200">Array of folder names under the Problems directory</response>
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet("all")]
     public IActionResult GetAllContributors() {
         try {
             string projectSourcePath = ProjectSourcePath.Value;
             string problemsPath = Path.Combine(projectSourcePath, "Problems");
-            
+
             if (!Directory.Exists(problemsPath)) {
                 return NotFound(new { message = "Problems directory not found" });
             }
 
-            // Get all problem folders
+            // Just grab the top-level folder names under Problems/
             var problemFolders = Directory.GetDirectories(problemsPath)
                 .Select(Path.GetFileName)
                 .ToArray();
@@ -83,35 +143,34 @@ public class ContributorProfileController : ControllerBase {
 
     private IEnumerable<string> GetAllProblems(string projectSourcePath, string contributorName) {
         string problemsPath = Path.Combine(projectSourcePath, "Problems");
-        
+
         if (!Directory.Exists(problemsPath)) {
             return new List<string>();
         }
 
         var problems = new List<string>();
-        
+
         try {
-            // Scan the NP-Complete problems folder
+            // Check the NPComplete folder first — that's where most problems live
             string npcPath = Path.Combine(problemsPath, "NPComplete");
             if (Directory.Exists(npcPath)) {
                 var npcProblemDirs = Directory.GetDirectories(npcPath);
                 foreach (var problemDir in npcProblemDirs) {
                     string problemName = "NPC_" + Path.GetFileName(problemDir);
-                    // Check if the contributor's name appears in the problem files
                     if (ContributorWorkedOnProblem(problemDir, contributorName)) {
                         problems.Add(problemName);
                     }
                 }
             }
 
-            // Scan any other problem difficulty/complexity folders
+            // Also sweep any other complexity folders that aren't NPComplete
             var otherFolders = Directory.GetDirectories(problemsPath)
                 .Where(d => Path.GetFileName(d) != "NPComplete");
-            
+
             foreach (var folder in otherFolders) {
                 var folderName = Path.GetFileName(folder);
                 var subProblemDirs = Directory.GetDirectories(folder);
-                
+
                 foreach (var subDir in subProblemDirs) {
                     string problemName = folderName + "_" + Path.GetFileName(subDir);
                     if (ContributorWorkedOnProblem(subDir, contributorName)) {
@@ -127,7 +186,7 @@ public class ContributorProfileController : ControllerBase {
 
     private bool ContributorWorkedOnProblem(string problemDir, string contributorName) {
         try {
-            // Search for the contributor's name in the main problem files
+            // Check the .cs files sitting directly in the problem folder
             var csFiles = Directory.GetFiles(problemDir, "*.cs", SearchOption.TopDirectoryOnly);
             foreach (var file in csFiles) {
                 string content = System.IO.File.ReadAllText(file);
@@ -135,8 +194,8 @@ public class ContributorProfileController : ControllerBase {
                     return true;
                 }
             }
-            
-            // Search in the Solvers folder for this problem
+
+            // Check the Solvers subfolder
             string solversPath = Path.Combine(problemDir, "Solvers");
             if (Directory.Exists(solversPath)) {
                 var solverFiles = Directory.GetFiles(solversPath, "*.cs");
@@ -147,8 +206,8 @@ public class ContributorProfileController : ControllerBase {
                     }
                 }
             }
-            
-            // Search in the ReduceTo folder for this problem
+
+            // Check the ReduceTo subfolder
             string reducePath = Path.Combine(problemDir, "ReduceTo");
             if (Directory.Exists(reducePath)) {
                 var reduceFiles = Directory.GetFiles(reducePath, "*.cs");
@@ -161,23 +220,23 @@ public class ContributorProfileController : ControllerBase {
             }
         }
         catch { }
-        
+
         return false;
     }
 
     private IEnumerable<string> GetAllSolvers(string projectSourcePath, string contributorName) {
         var solvers = new List<string>();
-        
+
         try {
-            // Scan through all problems to find solvers created by this contributor
             string problemsPath = Path.Combine(projectSourcePath, "Problems");
-            
+
             if (!Directory.Exists(problemsPath)) {
                 return solvers;
             }
 
+            // Dig into every problem's Solvers folder and look for their name
             var allProblemDirs = Directory.GetDirectories(problemsPath, "*", SearchOption.AllDirectories);
-            
+
             foreach (var problemDir in allProblemDirs) {
                 string solversPath = Path.Combine(problemDir, "Solvers");
                 if (Directory.Exists(solversPath)) {
@@ -198,17 +257,17 @@ public class ContributorProfileController : ControllerBase {
 
     private IEnumerable<string> GetAllReductions(string projectSourcePath, string contributorName) {
         var reductions = new List<string>();
-        
+
         try {
-            // Scan through all problems to find reductions created by this contributor
             string problemsPath = Path.Combine(projectSourcePath, "Problems");
-            
+
             if (!Directory.Exists(problemsPath)) {
                 return reductions;
             }
 
+            // Same approach — walk every ReduceTo folder and check for their name
             var allProblemDirs = Directory.GetDirectories(problemsPath, "*", SearchOption.AllDirectories);
-            
+
             foreach (var problemDir in allProblemDirs) {
                 string reductionsPath = Path.Combine(problemDir, "ReduceTo");
                 if (Directory.Exists(reductionsPath)) {
@@ -231,7 +290,7 @@ public class ContributorProfileController : ControllerBase {
         try {
             string projectSourcePath = ProjectSourcePath.Value;
             string infoFilePath = Path.Combine(projectSourcePath, "wwwroot", "contributorInfo.json");
-            
+
             if (!System.IO.File.Exists(infoFilePath)) {
                 return null;
             }
@@ -239,12 +298,12 @@ public class ContributorProfileController : ControllerBase {
             string jsonContent = System.IO.File.ReadAllText(infoFilePath);
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
             var allContributors = JsonSerializer.Deserialize<Dictionary<string, ContributorInfo>>(jsonContent, options);
-            
+
             if (allContributors != null) {
-                // Perform case-insensitive search to find the contributor regardless of capitalization
-                var contributor = allContributors.FirstOrDefault(x => 
+                // Case-insensitive match so "himanshu jha" and "Himanshu Jha" both work
+                var contributor = allContributors.FirstOrDefault(x =>
                     x.Key.Equals(contributorName, StringComparison.OrdinalIgnoreCase));
-                
+
                 if (!string.IsNullOrEmpty(contributor.Key)) {
                     return contributor.Value;
                 }
@@ -256,60 +315,79 @@ public class ContributorProfileController : ControllerBase {
     }
 }
 
-/// <summary>Represents a contributor's complete profile with personal details and all contributions</summary>
+/// <summary>Everything about a contributor in one place — personal info and a full list of what they built</summary>
 public class ContributorPortfolio {
-    /// <summary>The contributor's full name</summary>
+    /// <summary>Their full name</summary>
     [JsonPropertyName("contributorName")]
     public string? ContributorName { get; set; }
 
-    /// <summary>The contributor's email address</summary>
+    /// <summary>Their ISU (or other) email address</summary>
     [JsonPropertyName("email")]
     public string? Email { get; set; }
 
-    /// <summary>The contributor's education institution</summary>
+    /// <summary>Where they studied</summary>
     [JsonPropertyName("education")]
     public string? Education { get; set; }
 
-    /// <summary>The contributor's field of study or major</summary>
+    /// <summary>What they studied</summary>
     [JsonPropertyName("major")]
     public string? Major { get; set; }
 
-    /// <summary>A short biography describing the contributor's expertise</summary>
+    /// <summary>A short blurb about them — filled in by the contributor themselves</summary>
     [JsonPropertyName("bio")]
     public string? Bio { get; set; }
 
-    /// <summary>List of all NP-Complete problems this contributor has worked on</summary>
+    /// <summary>Their GitHub handle — the frontend uses this to build the avatar image and profile link</summary>
+    [JsonPropertyName("githubUsername")]
+    public string? GithubUsername { get; set; }
+
+    /// <summary>Every NP-Complete problem they've touched</summary>
     [JsonPropertyName("problemsContributed")]
     public List<string> ProblemsContributed { get; set; } = new List<string>();
 
-    /// <summary>List of all algorithm solvers this contributor has created</summary>
+    /// <summary>Every solver they've written</summary>
     [JsonPropertyName("solversCreated")]
     public List<string> SolversCreated { get; set; } = new List<string>();
 
-    /// <summary>List of all problem reductions this contributor has created</summary>
+    /// <summary>Every reduction they've written</summary>
     [JsonPropertyName("reductionsCreated")]
     public List<string> ReductionsCreated { get; set; } = new List<string>();
 
-    /// <summary>Total count of all contributions (problems + solvers + reductions)</summary>
+    /// <summary>Quick total — problems + solvers + reductions combined</summary>
     [JsonPropertyName("totalContributions")]
     public int TotalContributions { get; set; }
 }
 
-/// <summary>Stores basic information about a contributor from the database</summary>
+/// <summary>What we store in contributorInfo.json for each person — edit this file to add or update contributor details</summary>
 public class ContributorInfo {
-    /// <summary>The contributor's email address</summary>
+    /// <summary>Their email address</summary>
     [JsonPropertyName("email")]
     public string? Email { get; set; }
 
-    /// <summary>The contributor's educational institution</summary>
+    /// <summary>Where they studied, e.g. "Idaho State University"</summary>
     [JsonPropertyName("education")]
     public string? Education { get; set; }
 
-    /// <summary>The contributor's field of study</summary>
+    /// <summary>Their field of study</summary>
     [JsonPropertyName("major")]
     public string? Major { get; set; }
 
-    /// <summary>A short biography about the contributor</summary>
+    /// <summary>A short bio written by the contributor</summary>
     [JsonPropertyName("bio")]
     public string? Bio { get; set; }
+
+    /// <summary>Their GitHub username — leave blank if they don't have one or haven't added it yet</summary>
+    [JsonPropertyName("githubUsername")]
+    public string? GithubUsername { get; set; }
+}
+
+/// <summary>Slim version used by the /directory endpoint — just enough for the About Us page to show names and GitHub links without loading full profiles</summary>
+public class ContributorDirectoryEntry {
+    /// <summary>Their full name</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    /// <summary>Their GitHub username — empty string if not set yet</summary>
+    [JsonPropertyName("githubUsername")]
+    public string GithubUsername { get; set; } = "";
 }

--- a/redux-tests/Navigation/ContributorProfile_Tests.cs
+++ b/redux-tests/Navigation/ContributorProfile_Tests.cs
@@ -1,0 +1,243 @@
+using Xunit;
+using System.Text.Json;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class ContributorProfile_Tests {
+
+    private readonly ContributorProfileController _controller;
+    private readonly string _jsonFilePath;
+
+    public ContributorProfile_Tests() {
+        _controller = new ContributorProfileController();
+        _jsonFilePath = Path.Combine(ProjectSourcePath.Value, "wwwroot", "contributorInfo.json");
+    }
+
+    // ─── contributorInfo.json sanity checks ───────────────────────────────────
+
+    [Fact]
+    public void ContributorInfoJson_FileExists() {
+        Assert.True(File.Exists(_jsonFilePath), "contributorInfo.json is missing from wwwroot");
+    }
+
+    [Fact]
+    public void ContributorInfoJson_IsValidJson() {
+        string content = File.ReadAllText(_jsonFilePath);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var contributors = JsonSerializer.Deserialize<Dictionary<string, ContributorInfo>>(content, options);
+        Assert.NotNull(contributors);
+    }
+
+    [Fact]
+    public void ContributorInfoJson_HasAtLeastOneEntry() {
+        string content = File.ReadAllText(_jsonFilePath);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var contributors = JsonSerializer.Deserialize<Dictionary<string, ContributorInfo>>(content, options);
+        Assert.NotNull(contributors);
+        Assert.True(contributors.Count > 0, "contributorInfo.json has no entries");
+    }
+
+    [Fact]
+    public void ContributorInfoJson_NoEntryHasBlankName() {
+        string content = File.ReadAllText(_jsonFilePath);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var contributors = JsonSerializer.Deserialize<Dictionary<string, ContributorInfo>>(content, options);
+        Assert.NotNull(contributors);
+        foreach (var key in contributors.Keys) {
+            Assert.False(string.IsNullOrWhiteSpace(key), "Found an entry with a blank or null name key");
+        }
+    }
+
+    [Fact]
+    public void ContributorInfoJson_GithubUsernameFieldIsNeverNull() {
+        string content = File.ReadAllText(_jsonFilePath);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var contributors = JsonSerializer.Deserialize<Dictionary<string, ContributorInfo>>(content, options);
+        Assert.NotNull(contributors);
+        foreach (var kvp in contributors) {
+            // null means the field was missing entirely from the JSON — should be "" if not set
+            Assert.True(kvp.Value.GithubUsername != null,
+                $"{kvp.Key} is missing the githubUsername field — add it as an empty string");
+        }
+    }
+
+    // ─── GET /names ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetContributorNames_Returns200() {
+        var result = _controller.GetContributorNames();
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetContributorNames_ReturnsNonEmptyArray() {
+        var ok = _controller.GetContributorNames() as OkObjectResult;
+        Assert.NotNull(ok);
+        var names = ok.Value as string[];
+        Assert.NotNull(names);
+        Assert.True(names.Length > 0, "Names list came back empty");
+    }
+
+    [Fact]
+    public void GetContributorNames_NoDuplicates() {
+        var ok = _controller.GetContributorNames() as OkObjectResult;
+        Assert.NotNull(ok);
+        var names = ok.Value as string[];
+        Assert.NotNull(names);
+        Assert.Equal(names.Length, names.Distinct().Count());
+    }
+
+    // ─── GET /directory ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetContributorDirectory_Returns200() {
+        var result = _controller.GetContributorDirectory();
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetContributorDirectory_EachEntryHasName() {
+        var ok = _controller.GetContributorDirectory() as OkObjectResult;
+        Assert.NotNull(ok);
+        var entries = ok.Value as ContributorDirectoryEntry[];
+        Assert.NotNull(entries);
+        foreach (var entry in entries) {
+            Assert.False(string.IsNullOrWhiteSpace(entry.Name), "Found a directory entry with a blank name");
+        }
+    }
+
+    [Fact]
+    public void GetContributorDirectory_GithubUsernameIsNeverNull() {
+        var ok = _controller.GetContributorDirectory() as OkObjectResult;
+        Assert.NotNull(ok);
+        var entries = ok.Value as ContributorDirectoryEntry[];
+        Assert.NotNull(entries);
+        foreach (var entry in entries) {
+            Assert.NotNull(entry.GithubUsername);
+        }
+    }
+
+    [Fact]
+    public void GetContributorDirectory_CountMatchesNamesEndpoint() {
+        var namesOk = _controller.GetContributorNames() as OkObjectResult;
+        var dirOk = _controller.GetContributorDirectory() as OkObjectResult;
+        Assert.NotNull(namesOk);
+        Assert.NotNull(dirOk);
+        var names = namesOk.Value as string[];
+        var entries = dirOk.Value as ContributorDirectoryEntry[];
+        Assert.NotNull(names);
+        Assert.NotNull(entries);
+        Assert.Equal(names.Length, entries.Length);
+    }
+
+    [Theory]
+    [InlineData("Himanshu Jha",    "himanshujha05")]
+    [InlineData("Pratham Khanal",  "pkprathamkhanal")]
+    [InlineData("Sansar Kharal",   "kharsans")]
+    [InlineData("Andrija Sevaljevic", "Andrija-Sevaljevic")]
+    [InlineData("Jason Wright",    "wrigjl")]
+    [InlineData("Alex Svancara",   "svanalex")]
+    public void GetContributorDirectory_KnownGithubUsernamesAreCorrect(string name, string expectedUsername) {
+        var ok = _controller.GetContributorDirectory() as OkObjectResult;
+        Assert.NotNull(ok);
+        var entries = ok.Value as ContributorDirectoryEntry[];
+        Assert.NotNull(entries);
+        var entry = entries.FirstOrDefault(e => e.Name == name);
+        Assert.NotNull(entry);
+        Assert.Equal(expectedUsername, entry.GithubUsername);
+    }
+
+    // ─── GET /{contributorName} ───────────────────────────────────────────────
+
+    [Fact]
+    public void GetContributorProfile_KnownContributor_Returns200() {
+        var result = _controller.GetContributorProfile("Himanshu Jha");
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetContributorProfile_ReturnsCorrectName() {
+        var ok = _controller.GetContributorProfile("Himanshu Jha") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        Assert.Equal("Himanshu Jha", portfolio.ContributorName);
+    }
+
+    [Fact]
+    public void GetContributorProfile_ReturnsCorrectGithubUsername() {
+        var ok = _controller.GetContributorProfile("Himanshu Jha") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        Assert.Equal("himanshujha05", portfolio.GithubUsername);
+    }
+
+    [Fact]
+    public void GetContributorProfile_CaseInsensitiveLookup_StillReturnsProfile() {
+        // "himanshu jha" (all lowercase) should match "Himanshu Jha" in the JSON
+        var ok = _controller.GetContributorProfile("himanshu jha") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        Assert.Equal("himanshujha05", portfolio.GithubUsername);
+    }
+
+    [Fact]
+    public void GetContributorProfile_UnknownContributor_FieldsFallBackToNotSpecified() {
+        var ok = _controller.GetContributorProfile("Nonexistent Person") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        Assert.Equal("Not specified", portfolio.Email);
+        Assert.Equal("Not specified", portfolio.Bio);
+        Assert.Equal("Not specified", portfolio.Education);
+        Assert.Equal("Not specified", portfolio.Major);
+    }
+
+    [Fact]
+    public void GetContributorProfile_UnknownContributor_GithubUsernameIsEmptyString() {
+        var ok = _controller.GetContributorProfile("Nonexistent Person") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        Assert.Equal("", portfolio.GithubUsername);
+    }
+
+    [Fact]
+    public void GetContributorProfile_ListsAreNeverNull() {
+        var ok = _controller.GetContributorProfile("Himanshu Jha") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        Assert.NotNull(portfolio.ProblemsContributed);
+        Assert.NotNull(portfolio.SolversCreated);
+        Assert.NotNull(portfolio.ReductionsCreated);
+    }
+
+    [Fact]
+    public void GetContributorProfile_TotalContributions_MatchesSumOfLists() {
+        var ok = _controller.GetContributorProfile("Himanshu Jha") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        int expected = portfolio.ProblemsContributed.Count
+                     + portfolio.SolversCreated.Count
+                     + portfolio.ReductionsCreated.Count;
+        Assert.Equal(expected, portfolio.TotalContributions);
+    }
+
+    [Fact]
+    public void GetContributorProfile_TotalContributions_IsNonNegative() {
+        var ok = _controller.GetContributorProfile("Himanshu Jha") as OkObjectResult;
+        Assert.NotNull(ok);
+        var portfolio = ok.Value as ContributorPortfolio;
+        Assert.NotNull(portfolio);
+        Assert.True(portfolio.TotalContributions >= 0);
+    }
+}

--- a/wwwroot/contributorInfo.json
+++ b/wwwroot/contributorInfo.json
@@ -3,157 +3,196 @@
     "email": "kadenmarchetti@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Full-stack developer with expertise in NP-Complete problems"
+    "bio": "Full-stack developer with expertise in NP-Complete problems",
+    "githubUsername": ""
   },
   "Caleb Eardley": {
     "email": "calebeardley@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Backend specialist focusing on problem reductions"
+    "bio": "Backend specialist focusing on problem reductions",
+    "githubUsername": ""
   },
   "Daniel Igbokwe": {
     "email": "danieligbokwe@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Algorithm optimization expert"
+    "bio": "Algorithm optimization expert",
+    "githubUsername": "igbodani"
   },
   "Alex Diviney": {
     "email": "alexdiviney@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Frontend and visualization specialist"
+    "bio": "Frontend and visualization specialist",
+    "githubUsername": ""
   },
   "Janita Aamir": {
     "email": "janitamir@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Problem solver and verifier developer"
+    "bio": "Problem solver and verifier developer",
+    "githubUsername": ""
   },
   "Andrija Sevaljevic": {
     "email": "andrijaSevaljevic@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Graph algorithm specialist"
+    "bio": "Graph algorithm specialist",
+    "githubUsername": "Andrija-Sevaljevic"
   },
   "Garret Stouffer": {
     "email": "garretstouffer@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Data structure and algorithm expert"
+    "bio": "Data structure and algorithm expert",
+    "githubUsername": ""
   },
   "Porter Glines": {
     "email": "porterglines@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Testing and quality assurance specialist"
+    "bio": "Testing and quality assurance specialist",
+    "githubUsername": ""
   },
   "Show Pratoomratana": {
     "email": "showpratoomratana@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "UI/UX and frontend developer"
+    "bio": "UI/UX and frontend developer",
+    "githubUsername": ""
   },
   "Russell Phillips": {
     "email": "russellphillips@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Documentation and project coordinator"
+    "bio": "Documentation and project coordinator",
+    "githubUsername": ""
   },
   "Michael Crapse": {
     "email": "michaelcrapse@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Backend infrastructure developer"
+    "bio": "Backend infrastructure developer",
+    "githubUsername": ""
   },
   "Ian Gonzalez": {
     "email": "iangonzalez@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Algorithm solver specialist"
+    "bio": "Algorithm solver specialist",
+    "githubUsername": ""
   },
   "Sabal Subedi": {
     "email": "sabalsubedi@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Problem verification specialist"
+    "bio": "Problem verification specialist",
+    "githubUsername": "sabal-subedi"
   },
   "Himanshu Jha": {
     "email": "himanshujha@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Full-stack developer and API specialist"
+    "bio": "Full-stack developer and API specialist",
+    "githubUsername": "himanshujha05"
   },
   "Sansar Kharal": {
     "email": "sanskharal@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Backend and solver specialist"
+    "bio": "Backend and solver specialist",
+    "githubUsername": "kharsans"
   },
   "Pratham Khanal": {
     "email": "prathamkhanal@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Database and backend developer"
+    "bio": "Database and backend developer",
+    "githubUsername": "pkprathamkhanal"
   },
   "George Lake": {
     "email": "georgelake@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Algorithm specialist and reducer"
+    "bio": "Algorithm specialist and reducer",
+    "githubUsername": ""
   },
   "Grant Gardner": {
     "email": "grantgardner@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Problem solver and verifier contributor"
+    "bio": "Problem solver and verifier contributor",
+    "githubUsername": ""
   },
   "Jason Wright": {
     "email": "jasonwright@isu.edu",
     "education": "Idaho State University",
-    "major": "Computer Science"
-
-    
+    "major": "Computer Science",
+    "bio": "",
+    "githubUsername": "wrigjl"
   },
   "Alex Svancara": {
     "email": "alexsvancara@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Problem implementation specialist"
+    "bio": "Problem implementation specialist",
+    "githubUsername": "svanalex"
   },
   "Eric Hill": {
     "email": "erichill@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Solver and reduction developer"
+    "bio": "Solver and reduction developer",
+    "githubUsername": ""
   },
   "Max Grünwoldt": {
     "email": "maxgrunwoldt@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Algorithm and data structure expert"
+    "bio": "Algorithm and data structure expert",
+    "githubUsername": ""
   },
   "Paul Gilbreath": {
     "email": "paulgilbreath@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Backend developer and API contributor"
+    "bio": "Backend developer and API contributor",
+    "githubUsername": ""
   },
   "Andreas Kramer": {
     "email": "andreaskramer@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Problem implementation and testing"
+    "bio": "Problem implementation and testing",
+    "githubUsername": "kramandr"
   },
   "Courtney Bodily": {
     "email": "courtneybodily@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Project lead and system architect"
+    "bio": "Project lead and system architect",
+    "githubUsername": ""
   },
   "Rakesh Itani": {
     "email": "rakeshitani@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Frontend developer and UI specialist"
+    "bio": "Frontend developer and UI specialist",
+    "githubUsername": ""
+  },
+  "David Lindeman": {
+    "email": "",
+    "education": "Idaho State University",
+    "major": "Computer Science",
+    "bio": "",
+    "githubUsername": ""
+  },
+  "Pravesh Aryal": {
+    "email": "pravesharyal@isu.edu",
+    "education": "Idaho State University",
+    "major": "Computer Science",
+    "bio": "Test contributor entry",
+    "githubUsername": "PraveshAryal03"
   }
 }

--- a/wwwroot/contributorInfo.json
+++ b/wwwroot/contributorInfo.json
@@ -220,7 +220,7 @@
     "email": "koraskoirala@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Machine learning model architecture; contributor to Redux testing and problem verification"
+    "bio": "Machine learning model architecture; contributor to Redux testing and problem verification",
     "githubUsername": ""
   },
   "Dinesh Khanal": {
@@ -234,7 +234,7 @@
     "email": "khanmusa@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Implemented the Knapsack DP solver and unit tests"
+    "bio": "Implemented the Knapsack DP solver and unit tests",
     "githubUsername": ""
   },
   "Calvin Condie": {

--- a/wwwroot/contributorInfo.json
+++ b/wwwroot/contributorInfo.json
@@ -185,7 +185,6 @@
     "email": "",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "",
     "githubUsername": "",
     "bio": "Frontend developer and UI specialist"
   },
@@ -193,48 +192,56 @@
     "email": "kaosiibeabuchi@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science and Software Engineering",
-    "bio": "Problem solver and verifier developer"
+    "bio": "Problem solver and verifier developer",
+    "githubUsername": ""
   },
   "Diya Pandey": {
     "email": "diyapandey@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science and Software Engineering",
-    "bio": "Problem architect developer"
+    "bio": "Problem architect developer",
+    "githubUsername": ""
   },
   "Srijan Pant": {
     "email": "srijanpant@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Testing and quality assurance specialist"
+    "bio": "Testing and quality assurance specialist",
+    "githubUsername": ""
   },
   "Pravesh Aryal": {
     "email": "praveshAryal@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science (Minor: Mathematics)",
-    "bio": "Machine learning model architecture; contributor to Redux graph algorithms and problem implementations"
+    "bio": "Machine learning model architecture; contributor to Redux graph algorithms and problem implementations",
+    "githubUsername": ""
   },
   "Koras Koirala": {
     "email": "koraskoirala@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
     "bio": "Machine learning model architecture; contributor to Redux testing and problem verification"
+    "githubUsername": ""
   },
   "Dinesh Khanal": {
     "email": "dineshkhanal@isu.edu",
     "education": "Idaho State University",
     "major": "Mathematics (Minor: Computer Science)",
-    "bio": "Algorithm and logic developer; contributor to Redux problem solver design"
+    "bio": "Algorithm and logic developer; contributor to Redux problem solver design",
+    "githubUsername": ""
   },
   "Musab Khan": {
     "email": "khanmusa@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
     "bio": "Implemented the Knapsack DP solver and unit tests"
+    "githubUsername": ""
   },
   "Calvin Condie": {
     "email": "calvincondie@isu.edu",
     "education": "Idaho State University",
     "major": "Computer Science",
-    "bio": "Implemented the Knapsack DP solver and unit tests"
+    "bio": "Implemented the Knapsack DP solver and unit tests",
+    "githubUsername": ""
   }
 }

--- a/wwwroot/contributorInfo.json
+++ b/wwwroot/contributorInfo.json
@@ -186,7 +186,7 @@
     "education": "Idaho State University",
     "major": "Computer Science",
     "bio": "",
-    "githubUsername": ""
+    "githubUsername": "",
     "bio": "Frontend developer and UI specialist"
   },
   "Kaosi Ibeabuchi": {

--- a/wwwroot/contributorInfo.json
+++ b/wwwroot/contributorInfo.json
@@ -187,12 +187,5 @@
     "major": "Computer Science",
     "bio": "",
     "githubUsername": ""
-  },
-  "Pravesh Aryal": {
-    "email": "pravesharyal@isu.edu",
-    "education": "Idaho State University",
-    "major": "Computer Science",
-    "bio": "Test contributor entry",
-    "githubUsername": "PraveshAryal03"
   }
 }


### PR DESCRIPTION
## What is this PR about?

Right now, every time a new student joins the Redux project and contributes code, someone has to manually open the frontend file (`index.js`) and hardcode their name into the contributors list. That's an annoying two-repo change for what should be a one-line addition.

This PR fixes that completely. Contributors now only need to add their entry to a single JSON file in the backend — `wwwroot/contributorInfo.json` — and their name automatically shows up on the About Us page the next time the backend is restarted. No frontend changes needed.

On top of that, we also added GitHub username support so the About Us page can display each contributor's avatar and a clickable link to their GitHub profile directly from the modal.

---

## What changed?

### `wwwroot/contributorInfo.json`
- Added a new `githubUsername` field to every contributor entry
- Filled in the known GitHub usernames for contributors whose profiles were previously hardcoded in the frontend (Himanshu Jha, Pratham Khanal, Sansar Kharal, Andrija Sevaljevic, Jason Wright, Alex Svancara, Daniel Igbokwe, Sabal Subedi, Andreas Kramer)
- Left `githubUsername` as an empty string for contributors who haven't added theirs yet — they can fill it in anytime
- Added missing contributor **David Lindeman** to the JSON

### `AdditionalControllers/Navigation/ContributerProfile.cs`
Two new API endpoints were added:

**`GET /Navigation/ContributorProfile/names`**
Returns a plain array of all contributor names directly from `contributorInfo.json`. This was the first step toward removing the hardcoded names list from the frontend.

**`GET /Navigation/ContributorProfile/directory`**
Returns an array of `{ name, githubUsername }` objects — everything the About Us page needs in a single API call. The frontend now fetches this on load, builds the names list dynamically, and uses the GitHub usernames to render avatars and profile links in the contributor modal. No hardcoding on either side.

The `ContributorInfo` and `ContributorPortfolio` model classes were also updated to include the `GithubUsername` property so it flows through the existing profile endpoint too.

All inline comments were rewritten in plain, conversational language so the code is easier to pick up for new contributors.

### `redux-tests/Navigation/ContributorProfile_Tests.cs` *(new file)*
27 unit tests covering everything added in this PR:

- JSON file exists, is valid, has no blank name keys, and has no null `githubUsername` fields
- `/names` returns a non-empty array with no duplicates
- `/directory` returns the correct count, no blank entries, and verifies 6 known GitHub usernames by name
- `/profile` returns correct data for a known contributor, handles case-insensitive lookups gracefully, falls back to `"Not specified"` for unknown contributors, and verifies that `totalContributions` always equals the sum of the three contribution lists

All 27 tests pass.

---

## How does a new contributor use this?

1. Open `wwwroot/contributorInfo.json`
2. Add an entry like this:

```json
"Your Full Name": {
  "email": "youremail@isu.edu",
  "education": "Idaho State University",
  "major": "Computer Science",
  "bio": "A short sentence about yourself",
  "githubUsername": "your-github-username"
}
```

3. Restart the backend — your name appears on the About Us page automatically

That's it. No frontend PR needed.

---

## Test plan

- [ ] Run `dotnet test API.csproj --filter "ContributorProfile"` — all 27 tests should pass
- [ ] Start the backend and hit `GET /Navigation/ContributorProfile/directory` — should return all names with their GitHub usernames
- [ ] Open the About Us page — contributor list should load dynamically (no hardcoded names)
- [ ] Click a contributor who has a `githubUsername` set — modal should show their GitHub avatar and a clickable profile link
- [ ] Click a contributor with no `githubUsername` — modal should open normally with no GitHub section shown
- [ ] Add a new entry to `contributorInfo.json`, restart the backend, refresh the page — new name should appear without any frontend changes