### PR TITLE
upgrade CI actions to Node.js 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from v4 → v6
- Bumps `actions/setup-dotnet` from v4 → v5

Both v4 actions run on Node.js 20, which is deprecated on GitHub Actions runners and will be forcibly removed on September 16, 2026 (forced default June 16, 2026).

## Test plan

- [ ] Confirm the PR CI run completes without the Node.js 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)