### PR TITLE
Replace dead _complexity backing field with nullable auto-property (CS0414)

### DIFF
--- a/ProblemTemplate/Templates/ReduceTo/NPC_PROBLEM/Reduction.txt
+++ b/ProblemTemplate/Templates/ReduceTo/NPC_PROBLEM/Reduction.txt
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Interfaces.JSON_Objects;
 using API.Problems.NPComplete.NPC_{REDUCE_TO};
@@ -12,6 +13,8 @@ class {REDUCTION_PASCAL_CASE} : IReduction<{REDUCE_FROM}, {REDUCE_TO}> {
     public string source {get;} = "TODO";
     public string sourceLink {get;} = "TODO";
     public string[] contributors {get;} = { "TODO" };
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
 
     private {REDUCE_FROM} _reductionFrom;
     private {REDUCE_TO} _reductionTo;

--- a/ProblemTemplate/Templates/Solvers/ProblemSolver.txt
+++ b/ProblemTemplate/Templates/Solvers/ProblemSolver.txt
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 
 namespace API.Problems.NPComplete.NPC_{PROBLEM}.Solvers;
@@ -8,6 +9,8 @@ class {SOLVER_PASCAL_CASE} : ISolver<{PROBLEM}> {
     public string solverDefinition {get;} = "TODO";
     public string source {get;} = "TODO";
     public string[] contributors {get;} = { "TODO" };
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     public bool timerHasExpired { get; set; }
 
     // --- Methods Including Constructors ---

--- a/ProblemTemplate/Templates/Verifiers/ProblemVerifier.txt
+++ b/ProblemTemplate/Templates/Verifiers/ProblemVerifier.txt
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 
 namespace API.Problems.NPComplete.NPC_{PROBLEM}.Verifiers;
@@ -10,6 +11,8 @@ class {VERIFIER_PASCAL_CASE} : IVerifier<{PROBLEM}> {
     public string source {get;} = " ";
     public string sourceLink {get;} = "TODO";
     public string[] contributors {get;} = { "TODO" };
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     private string _certificate =  "";
 
     public string certificate {

--- a/Problems/NPComplete/NPC_CLIQUE/ReduceTo/NPC_VertexCover/sipserReductionVertexCover.cs
+++ b/Problems/NPComplete/NPC_CLIQUE/ReduceTo/NPC_VertexCover/sipserReductionVertexCover.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Interfaces.Graphs.GraphParser;
 using API.Interfaces.JSON_Objects;
@@ -20,7 +21,8 @@ class sipserReductionVertexCover : IReduction<CLIQUE, VERTEXCOVER> {
     public List<Gadget> gadgets { get; }
     private CLIQUE _reductionFrom;
     private VERTEXCOVER _reductionTo;
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
 
     public CLIQUE reductionFrom {
         get {

--- a/Problems/NPComplete/NPC_EXACTCOVER/ReduceTo/NPC_SUBSETSUM/KarpExactCoverToSubsetSum.cs
+++ b/Problems/NPComplete/NPC_EXACTCOVER/ReduceTo/NPC_SUBSETSUM/KarpExactCoverToSubsetSum.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Problems.NPComplete.NPC_EXACTCOVER;
 using API.Problems.NPComplete.NPC_SUBSETSUM;
@@ -14,7 +15,8 @@ class KarpExactCoverToSubsetSum : IReduction<EXACTCOVER, SUBSETSUM>
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors {get;} = { "Andrija Sevaljevic" };
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     private Dictionary<Object, Object> _gadgetMap = new Dictionary<Object, Object>();
 
     private EXACTCOVER _reductionFrom;

--- a/Problems/NPComplete/NPC_GRAPHCOLORING/ReduceTo/NPC_CLIQUECOVER/GraphColoringToCliqueCover.cs
+++ b/Problems/NPComplete/NPC_GRAPHCOLORING/ReduceTo/NPC_CLIQUECOVER/GraphColoringToCliqueCover.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Interfaces.JSON_Objects;
 using API.Problems.NPComplete.NPC_CLIQUECOVER;
@@ -15,7 +16,8 @@ class GraphColoringToCliqueCover : IReduction<GRAPHCOLORING, CLIQUECOVER>
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors {get;} = { "Andrija Sevaljevic" };
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     public List<Gadget> gadgets { get; }
     private GRAPHCOLORING _reductionFrom;
     private CLIQUECOVER _reductionTo;

--- a/Problems/NPComplete/NPC_GRAPHCOLORING/ReduceTo/NPC_EXACTCOVER/KarpGraphColorToExactCover.cs
+++ b/Problems/NPComplete/NPC_GRAPHCOLORING/ReduceTo/NPC_EXACTCOVER/KarpGraphColorToExactCover.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Problems.NPComplete.NPC_GRAPHCOLORING;
 using API.Problems.NPComplete.NPC_EXACTCOVER;
@@ -14,7 +15,8 @@ class KarpGraphColorToExactCover : IReduction<GRAPHCOLORING, EXACTCOVER>
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors {get;} = { "Andrija Sevaljevic" };
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     private Dictionary<Object, Object> _gadgetMap = new Dictionary<Object, Object>();
 
     private GRAPHCOLORING _reductionFrom;

--- a/Problems/NPComplete/NPC_HITTINGSET/ReduceTo/NPC_EXACTCOVER/reduceToEXACTCOVER.cs
+++ b/Problems/NPComplete/NPC_HITTINGSET/ReduceTo/NPC_EXACTCOVER/reduceToEXACTCOVER.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Problems.NPComplete.NPC_EXACTCOVER;
 using SPADE;
@@ -16,7 +17,8 @@ class reduceToEXACTCOVER : IReduction<HITTINGSET, EXACTCOVER>
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors { get; } = { "Russell Phillip" };
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
 
 
     private HITTINGSET _reductionFrom;

--- a/Problems/NPComplete/NPC_INDEPENDENTSET/ReduceTo/NPC_CLIQUE/reduceToCLIQUE.cs
+++ b/Problems/NPComplete/NPC_INDEPENDENTSET/ReduceTo/NPC_CLIQUE/reduceToCLIQUE.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Interfaces.Graphs;
 using API.Interfaces.Graphs.GraphParser;
@@ -24,7 +25,8 @@ class reduceToCLIQUE : IReduction<INDEPENDENTSET, CLIQUE> {
     private INDEPENDENTSET _reductionFrom;
     private CLIQUE _reductionTo;
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
 
 
     // --- Properties ---

--- a/Problems/NPComplete/NPC_PARTITION/ReduceTo/NPC_WEIGHTEDCUT/WEIGHTEDCUTReduction.cs
+++ b/Problems/NPComplete/NPC_PARTITION/ReduceTo/NPC_WEIGHTEDCUT/WEIGHTEDCUTReduction.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Problems.NPComplete.NPC_WEIGHTEDCUT;
 
@@ -13,7 +14,8 @@ class WEIGHTEDCUTReduction : IReduction<PARTITION, WEIGHTEDCUT>
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors { get; } = { "Andrija Sevaljevic" };
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     private Dictionary<Object, Object> _gadgetMap = new Dictionary<Object, Object>();
 
     private PARTITION _reductionFrom;

--- a/Problems/NPComplete/NPC_SAT/ReduceTo/NPC_SAT3/KarpSATToSAT3.cs
+++ b/Problems/NPComplete/NPC_SAT/ReduceTo/NPC_SAT3/KarpSATToSAT3.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Problems.NPComplete.NPC_SAT;
 using API.Problems.NPComplete.NPC_SAT3;
@@ -15,7 +16,8 @@ class KarpSATToSAT3 : IReduction<SAT, SAT3>
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors { get; } = { "Andrija Sevaljevic" };
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     public List<Gadget> gadgets { get; }
     private SAT _reductionFrom;
     private SAT3 _reductionTo;

--- a/Problems/NPComplete/NPC_SUBSETSUM/ReduceTo/NPC_PARTITION/SubsetSumToPartitionReduction.cs
+++ b/Problems/NPComplete/NPC_SUBSETSUM/ReduceTo/NPC_PARTITION/SubsetSumToPartitionReduction.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Problems.NPComplete.NPC_PARTITION;
 
@@ -12,7 +13,8 @@ class SubsetSumToPartitionReduction : IReduction<SUBSETSUM, PARTITION> {
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors {get;} = {"Andrija Sevaljevic"};
   
-    private string _complexity ="";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     private Dictionary<Object,Object> _gadgetMap = new Dictionary<Object,Object>();
 
     private SUBSETSUM _reductionFrom;

--- a/Problems/NPComplete/NPC_VERTEXCOVER/ReduceTo/NPC_NODESET/KarpVertexCoverToNodeSet.cs
+++ b/Problems/NPComplete/NPC_VERTEXCOVER/ReduceTo/NPC_NODESET/KarpVertexCoverToNodeSet.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Interfaces.JSON_Objects;
 using API.Problems.NPComplete.NPC_NODESET;
@@ -15,7 +16,8 @@ class KarpVertexCoverToNodeSet : IReduction<VERTEXCOVER, NODESET>
     public string source {get;} = "This reduction was found by the Algorithms Seminar at the Cornell University Computer Science Department. Karp, Richard M. Reducibility among combinatorial problems. Complexity of computer computations. Springer, Boston, MA, 1972. 85-103.";
     public string[] contributors {get;} = { "Andrija Sevaljevic" };
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
     public List<Gadget> gadgets { get; }
     private VERTEXCOVER _reductionFrom;
     private NODESET _reductionTo;

--- a/Problems/NPComplete/NPC_VERTEXCOVER/Verifiers/VCVerifier.cs
+++ b/Problems/NPComplete/NPC_VERTEXCOVER/Verifiers/VCVerifier.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using API.Interfaces;
 using API.Interfaces.Graphs.GraphParser;
 
@@ -11,7 +12,8 @@ class VCVerifier : IVerifier<VERTEXCOVER> {
     public string source {get;} = "";
     public string[] contributors {get;} = { "Janita Aamir","Alex Diviney"};
 
-    private string _complexity = "";
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? complexity { get; set; } = null;
 
     private string _certificate = "";
 


### PR DESCRIPTION
## Summary

Ten reduction/verifier classes declared \`private string _complexity = ""\` but never wired up a public \`complexity\` property, causing two problems:
- **CS0414** build warnings (field assigned, value never read)
- **Silent omission** of \`complexity\` from API responses, even though other classes expose it

Replaced with a nullable auto-property decorated with \`[JsonIgnore]\` in all affected classes:

\`\`\`csharp
[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
public string? complexity { get; set; } = null;
\`\`\`

\`null\` is an explicit "not specified" sentinel. The \`[JsonIgnore]\` attribute means the field is **omitted from the JSON response** when null, keeping the API surface clean until a real value is provided. Also adds the property to the **Reduction**, **Solver**, and **Verifier** scaffolding templates so new classes get it by default.

## Test plan
- [ ] \`dotnet build\` produces no CS0414 warnings in the affected files
- [ ] \`/reduce\` responses for affected reductions omit the \`complexity\` field entirely (not present, not null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)