### PR TITLE
suppress CS1591 in remaining test files missing the pragma

### DIFF
--- a/redux-tests/Problems/NPC_GRAPHCOLORING/GRAPHCOLORING_Tests.cs
+++ b/redux-tests/Problems/NPC_GRAPHCOLORING/GRAPHCOLORING_Tests.cs
@@ -2,6 +2,7 @@
 // Saurav Bhusal and Pramesh Shah
 // sauravbhusal@isu.edu, prameshshah@isu.edu
 
+#pragma warning disable CS1591
 using Xunit;
 using API.Problems.NPComplete.NPC_GRAPHCOLORING;
 using API.Problems.NPComplete.NPC_GRAPHCOLORING.Solvers;

--- a/redux-tests/Problems/NPC_LOSSLESSDATACOMPRESSION/LOSSLESSDATACOMPRESSION_Tests.cs
+++ b/redux-tests/Problems/NPC_LOSSLESSDATACOMPRESSION/LOSSLESSDATACOMPRESSION_Tests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿#pragma warning disable CS1591
+using Xunit;
 using API.Problems.NPComplete.NPC_LOSSLESSDATACOMPRESSION;
 
 namespace redux_tests;

--- a/redux-tests/Problems/P_STRONGLYCONNECTEDCOMPONENTS/P_STRONGLYCONNECTEDCOMPONENTS_Tests.cs
+++ b/redux-tests/Problems/P_STRONGLYCONNECTEDCOMPONENTS/P_STRONGLYCONNECTEDCOMPONENTS_Tests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1591
 using Xunit;
 using API.Problems.NPComplete.NPC_STRONGLYCONNECTEDCOMPONENTS;
 using API.Problems.NPComplete.NPC_STRONGLYCONNECTEDCOMPONENTS.Solvers;


### PR DESCRIPTION
Three test files were missing `#pragma warning disable CS1591` that every other test file already has:

- `redux-tests/Problems/NPC_GRAPHCOLORING/GRAPHCOLORING_Tests.cs`
- `redux-tests/Problems/NPC_LOSSLESSDATACOMPRESSION/LOSSLESSDATACOMPRESSION_Tests.cs`
- `redux-tests/Problems/P_STRONGLYCONNECTEDCOMPONENTS/P_STRONGLYCONNECTEDCOMPONENTS_Tests.cs`

xUnit test methods don't need public API documentation. This eliminates 24 CS1591 warnings and brings these files in line with the other 24 test files in the suite.

No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)