### PR TITLE
Self-describing instance/certificate formats; structured 400 on parse error

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -73,14 +73,51 @@ public class ProblemProvider : ControllerBase
     /// <param name="verify">The certificate and problem instance</param>
     /// <returns>true or false</returns>
     [ProducesResponseType(typeof(bool), 200)]
+    [ProducesResponseType(400)]
     [HttpPost("verify")]
-    public string verify(string verifier, [FromBody] Verify verify)
+    public IActionResult verify(string verifier, [FromBody] Verify verify)
     {
-        // TODO: validate arguments
-        return JsonSerializer.Serialize(
-            Verifier(verifier).verify(verify.ProblemInstance, verify.Certificate).ToString(), 
-            new JsonSerializerOptions { WriteIndented = true }
-        );
+        try {
+            string result = JsonSerializer.Serialize(
+                Verifier(verifier).verify(verify.ProblemInstance, verify.Certificate).ToString(),
+                new JsonSerializerOptions { WriteIndented = true }
+            );
+            return Content(result, "application/json");
+        } catch (ProblemParseException ex) {
+            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
+                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
+        } catch (CertificateParseException ex) {
+            return BadRequest(ParseErrorBody("certificate_parse_error", ex.Problem.problemName,
+                ex.Problem.certificateFormat, ex.Received, ex.Message));
+        }
+    }
+
+    private static object ParseErrorBody(string error, string problemName, string expected, string received, string detail) {
+        return new {
+            error,
+            problem = problemName,
+            expected,
+            received,
+            detail
+        };
+    }
+
+    private static string LookupInstanceFormat(string problemName) {
+        // problemName may be either the class name (Problems key) or the
+        // friendly problemName property — scan both. Error path: O(N) is fine.
+        if (Problems.TryGetValue(problemName.ToLower(), out var type)) {
+            try { return (Activator.CreateInstance(type) as IProblem)?.instanceFormat ?? ""; }
+            catch { /* fall through */ }
+        }
+        foreach (var kv in Problems) {
+            try {
+                if (Activator.CreateInstance(kv.Value) is IProblem p
+                    && string.Equals(p.problemName, problemName, StringComparison.OrdinalIgnoreCase)) {
+                    return p.instanceFormat;
+                }
+            } catch { /* skip */ }
+        }
+        return "";
     }
 
     /// <summary>
@@ -119,11 +156,21 @@ public class ProblemProvider : ControllerBase
     /// <param name="problemInstance" example = "(x1 | !x2 | x3) &amp; (!x1 | x3 | x1) &amp; (x2 | !x3 | x1)">instance string</param>
     /// <returns>object instance</returns>
     [ProducesResponseType(typeof(IProblem), 200)]
+    [ProducesResponseType(400)]
     [HttpPost("problemInstance")]
-    public string problemInstance(string problem, [FromBody] string problemInstance)
+    public IActionResult problemInstance(string problem, [FromBody] string problemInstance)
     {
-        // TODO: validate arguments
-        return Newtonsoft.Json.JsonConvert.SerializeObject(ProblemInstance(problem, problemInstance));
+        try {
+            return Content(
+                Newtonsoft.Json.JsonConvert.SerializeObject(ProblemInstance(problem, problemInstance)),
+                "application/json");
+        } catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is ProblemParseException ex) {
+            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
+                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
+        } catch (ProblemParseException ex) {
+            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
+                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
+        }
     }
 
     private static bool IsEmptyVisualization(API_JSON item)

