### PR TITLE
remove unused variables _startState & _acceptStates in API_GraphJSON

### DIFF
--- a/Interfaces/JSON_Objects/Graphs/API_GraphJSON.cs
+++ b/Interfaces/JSON_Objects/Graphs/API_GraphJSON.cs
@@ -9,11 +9,6 @@ class API_GraphJSON : API_JSON
     public List<API_Node_Programmable_Small> _nodes;
     public List<API_Link> _links;
 
-    // Added Start and Accept States Elements -- Michael Trosper -- 1/20/2026 //
-    // Modified the Node Class To Include Initial and Accept State Information -- Andrija Sevaljevic -- 4/16/2026 //
-    public API_Node_Programmable_Automata _startState;
-    public List<API_Node_Programmable_Automata> _acceptStates;
-
     public API_GraphJSON()
     {
         this._nodes = new List<API_Node_Programmable_Small>();


### PR DESCRIPTION
These two variables are unused in the graph code as far as I can tell and it fixes two more warnings.