### PR TITLE
fix: address review feedback on Topological Sort (PR #178)

### DIFF
--- a/Problems/NPComplete/NPC_TOPOLOGICALSORT/Visualizations/TopologicalSortDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_TOPOLOGICALSORT/Visualizations/TopologicalSortDefaultVisualization.cs
@@ -1,5 +1,4 @@
 using API.Interfaces;
-using API.Interfaces.Graphs.GraphParser;
 using API.Interfaces.JSON_Objects.Graphs;
 using API.Interfaces.JSON_Objects;
 using API.Problems.NPComplete.NPC_TOPOLOGICALSORT.Solvers;
@@ -10,7 +9,7 @@ class TopologicalSortDefaultVisualization : IVisualization<TOPOLOGICALSORT>
 {
     // --- Fields ---
     public string visualizationName { get; } = "Topological Sort Visualization";
-    public string visualizationDefinition { get; } = "This is a default visualization for Topological Sort. Nodes and edges are highlighted in the order they appear in the topological ordering produced by Kahn's Algorithm.";
+    public string visualizationDefinition { get; } = "Animates the graph by topological rank: all source nodes (in-degree zero) highlight first, followed by their successors in waves. This mirrors how Kahn's Algorithm peels off layers of zero-in-degree nodes during execution. Every edge is highlighted because, in a valid topological ordering, every directed edge points forward.";
     public string source { get; } = "Kahn, A. B. (1962). Topological sorting of large networks. Communications of the ACM, 5(11), 558-562.";
     public string[] contributors { get; } = { "Pravesh Aryal", "Koras Koirala", "Dinesh Khanal" };
     public string visualizationType { get; } = "Graph D3";
@@ -27,39 +26,78 @@ class TopologicalSortDefaultVisualization : IVisualization<TOPOLOGICALSORT>
 
     public API_JSON SolvedVisualization(TOPOLOGICALSORT problem, string solution)
     {
-        List<string> solutionNodes = GraphParser.parseNodeListWithStringFunctions(solution);
         API_GraphJSON apiGraph = problem.graph.ToAPIGraph();
 
-        for (int i = 0; i < solutionNodes.Count - 1; i++)
+        // No valid topological ordering (cycle in graph): return graph un-highlighted.
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return apiGraph;
+
+        // Compute the topological rank of every node.
+        // rank(v) = length of longest path from any source node to v.
+        // All rank-0 nodes (in-degree zero) animate first, rank-1 next, etc.
+        Dictionary<string, int> rank = ComputeRanks(problem);
+        int maxRank = rank.Values.Count == 0 ? 0 : rank.Values.Max();
+
+        // Spread the animation evenly across a fixed total duration.
+        const int totalDurationMs = 5000;
+        int delayPerRank = maxRank == 0 ? 0 : totalDurationMs / (maxRank + 1);
+
+        // Highlight every node, timed by its topological rank.
+        foreach (var node in apiGraph.nodes)
         {
-            var from = solutionNodes[i];
-            var to = solutionNodes[i + 1];
-
-            var link = apiGraph.links.FirstOrDefault(l =>
-                l.source == from && l.target == to
-            );
-            var node = apiGraph.nodes.FirstOrDefault(n => n.name == solutionNodes[i]);
-
-            if (link != null)
-            {
-                link.color = "Solution";
-                link.delay = ((i + 1) * 5000 / apiGraph.nodes.Count).ToString();
-            }
-            if (node != null)
-            {
-                node.color = "Solution";
-                node.delay = ((i + 1) * 5000 / solutionNodes.Count).ToString();
-            }
+            int r = rank.TryGetValue(node.name, out var value) ? value : 0;
+            node.color = "Solution";
+            node.delay = (r * delayPerRank).ToString();
         }
 
-        // Color the last node in the ordering
-        var lastNode = apiGraph.nodes.FirstOrDefault(n => n.name == solutionNodes[solutionNodes.Count - 1]);
-        if (lastNode != null)
+        // Highlight every edge. An edge (u -> v) appears one rank-step after u.
+        foreach (var link in apiGraph.links)
         {
-            lastNode.color = "Solution";
-            lastNode.delay = "5000";
+            int sourceRank = rank.TryGetValue(link.source, out var value) ? value : 0;
+            link.color = "Solution";
+            link.delay = ((sourceRank + 1) * delayPerRank).ToString();
         }
 
         return apiGraph;
+    }
+
+    private static Dictionary<string, int> ComputeRanks(TOPOLOGICALSORT problem)
+    {
+        Dictionary<string, int> rank = new Dictionary<string, int>();
+        Dictionary<string, int> inDegree = new Dictionary<string, int>();
+
+        foreach (var node in problem.nodes)
+        {
+            rank[node] = 0;
+            inDegree[node] = 0;
+        }
+
+        foreach (var edge in problem.edges)
+        {
+            if (inDegree.ContainsKey(edge.Value))
+                inDegree[edge.Value]++;
+        }
+
+        Queue<string> queue = new Queue<string>();
+        foreach (var node in problem.nodes)
+        {
+            if (inDegree[node] == 0)
+                queue.Enqueue(node);
+        }
+
+        while (queue.Count > 0)
+        {
+            string current = queue.Dequeue();
+            foreach (var edge in problem.edges)
+            {
+                if (edge.Key != current) continue;
+                rank[edge.Value] = Math.Max(rank[edge.Value], rank[current] + 1);
+                inDegree[edge.Value]--;
+                if (inDegree[edge.Value] == 0)
+                    queue.Enqueue(edge.Value);
+            }
+        }
+
+        return rank;
     }
 }

--- a/redux-tests/Problems/NPC_TOPOLOGICALSORT/TOPOLOGICALSORT_Tests.cs
+++ b/redux-tests/Problems/NPC_TOPOLOGICALSORT/TOPOLOGICALSORT_Tests.cs
@@ -64,8 +64,10 @@ public class TOPOLOGICALSORT_Tests
     public void TOPOLOGICALSORT_Solver_DefaultInstance()
     {
         var problem = new TOPOLOGICALSORT();
-        string solution = new KahnsAlgorithm().solve(problem);
-        Assert.Equal("{1,2,3,4,6,5}", solution);
+        var solver = new KahnsAlgorithm();
+        var verifier = new TopologicalSortVerifier();
+        string solution = solver.solve(problem);
+        Assert.True(verifier.verify(problem, solution));
     }
 
     [Theory]


### PR DESCRIPTION
# fix: address review feedback on Topological Sort (PR #178)

Follow-up to [PR #178](https://github.com/ReduxISU/Redux/pull/178), addressing both review comments left by @Andrija-Sevaljevic:

> 1. **Tests** — Make sure that the verifier is called for the default instance, rather than expecting a specific instance. Multiple solutions could be correct (non-unique).
> 2. **Visualization** — I would remove it or implement a new template for it on the front-end. It does not logically make sense to visualize the problem this way.

This PR keeps and *improves* the visualization rather than removing it. The visualization upgrade is paired with a companion frontend PR in the [Redux_GUI repository](https://github.com/ReduxISU/Redux_GUI) that finally honors the `delay` field on graph nodes and links — see cross-link below.

---

## Changes

### Commit 1 — `fix(test): use verifier instead of exact-string match for default solver test`

The previous default-instance solver test asserted exact string equality against one specific output:
```csharp
Assert.Equal("{1,2,3,4,6,5}", solution);
```
Multiple valid topological orderings exist for the default DAG, so coupling the test to one of them is fragile — any future change to iteration order would silently break the test even though the algorithm remained correct.

Replaced with a verifier check that accepts *any* valid ordering:
```csharp
var verifier = new TopologicalSortVerifier();
Assert.True(verifier.verify(problem, solution));
```

This matches the pattern already used by the other solver tests in this file (`TOPOLOGICALSORT_Solver_ProducesValidOrder`).

---

### Commit 2 — `feat(viz): animate Topological Sort by topological rank`

`SolvedVisualization` now computes each node's **topological rank** (the length of the longest path from any source node) and animates the graph in waves:

- All in-degree-zero nodes (rank 0) light up first at delay 0
- Their immediate successors (rank 1) light up after one rank-step
- And so on in layers, until the deepest dependency

Every edge is colored `Solution` because in any valid topological ordering every directed edge points forward. Edge animation is timed one rank-step after its source node, so dependencies visibly flow through the graph as Kahn's algorithm would peel them off layer by layer.

For cyclic instances (where the solver returns `{}`), `SolvedVisualization` returns the graph un-highlighted — there is no valid ordering to animate, which is the correct behavior.

A new private helper `ComputeRanks(problem)` performs a Kahn-style traversal to assign ranks; total animation duration is configurable via `totalDurationMs` (currently 5 s).

**Companion frontend PR**
The backend's `delay` field has historically not been read by the frontend D3 renderer in `Redux_GUI/components/Visualization/svgs/StandardGraphSvgReact.js`. To make the rank-based animation visible, a paired PR teaches that component to honor the `delay` field via D3 transitions:

> **Frontend PR:** [ReduxISU/Redux_GUI#TBD — feat: honor delay field for staggered graph animations](https://github.com/ReduxISU/Redux_GUI) *(link will be added as a comment once opened)*

Once both PRs are merged, the topological sort visualization animates in waves, and every other graph visualization that sets `delay` benefits from the same animation support.

---

## Verification

| Check | Command | Result |
|---|---|---|
| Build | `dotnet build API.csproj` | 0 errors |
| Tests | `dotnet test API.csproj --filter "FullyQualifiedName~TOPOLOGICALSORT"` | **21 / 21 pass** |
| Live API — visualize endpoint | `POST /ProblemProvider/visualize?visualization=TopologicalSortDefaultVisualization` on default instance | Returns staggered delays: `0 → 1250 → 2500 → 3750` ms across 4 ranks (5 s total) |
| Cycle handling | Solver on `({1,2,3},{(1,2),(2,3),(3,1)})` | Returns `{}`; visualize returns un-highlighted graph |
| End-to-end with frontend PR | Local GUI at `http://localhost:3000` | Nodes and edges visibly animate in waves on toggling Highlight Solution |

## Test plan

- [x] Default-instance solver test asserts via verifier instead of exact string
- [x] Full TOPOLOGICALSORT test suite (21 tests) passes
- [x] `SolvedVisualization` produces correctly staggered delays for the default instance
- [x] Cyclic input returns un-highlighted graph (no spurious animation)
- [x] End-to-end animation verified locally with companion frontend PR

## Team

- **Pravesh Aryal** — verifier, integration, follow-up changes
- **Dinesh Khanal** — algorithm research and design
- **Koras Koirala** — unit test suite