--- a/Interfaces/ParseExceptions.cs
+++ b/Interfaces/ParseExceptions.cs
@@ -1,0 +1,29 @@
+namespace API.Interfaces;
+
+// Thrown when a problem's instance constructor cannot parse the supplied
+// instance string. Controllers translate this to HTTP 400 with the
+// problem's `instanceFormat` as the structured hint.
+internal class ProblemParseException : Exception {
+    public string ProblemName { get; }
+    public string Received { get; }
+    public ProblemParseException(string problemName, string received, string? detail = null)
+        : base(detail ?? $"could not parse {problemName} instance") {
+        ProblemName = problemName;
+        Received = received;
+    }
+}
+
+// Thrown when a verifier cannot parse the supplied certificate string.
+// Controllers translate this to HTTP 400 with the problem's
+// `certificateFormat` as the structured hint. Carries the problem
+// instance (already constructed successfully) so the controller can
+// read its certificateFormat directly.
+internal class CertificateParseException : Exception {
+    public IProblem Problem { get; }
+    public string Received { get; }
+    public CertificateParseException(IProblem problem, string received, string? detail = null)
+        : base(detail ?? $"could not parse {problem.problemName} certificate") {
+        Problem = problem;
+        Received = received;
+    }
+}

--- a/Interfaces/ProblemInterface.cs
+++ b/Interfaces/ProblemInterface.cs
@@ -13,6 +13,14 @@ interface IProblem {
     string defaultInstance{get;}
     string instance{ get; }
 
+    // Format descriptors consumed by /ProblemProvider/info. Each should be a
+    // short descriptive sentence with an embedded concrete example so a
+    // caller (LLM, GUI, or human) can construct a valid instance/certificate
+    // without reading the verifier source. Defaults to "" on problems that
+    // haven't been backfilled yet.
+    string instanceFormat { get => ""; }
+    string certificateFormat { get => ""; }
+
     string[] contributors{ get; }
 
     ISolver defaultSolver {get;}

--- a/Interfaces/VerifierInterface.cs
+++ b/Interfaces/VerifierInterface.cs
@@ -15,7 +15,16 @@ interface IVerifier<T> : IVerifier where T : IProblem {
         // Should there be some sort of contraint that assures there is a constructor
         // that matches the signature of a single `string` argument?
         // Perhaps a static `FromInstance(string instance)` method for `IProblem` will work.
-        return verify((T)Activator.CreateInstance(typeof(T), problem), certificate);
+        T problemInstance;
+        try {
+            problemInstance = (T)Activator.CreateInstance(typeof(T), problem)!;
+        } catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null) {
+            // Unwrap so ProblemParseException (or any other constructor exception)
+            // surfaces with its real type to the controller layer.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable
+        }
+        return verify(problemInstance, certificate);
     }
     bool verify(T problem, string certificate);
 }

--- a/ProblemTemplate/Templates/PROBLEM_Class.txt
+++ b/ProblemTemplate/Templates/PROBLEM_Class.txt
@@ -16,6 +16,12 @@ class {NAME_UPPERCASE} : IProblem<{NAME_PASCAL_CASE}Solver, {NAME_PASCAL_CASE}Ve
     public string sourceLink {get;} = "TODO";
     private static readonly string _defaultInstance = "TODO";
     public string defaultInstance {get;} = _defaultInstance;
+    // Short descriptive sentence with a concrete example. Consumed by
+    // /ProblemProvider/info and by parse-error responses; this is the
+    // canonical place to tell an LLM (or a human, or the GUI) what
+    // shape your instance/certificate strings take.
+    public string instanceFormat {get;} = "TODO: describe the instance string format with an embedded example, e.g. 'Boolean formula in 3-CNF, clauses joined by `&`. Example: (x1 | !x2 | x3) & (!x1 | x3 | x1)'";
+    public string certificateFormat {get;} = "TODO: describe the certificate string the verifier accepts with an embedded example, e.g. '(x1:True,x2:False,x3:True) -- one variable:Boolean pair per variable, comma-separated'";
     public string instance {get;set;} = string.Empty;
     public string wikiName {get;} = "";
     public {NAME_PASCAL_CASE}Solver defaultSolver {get;} = new {NAME_PASCAL_CASE}Solver();
