### PR TITLE
fix SAT3 solver crash when all clauses satisfied in one step

### DIFF
--- a/Problems/NPComplete/NPC_SAT3/SAT3PQObject.cs
+++ b/Problems/NPComplete/NPC_SAT3/SAT3PQObject.cs
@@ -142,8 +142,18 @@ class SAT3PQObject{
         //update dictionary
         // this.varStates.Add(this.nextVar, boolValue);
         if(isValid){
-            //create new object
-            SAT3PQObject newSATObj = new SAT3PQObject(new SAT3(newPhiExpression), depth + 1, totalNumberOfVariables);
+            SAT3PQObject newSATObj;
+            if(newPhiExpression == "()"){
+                // All clauses were satisfied by assigning nextVar = boolValue.
+                // new SAT3("()") is rejected by validateInstance (empty literal), so build
+                // the solved-sentinel state directly: clauses = [[""]] is what
+                // evaluateBooleanExpression checks to return 1 (satisfied).
+                SAT3 doneSAT = new SAT3();
+                doneSAT.clauses = new List<List<string>> { new List<string> { "" } };
+                newSATObj = new SAT3PQObject(doneSAT, depth + 1, totalNumberOfVariables);
+            } else {
+                newSATObj = new SAT3PQObject(new SAT3(newPhiExpression), depth + 1, totalNumberOfVariables);
+            }
             newSATObj.setVarStates(this.varStates);
             newSATObj.setVarWeights(this.varWeights);
             //adds the new state to the objects state of vars


### PR DESCRIPTION
## Problem

`validateInstance` (added in #217) correctly rejects malformed literals, but `createNewSatState` in `SAT3PQObject` was using `new SAT3("()")` as an internal sentinel for "all clauses satisfied by this assignment." After stripping parens, `"()"` becomes an empty string, which `validateInstance` rejects as an invalid literal — causing a `ProblemParseException` in the middle of the backtracking solver.

## Fix

Detect `newPhiExpression == "()"` before calling `new SAT3()` and build the solved-sentinel state directly: `clauses = [[""]]`, which `evaluateBooleanExpression` already checks for to return `1` (satisfied). No changes to the solver logic or the validator.

## Test plan

- [x] `dotnet test` — 393/393 passing (was 8 SAT3 failures before this fix)
- [x] All 24 SAT3-specific tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)