### PR TITLE
Add Graph Coloring Greedy solver

### DIFF
--- a/Problems/NPComplete/NPC_GRAPHCOLORING/Solvers/GraphColoringGreedy.cs
+++ b/Problems/NPComplete/NPC_GRAPHCOLORING/Solvers/GraphColoringGreedy.cs
@@ -1,0 +1,75 @@
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Interfaces.Graphs;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace API.Problems.NPComplete.NPC_GRAPHCOLORING.Solvers;
+
+class GraphColoringGreedy : ISolver<GRAPHCOLORING> {
+ 
+    public string solverName {get;} = "Graph Coloring Greedy";
+    public string solverDefinition {get;} = "A greedy algorithm that iterates through each vertex and assigns the smallest color not used by any of its neighbors.";
+    public string source {get;} = "Dasgupta, S, Papadimitriou, C, & Vazirani, U. (2006). Algorithms. McGraw-Hill. Chapter 9.2";
+    public string[] contributors {get;} = { "Pramesh Shah" };
+    public bool timerHasExpired { get; set; }
+
+    // Constructor 
+    public GraphColoringGreedy() { }
+
+    // Builds certificate string in format {{a,d},{b},{c}}
+    private string BuildCertificate(Dictionary<string, int> colorAssignment, List<string> nodes, int numColors)
+    {
+        List<string> colorGroups = new List<string>();
+        for (int i = 0; i < numColors; i++)
+        {
+            List<string> group = nodes.Where(node => colorAssignment[node] == i).ToList();
+            colorGroups.Add("{" + string.Join(",", group) + "}");
+        }
+        return "{" + string.Join(",", colorGroups) + "}";
+    }
+
+    public string solve(GRAPHCOLORING gColor)
+    {
+        List<string> nodes = gColor.nodes;
+        List<KeyValuePair<string, string>> edges = gColor.edges;
+
+        // Guard, empty graph
+        if (nodes == null || nodes.Count == 0)
+            return "{}";
+
+        // Build adjacency list
+        Dictionary<string, List<string>> adjacency = new Dictionary<string, List<string>>();
+        foreach (string node in nodes)
+            adjacency[node] = new List<string>();
+
+        foreach (KeyValuePair<string, string> edge in edges) {
+            adjacency[edge.Key].Add(edge.Value);
+            adjacency[edge.Value].Add(edge.Key);
+        }
+
+        // For each vertex assign smallest color not used by neighbors
+        Dictionary<string, int> colorAssignment = new Dictionary<string, int>();
+        foreach (string node in nodes)
+        {
+            HashSet<int> usedColors = new HashSet<int>();
+            foreach (string neighbor in adjacency[node])
+                if (colorAssignment.ContainsKey(neighbor))
+                    usedColors.Add(colorAssignment[neighbor]);
+
+            int color = 0;
+            while (usedColors.Contains(color))
+                color++;
+
+            colorAssignment[node] = color;
+        }
+
+        int numColors = colorAssignment.Values.Max() + 1;
+
+        // Guard, greedy used more colors than K allows
+        if (numColors > gColor.K)
+            return "{}";
+
+        return BuildCertificate(colorAssignment, nodes, numColors);
+    }
+}