@@ -33,7 +39,14 @@ class {NAME_UPPERCASE} : IProblem<{NAME_PASCAL_CASE}Solver, {NAME_PASCAL_CASE}Ve
     public {NAME_UPPERCASE}(string stringInstance) {
         instance = stringInstance;
 
-
+        // On a malformed instance, throw `ProblemParseException` (see
+        // Interfaces/ParseExceptions.cs). The controller layer catches it
+        // and returns HTTP 400 with `instanceFormat` quoted back to the
+        // caller. Example:
+        //
+        //   if (string.IsNullOrWhiteSpace(stringInstance)) {
+        //       throw new ProblemParseException("{NAME}", stringInstance, "instance is empty");
+        //   }
 
         // TODO: implement parsing of string instance of {NAME}. SPADE is a class meant to help with this step, see https://github.com/Jetison333/SPADE/blob/main/Documentation/index.md for more information.
         //

--- a/ProblemTemplate/Templates/README.md
+++ b/ProblemTemplate/Templates/README.md
@@ -16,12 +16,16 @@ The PROBLEMNAME_Class.cs should implement the `IProblem` interface or one of its
 * `string sourceLink` : A link to the formal citation
 * `string wikiName` : This is deprecated, and should be removed from all problems
 * `string defaultInstance` : A reasonably sized example of the problem, and the necessary format. *If the problem is of a similar form to an existing problem, such as a directed graph, the format should match the existing problems.*
+* `string instanceFormat` : Short descriptive sentence with a concrete embedded example of the instance string the problem accepts. Consumed by `/ProblemProvider/info` and by parse-error responses, so this is the canonical place to tell an LLM, the GUI, or a human what shape your instances take. Prefer a sentence + example over a formal grammar.
+* `string certificateFormat` : Same shape as `instanceFormat`, but describes what the verifier accepts as a certificate. The default verifier defines this; if your problem has multiple verifiers, declare the format the *default* one expects here.
 * `string[] contributors` : A list of names of all developers who have worked on the problem
 * `T defaultSolver` : An object of the default solver for the problem
 * `U defaultVerifier` : An object of the default verifier for the problem
 * `V defaultVisualization` : An objet of the default visualization for the problem
 
-The PROBLEMNAME_Class.cs should also include any necessary problem variables, any functions necessary for parsing string instances into a variable, and two constructors. One constructor that takes a string instance, and one which uses the default instance. 
+The PROBLEMNAME_Class.cs should also include any necessary problem variables, any functions necessary for parsing string instances into a variable, and two constructors. One constructor that takes a string instance, and one which uses the default instance.
+
+The string-instance constructor should **throw `ProblemParseException`** (defined in `Interfaces/ParseExceptions.cs`) on malformed input rather than silently constructing a half-populated object. The controller layer catches this exception and returns HTTP 400 with `instanceFormat` quoted back to the caller, which is what lets every client — MCP wrappers, the GUI, an LLM agent — recover from a bad input by reading the structured error rather than parsing a stack trace.
 
 ### Reductions
 The Reductions folder should contain all reduction files for that problem. Each of which implements the `IReduction` interface found in ReductionInterface.cs. This includes
@@ -55,6 +59,8 @@ The Verifiers folder should contain all verifier files for that problem. Each of
 * `string[] contributors` : A list of names of all developers who have worked on the verifier
 
 The file should also include a function which takes a problem object and certificate, and returns a Boolean for if the certificate is a solution to the given problem. As well as any other necessary functions.
+
+The verifier should **throw `CertificateParseException`** (defined in `Interfaces/ParseExceptions.cs`) on malformed certificate input rather than silently returning `false`. The controller catches it and returns HTTP 400 with `problem.certificateFormat` quoted back to the caller. Return `false` only when the certificate parses successfully but fails the verification predicate.
 
 ### Visualizations
 The Visualizations folder should contain all visualizations files for that problem. Each of which implements the `IVisualization` interface found in VisualizationInterface.cs. This includes

--- a/ProblemTemplate/Templates/Verifiers/ProblemVerifier.txt
+++ b/ProblemTemplate/Templates/Verifiers/ProblemVerifier.txt
@@ -24,6 +24,19 @@ class {VERIFIER_PASCAL_CASE} : IVerifier<{PROBLEM}> {
     }
 
     public bool verify({PROBLEM} problem, string certificate){
+        // On a malformed certificate, throw `CertificateParseException`
+        // (see Interfaces/ParseExceptions.cs) rather than silently
+        // returning false. The controller layer catches it and returns
+        // HTTP 400 with `problem.certificateFormat` quoted back to the
+        // caller. Example:
+        //
+        //   if (string.IsNullOrWhiteSpace(certificate)) {
+        //       throw new CertificateParseException(problem, certificate, "certificate is empty");
+        //   }
+        //
+        // Return false only when the certificate parses successfully but
+        // fails the verification predicate; return true when it satisfies it.
+
         // TODO: implement {VERIFIER} for {PROBLEM}
         return true;
     }

--- a/Problems/NPComplete/NPC_CLIQUE/CLIQUE_Class.cs
+++ b/Problems/NPComplete/NPC_CLIQUE/CLIQUE_Class.cs
@@ -17,6 +17,8 @@ class CLIQUE : IGraphProblem<CliqueBruteForce,CliqueVerifier,CliqueDefaultVisual
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     private static string _defaultInstance = "(({1,2,3,4,5,6},{{4,1},{1,2},{4,3},{3,2},{2,4},{5,2},{3,5},{5,4},{3,6},{6,4},{1,6}}),4)"; 
     public string defaultInstance {get;} = _defaultInstance;
+    public string instanceFormat {get;} = "Graph and target clique size, shaped as ((nodes, edges), k). Nodes are a brace-delimited comma-separated list {n1,n2,...}; edges are a brace-delimited list of undirected pairs {{n1,n2},{n2,n3},...}; k is the required clique size. Example: (({1,2,3,4},{{1,2},{2,3},{3,4},{1,4}}),3)";
+    public string certificateFormat {get;} = "Comma-separated node names, optionally wrapped in braces. Must list exactly k nodes from the instance's node set, all pairwise adjacent. Example: {1,2,3,4}";
     public string instance {get;set;} = string.Empty;
     public string wikiName {get;} = "";
     private List<string> _nodes = new List<string>();
@@ -61,19 +63,26 @@ class CLIQUE : IGraphProblem<CliqueBruteForce,CliqueVerifier,CliqueDefaultVisual
     }
     public CLIQUE(string GInput)
     {
+        if (string.IsNullOrWhiteSpace(GInput)) {
+            throw new ProblemParseException("CLIQUE", GInput, "instance is empty");
+        }
+
         instance = GInput;
         StringParser cliqueGraph = new("{((N,E),K) | N is set, E subset N unorderedcross N, K is int}");
-        cliqueGraph.parse(GInput);
-        nodes = cliqueGraph["N"].ToList().Select(node => node.ToString()).ToList();
-        edges = cliqueGraph["E"].ToList().Select(edge =>
-        {
-            List<UtilCollection> cast = edge.ToList();
-            return new KeyValuePair<string, string>(cast[0].ToString(), cast[1].ToString());
-        }).ToList();
-        _K = int.Parse(cliqueGraph["K"].ToString());
+        try {
+            cliqueGraph.parse(GInput);
+            nodes = cliqueGraph["N"].ToList().Select(node => node.ToString()).ToList();
+            edges = cliqueGraph["E"].ToList().Select(edge =>
+            {
+                List<UtilCollection> cast = edge.ToList();
+                return new KeyValuePair<string, string>(cast[0].ToString(), cast[1].ToString());
+            }).ToList();
+            _K = int.Parse(cliqueGraph["K"].ToString());
 
-
-        graph = new UtilCollectionGraph(cliqueGraph["N"], cliqueGraph["E"]);
+            graph = new UtilCollectionGraph(cliqueGraph["N"], cliqueGraph["E"]);
+        } catch (Exception ex) when (ex is not ProblemParseException) {
+            throw new ProblemParseException("CLIQUE", GInput, ex.Message);
+        }
     }
 
 }

