### PR TITLE
do not hardcode the url encoded string

### DIFF
--- a/Interfaces/Tools/ProblemInstanceGenerators.cs
+++ b/Interfaces/Tools/ProblemInstanceGenerators.cs
@@ -101,9 +101,9 @@ static class ProblemInstanceGenerators{
         }
         string S = "";
         foreach(var clause in clauses){
-            S += " %26 "+clause;
+            S += " & "+clause;
         }
-        if(S.Length != 0) S = S.Substring(5);
+        if(S.Length != 0) S = S.Substring(3);
         return S;
     }
 };


### PR DESCRIPTION
We don't need to url encode the ampersands here because they will be sent via post json encoding. (I suspect someone was testing with url encoded strings at some point and this is leftover from that)