--- a/redux-tests/Problems/NPC_GRAPHCOLORING/GRAPHCOLORING_Tests.cs
+++ b/redux-tests/Problems/NPC_GRAPHCOLORING/GRAPHCOLORING_Tests.cs
@@ -1,0 +1,96 @@
+// GRAPHCOLORING_Tests.cs
+// Saurav Bhusal and Pramesh Shah
+// sauravbhusal@isu.edu, prameshshah@isu.edu
+
+using Xunit;
+using API.Problems.NPComplete.NPC_GRAPHCOLORING;
+using API.Problems.NPComplete.NPC_GRAPHCOLORING.Solvers;
+using API.Problems.NPComplete.NPC_GRAPHCOLORING.Verifiers;
+
+namespace API.Tests.Problems.NPC_GRAPHCOLORING;
+
+public class GRAPHCOLORING_Tests {
+
+    // Test 1: Default Redux instance
+    [Fact]
+    public void GreedySolver_DefaultInstance_ReturnsValidCertificate() {
+        GRAPHCOLORING problem = new GRAPHCOLORING();
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        GraphColoringVerifier verifier = new GraphColoringVerifier();
+        string certificate = solver.solve(problem);
+        Assert.True(verifier.verify(problem, certificate));
+    }
+
+    // Test 2: Single node
+    [Fact]
+    public void GreedySolver_SingleNode_ReturnsValidCertificate() {
+        GRAPHCOLORING problem = new GRAPHCOLORING("(({a},{}),1)");
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        GraphColoringVerifier verifier = new GraphColoringVerifier();
+        string certificate = solver.solve(problem);
+        Assert.True(verifier.verify(problem, certificate));
+    }
+
+    // Test 3: K too small returns empty
+    [Fact]
+    public void GreedySolver_KTooSmall_ReturnsEmpty() {
+        GRAPHCOLORING problem = new GRAPHCOLORING(
+            "(({a,b,c,d},{{a,b},{a,c},{a,d},{b,c},{b,d},{c,d}}),2)");
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        string certificate = solver.solve(problem);
+        Assert.Equal("{}", certificate);
+    }
+
+    // Test 4: Bipartite graph
+    [Fact]
+    public void GreedySolver_BipartiteGraph_UsesTwoColors() {
+        GRAPHCOLORING problem = new GRAPHCOLORING(
+            "(({a,b,c,d},{{a,c},{a,d},{b,c},{b,d}}),2)");
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        GraphColoringVerifier verifier = new GraphColoringVerifier();
+        string certificate = solver.solve(problem);
+        Assert.True(verifier.verify(problem, certificate));
+    }
+
+    // Test 5: No edges
+    [Fact]
+    public void GreedySolver_NoEdges_ReturnsValidCertificate() {
+        GRAPHCOLORING problem = new GRAPHCOLORING("(({a,b,c},{}),1)");
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        GraphColoringVerifier verifier = new GraphColoringVerifier();
+        string certificate = solver.solve(problem);
+        Assert.True(verifier.verify(problem, certificate));
+    }
+
+    // Test 6: Triangle needs 3 colors
+    [Fact]
+    public void GreedySolver_Triangle_NeedsThreeColors() {
+        GRAPHCOLORING problem = new GRAPHCOLORING(
+            "(({a,b,c},{{a,b},{b,c},{a,c}}),3)");
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        GraphColoringVerifier verifier = new GraphColoringVerifier();
+        string certificate = solver.solve(problem);
+        Assert.True(verifier.verify(problem, certificate));
+    }
+
+    // Test 7: Two nodes one edge
+    [Fact]
+    public void GreedySolver_TwoNodes_ReturnsValidCertificate() {
+        GRAPHCOLORING problem = new GRAPHCOLORING("(({a,b},{{a,b}}),2)");
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        GraphColoringVerifier verifier = new GraphColoringVerifier();
+        string certificate = solver.solve(problem);
+        Assert.True(verifier.verify(problem, certificate));
+    }
+
+    // Test 8: Complete graph K4
+    [Fact]
+    public void GreedySolver_CompleteGraphK4_ReturnsFourColors() {
+        GRAPHCOLORING problem = new GRAPHCOLORING(
+            "(({a,b,c,d},{{a,b},{a,c},{a,d},{b,c},{b,d},{c,d}}),4)");
+        GraphColoringGreedy solver = new GraphColoringGreedy();
+        GraphColoringVerifier verifier = new GraphColoringVerifier();
+        string certificate = solver.solve(problem);
+        Assert.True(verifier.verify(problem, certificate));
+    }
+}


### PR DESCRIPTION
## Summary
For this we added Greedy Solver to the existing 
Graph Coloring problem in Redux. Right now, Graph Coloring only has 
a Brute Force solver. We wanted to add a smarter, faster alternative 
that still produces a valid coloring.

## What We Changed
- Added `GraphColoringGreedy.cs` in 
  `Problems/NPComplete/NPC_GRAPHCOLORING/Solvers/`
- Added `GRAPHCOLORING_Tests.cs` in 
  `redux-tests/Problems/NPC_GRAPHCOLORING/`

## How the Algorithm Works
The greedy algorithm goes through each vertex one by one and assigns 
it the smallest color that none of its neighbors are already using. 
It is not guaranteed to find the minimum number of colors since it 
is a heuristic, but it always finds a valid coloring if one exists 
within K colors.

- Time Complexity: O(V + E)
- Returns `{}` if it cannot color the graph within K colors
- Source: Dasgupta et al., Algorithms, Chapter 9.2

## Tests Written
- Default Redux instance (9 nodes, K=3)
- Single node
- Two nodes with one edge
- Complete graph K4
- Bipartite graph
- No edges
- Triangle
- K too small edge case

## Team Contributions
- **Pramesh Shah** — Implemented the greedy solver 
  (`GraphColoringGreedy.cs`)
- **Saurav Bhusal** — Wrote the unit tests 
  (`GRAPHCOLORING_Tests.cs`)

## Notes
We tested this locally against the existing GraphColoringVerifier 
and it passes all cases. Both solutions show up correctly in the 
Redux GUI dropdown.