--- a/Problems/NPComplete/NPC_CLIQUE/Verifiers/CliqueVerifier.cs
+++ b/Problems/NPComplete/NPC_CLIQUE/Verifiers/CliqueVerifier.cs
@@ -31,8 +31,21 @@ class CliqueVerifier : IVerifier<CLIQUE> {
         return nodeList;
     }
     public bool verify(CLIQUE problem, string certificate){
-        
-        List<string> nodeList = parseCertificate(certificate);
+
+        if (string.IsNullOrWhiteSpace(certificate)) {
+            throw new CertificateParseException(problem, certificate, "certificate is empty");
+        }
+
+        List<string> nodeList;
+        try {
+            nodeList = parseCertificate(certificate);
+        } catch (Exception ex) {
+            throw new CertificateParseException(problem, certificate, ex.Message);
+        }
+        if (nodeList.Count == 0 || nodeList.Any(string.IsNullOrWhiteSpace)) {
+            throw new CertificateParseException(problem, certificate,
+                "certificate did not parse to a non-empty list of node names");
+        }
         //Check k value
         if(nodeList.Count != problem.K){
             return false;

--- a/Problems/NPComplete/NPC_SAT3/SAT3_Class.cs
+++ b/Problems/NPComplete/NPC_SAT3/SAT3_Class.cs
@@ -15,6 +15,8 @@ class SAT3 : IProblem<Sat3BacktrackingSolver,SAT3Verifier,Sat3DefaultVisualizati
     public string source {get;} = "Karp, Richard M. Reducibility among combinatorial problems. Complexity of computer computations. Springer, Boston, MA, 1972. 85-103.";
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string defaultInstance {get;} = "(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | !x1)";
+    public string instanceFormat {get;} = "Boolean formula in 3-CNF. Clauses joined by '&', literals within a clause joined by '|', negation prefix '!'. Each clause has at most 3 literals. Example: (x1 | !x2 | x3) & (!x1 | x3 | x1)";
+    public string certificateFormat {get;} = "Comma-separated variable:Boolean pairs, optionally wrapped in parentheses. Booleans must be capitalized True/False (T/F also accepted); ':' or '=' may be used as the separator. List every variable you are assigning. Example: (x1:True,x2:False,x3:True)";
     public Sat3BacktrackingSolver defaultSolver {get;} = new Sat3BacktrackingSolver();
     public SAT3Verifier defaultVerifier {get;} = new SAT3Verifier();
     public Sat3DefaultVisualization defaultVisualization { get; } = new Sat3DefaultVisualization();
@@ -51,11 +53,34 @@ class SAT3 : IProblem<Sat3BacktrackingSolver,SAT3Verifier,Sat3DefaultVisualizati
     }
     public SAT3(string phiInput) {
 
-        // TODO Validate there are only a maximum of 3 literals in each clause
+        validateInstance(phiInput);
 
         instance = phiInput;
         clauses = getClauses(instance);
         literals = getLiterals(instance);
+    }
+
+    private static void validateInstance(string phiInput) {
+        if (string.IsNullOrWhiteSpace(phiInput)) {
+            throw new ProblemParseException("3SAT", phiInput, "instance is empty");
+        }
+
+        string stripped = phiInput.Replace(" ", "").Replace("(", "").Replace(")", "");
+        string[] rawClauses = stripped.Split('&');
+        foreach (string clause in rawClauses) {
+            string[] rawLiterals = clause.Split('|');
+            if (rawLiterals.Length < 1 || rawLiterals.Length > 3) {
+                throw new ProblemParseException("3SAT", phiInput,
+                    $"clause '{clause}' has {rawLiterals.Length} literals; 3-CNF allows 1-3");
+            }
+            foreach (string literal in rawLiterals) {
+                string name = literal.StartsWith("!") ? literal.Substring(1) : literal;
+                if (string.IsNullOrEmpty(name) || !char.IsLetter(name[0])) {
+                    throw new ProblemParseException("3SAT", phiInput,
+                        $"literal '{literal}' is not a valid identifier (optionally prefixed with '!')");
+                }
+            }
+        }
     }
 
     public List<List<string>> getClauses(string phiInput) {

--- a/Problems/NPComplete/NPC_SAT3/Verifiers/SAT3Verifier.cs
+++ b/Problems/NPComplete/NPC_SAT3/Verifiers/SAT3Verifier.cs
@@ -35,6 +35,10 @@ class SAT3Verifier : IVerifier<SAT3> {
     // ONLY true literal names should be included in the user input seperated by commas
     public bool verify(SAT3 problem, string certificate) {
 
+        if (string.IsNullOrWhiteSpace(certificate)) {
+            throw new CertificateParseException(problem, certificate, "certificate is empty");
+        }
+
         // User input is effectively asking for the list of variables assigned to "True"
         List<List<string>> clauses = problem.clauses;
         string strippedInput = certificate.Replace(" ", "").Replace("(", "").Replace(")","");
@@ -49,6 +53,10 @@ class SAT3Verifier : IVerifier<SAT3> {
             if (assignmentParts.Length <= 1){
                 assignmentParts = assignment.Split('=');
             }
+            if (assignmentParts.Length < 2) {
+                throw new CertificateParseException(problem, certificate,
+                    $"assignment '{assignment}' is missing a ':' or '=' separator");
+            }
             string literalName = assignmentParts[0];
             string TF = assignmentParts[1];
 
@@ -56,8 +64,12 @@ class SAT3Verifier : IVerifier<SAT3> {
                 trueLiterals.Add(literalName);
             }
             else if (TF == "False" | TF == "F") {
-                string inverseLiteralName = "!" + literalName; 
+                string inverseLiteralName = "!" + literalName;
                 trueLiterals.Add(inverseLiteralName);
+            }
+            else {
+                throw new CertificateParseException(problem, certificate,
+                    $"assignment '{assignment}' has value '{TF}'; expected True/False (capitalized) or T/F");
             }
         }
 


### PR DESCRIPTION
Adds two new fields to IProblem and turns parse failures on /verify and /problemInstance into structured 400 responses that quote the expected format back to the caller.

New fields on IProblem (default-implemented as "" so existing problems compile unchanged):

  - string instanceFormat — a short descriptive sentence with an embedded concrete example of the instance string the problem expects
  - string certificateFormat — same shape, but describes what the verifier accepts as a certificate

Populated on SAT3 and CLIQUE as a pilot. Other problems return empty strings until backfilled.

Two new exception types in Interfaces/ParseExceptions.cs:

  - ProblemParseException — thrown by a problem's instance constructor on malformed input. Carries the offending string.
  - CertificateParseException — thrown by a verifier on malformed certificate input. Carries the IProblem instance so the controller can read its certificateFormat.

SAT3 and CLIQUE constructors throw ProblemParseException on shape errors instead of silently constructing a half-populated problem object. SAT3Verifier and CliqueVerifier throw CertificateParseException instead of silently dropping malformed assignments (previously, lowercase 'true'/'false' in a SAT3 certificate would parse to an empty true-literal list and the verifier would just return false — no diagnostic).

IVerifier<T>.verify default impl unwraps TargetInvocationException from Activator.CreateInstance so a ProblemParseException thrown from T(string) surfaces with its real type to the controller layer.

POST /ProblemProvider/verify and POST /ProblemProvider/problemInstance now return IActionResult. On parse failure they return HTTP 400 with body:

  { "error":    "instance_parse_error" | "certificate_parse_error",
    "problem":  "<problem name>",
    "expected": "<instanceFormat or certificateFormat verbatim>",
    "received": "<the offending input>",
    "detail":   "<specific reason>" }

The "expected" field is the same string exposed by /ProblemProvider/info on instanceFormat/certificateFormat — single source of truth for the format hint. Success responses are unchanged (same JSON-string body, HTTP 200).

Verified live: the canonical SAT3 gut-check certificate "x1=true,x2=true,x3=false,x4=true" now returns 400 with the SAT3 certificateFormat in expected and "assignment 'x1=true' has value 'true'; expected True/False (capitalized) or T/F" in detail.

Backfilling the remaining ~41 problems and extending the validate-and-throw pattern to their verifiers is a natural follow-up.