### PR TITLE
SAT3: shadowed depth/totalVars hides optimal traversal

### DIFF
--- a/Problems/NPComplete/NPC_SAT3/SAT3PQObject.cs
+++ b/Problems/NPComplete/NPC_SAT3/SAT3PQObject.cs
@@ -11,12 +11,15 @@ class SAT3PQObject{
 
     public SAT3PQObject(SAT3 inSAT3, int newDepth, int totalVariables){
         SATState = inSAT3;
-        string nextVar = string.Empty;
-        int depth = newDepth;
-        int totalVars = totalVariables;
+        depth = newDepth;
+        totalVars = totalVariables;
         varWeights = new Dictionary<string, int>();
         varStates = new Dictionary<string, bool>();
-        initNextVar();
+
+        //gets the next variable for evaluation and removes the variable from the literals
+        string newVar = getVarFromLiteral(SATState.literals[0]);
+        SATState.literals.RemoveAt(0);
+        nextVar = newVar;
     }
 
     //gets the variable witht he highest occurance
@@ -198,14 +201,6 @@ class SAT3PQObject{
         // Console.WriteLine("weights initialized");
         //sets the variable weights to the newly created dictionary with their count
         setVarWeights(numbVars);
-    }
-
-    //gets the next variable for evaluation and removes the variable from the literals
-    private void initNextVar(){
-        string newVar = getVarFromLiteral(SATState.literals[0]);
-        SATState.literals.RemoveAt(0);
-        // Console.WriteLine("newVar is : " + newVar);
-        this.nextVar = newVar;
     }
 
     //returns the literal without the !


### PR DESCRIPTION
the depth and totalVars variables were shadowed resulting in uninitialized variables in the construtor. While I was here, I also fixed a warning about nextVar needed to be non-null by the end of the constructor.

The solver for SAT3 worked, but only because it exhausted the space, not because it took any shortcuts.