### PR TITLE
Add missing XML doc comments to QuantumSolverSettings (CS1591)

### DIFF
--- a/QuantumSolverSettings.cs
+++ b/QuantumSolverSettings.cs
@@ -6,9 +6,11 @@ using Microsoft.AspNetCore.Authentication;
 /// </summary>
 public static class QuantumSolverSettingsGlobal
 {
+    /// <summary>Global Quantum Solver configuration instance, populated at startup.</summary>
     public static QuantumSolverSettings QuantumSolver { get; internal set; } = null!;
 }
 
+/// <summary>Configuration settings for the Quantum Solver service.</summary>
 public class QuantumSolverSettings
 {
     /// <summary>


### PR DESCRIPTION
## Summary

- `QuantumSolverSettings` class and `QuantumSolverSettingsGlobal.QuantumSolver` property were missing `<summary>` tags.
- Adds two one-line XML doc comments to clear both CS1591 warnings. No logic changes.
