### PR TITLE
BernsteinVazirani: use SPADE to parse/produce certificates; add parse validation

### DIFF
--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Class.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Class.cs
@@ -75,22 +75,32 @@ class BERNSTEINVAZIRANI : IProblem<BernsteinVaziraniClassicalSolver, BernsteinVa
         instance = input;
 
         StringParser parser = new(InstanceGrammar);
-        parser.parse(instance);
+        try {
+            parser.parse(instance);
+        } catch (Exception ex) {
+            throw new ProblemParseException(problemName, input, ex.Message);
+        }
 
         UtilCollection bitslist = parser["f"];
 
         var fvalues = new List<bool>();
-        bitslist.ToList().ForEach(x => {
-            if (x.ToString() == "0") {
+        foreach (UtilCollection x in bitslist) {
+            string bitStr = x.ToString();
+            if (bitStr == "0")
                 fvalues.Add(false);
-            } else if (x.ToString() == "1") {
+            else if (bitStr == "1")
                 fvalues.Add(true);
-            } else {
-                Console.WriteLine($"{this.GetType().Name}:{MethodBase.GetCurrentMethod()?.Name}: encountered non-bit value {x.ToString()} in function values list");
-            }
-        });
+            else
+                throw new ProblemParseException(problemName, input,
+                    $"'{bitStr}' is not a valid bit; expected 0 or 1");
+        }
 
-        nbits = PowerOfTwo(fvalues.Count);
+        try {
+            nbits = PowerOfTwo(fvalues.Count);
+        } catch (ArithmeticException) {
+            throw new ProblemParseException(problemName, input,
+                $"function table must have a power-of-2 number of entries; got {fvalues.Count}");
+        }
         funcValues = fvalues;
     }
 }

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Class.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Class.cs
@@ -19,6 +19,8 @@ class BERNSTEINVAZIRANI : IProblem<BernsteinVaziraniClassicalSolver, BernsteinVa
     private static readonly string _defaultInstance = "(0,1,0,1,1,0,1,0)";
     public string defaultInstance {get;} = _defaultInstance;
     public string instance {get;set;} = string.Empty;
+    public string certificateFormat {get;} =
+        $"Format: {BernsteinVaziraniClassicalVerifier.CertificateGrammar} Example: {BernsteinVaziraniClassicalVerifier.CertificateExample}";
     public string wikiName {get;} = ""; // Wiki name or link? - not used yet
     public BernsteinVaziraniClassicalSolver defaultSolver {get;} = new BernsteinVaziraniClassicalSolver();
     public BernsteinVaziraniClassicalVerifier defaultVerifier { get; } = new BernsteinVaziraniClassicalVerifier();

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Class.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Class.cs
@@ -16,9 +16,11 @@ class BERNSTEINVAZIRANI : IProblem<BernsteinVaziraniClassicalSolver, BernsteinVa
     public string problemDefinition { get; } = "The Bernstein-Vazirani problem asks for the identification of an unknown bit string s that defines a linear Boolean function f(x)= s*x (mod 2). The task is to determine the hidden string s using as few queries as possible";
     public string source { get; } = "Bernstein, Ethan, and Umesh, Vazirani. Quantum complexity theory. Proceedings of the twenty-fifth annual ACM symposium on Theory of computing. 1993.";
     public string sourceLink { get; } = "https://dl.acm.org/doi/pdf/10.1145/167088.167097";
+    public const string InstanceGrammar = "{f | f is list}";
     private static readonly string _defaultInstance = "(0,1,0,1,1,0,1,0)";
     public string defaultInstance {get;} = _defaultInstance;
     public string instance {get;set;} = string.Empty;
+    public string instanceFormat {get;} = $"Format: {InstanceGrammar} Example: {_defaultInstance}";
     public string certificateFormat {get;} =
         $"Format: {BernsteinVaziraniClassicalVerifier.CertificateGrammar} Example: {BernsteinVaziraniClassicalVerifier.CertificateExample}";
     public string wikiName {get;} = ""; // Wiki name or link? - not used yet
@@ -72,7 +74,7 @@ class BERNSTEINVAZIRANI : IProblem<BernsteinVaziraniClassicalSolver, BernsteinVa
     public BERNSTEINVAZIRANI(string input) {
         instance = input;
 
-        StringParser parser = new("{f | f is list}");
+        StringParser parser = new(InstanceGrammar);
         parser.parse(instance);
 
         UtilCollection bitslist = parser["f"];

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniClassicalSolver.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniClassicalSolver.cs
@@ -14,10 +14,10 @@ class BernsteinVaziraniClassicalSolver : ISolver<BERNSTEINVAZIRANI> {
     public BernsteinVaziraniClassicalSolver() {}
 
     public string solve(BERNSTEINVAZIRANI problem) {
-        string result = "";
+        var bits = new List<string>();
         for (int i = problem.NBits - 1; i >= 0; i--) {
-            result += problem.Func(1 << i) ? "1" : "0";
+            bits.Add(problem.Func(1 << i) ? "1" : "0");
         }
-        return result;
+        return "(" + string.Join(",", bits) + ")";
     }
 }

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniClassicalSolver.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniClassicalSolver.cs
@@ -1,4 +1,5 @@
 using API.Interfaces;
+using SPADE;
 
 namespace API.Problems.NPComplete.NPC_BERNSTEINVAZIRANI.Solvers;
 class BernsteinVaziraniClassicalSolver : ISolver<BERNSTEINVAZIRANI> {
@@ -14,10 +15,9 @@ class BernsteinVaziraniClassicalSolver : ISolver<BERNSTEINVAZIRANI> {
     public BernsteinVaziraniClassicalSolver() {}
 
     public string solve(BERNSTEINVAZIRANI problem) {
-        var bits = new List<string>();
-        for (int i = problem.NBits - 1; i >= 0; i--) {
-            bits.Add(problem.Func(1 << i) ? "1" : "0");
-        }
-        return "(" + string.Join(",", bits) + ")";
+        UtilCollection result = new("()");
+        for (int i = problem.NBits - 1; i >= 0; i--)
+            result.Add(new UtilCollection(problem.Func(1 << i) ? "1" : "0"));
+        return result.ToString();
     }
 }

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniQuantumSolver.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniQuantumSolver.cs
@@ -1,5 +1,6 @@
 using API.Interfaces;
 using API.Tools;
+using SPADE;
 using System.Text.Json;
 
 namespace API.Problems.NPComplete.NPC_BERNSTEINVAZIRANI.Solvers;
@@ -49,7 +50,10 @@ class BernsteinVaziraniQuantumSolver : ISolver<BERNSTEINVAZIRANI> {
             {
                 string answer = answerElement.GetString() ?? "No answer found";
                 // Quantum server returns a bare bit string ("101"); translate to certificate format
-                return "(" + string.Join(",", answer) + ")";
+                UtilCollection result = new("()");
+                foreach (char c in answer)
+                    result.Add(new UtilCollection(c.ToString()));
+                return result.ToString();
             }
 
             // If no answer field, return the whole response

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniQuantumSolver.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Solvers/BernsteinVaziraniQuantumSolver.cs
@@ -47,7 +47,9 @@ class BernsteinVaziraniQuantumSolver : ISolver<BERNSTEINVAZIRANI> {
 
             if (root.TryGetProperty("answer", out JsonElement answerElement))
             {
-                return answerElement.GetString() ?? "No answer found";
+                string answer = answerElement.GetString() ?? "No answer found";
+                // Quantum server returns a bare bit string ("101"); translate to certificate format
+                return "(" + string.Join(",", answer) + ")";
             }
 
             // If no answer field, return the whole response

--- a/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Verifiers/BernsteinVaziraniClassicalVerifier.cs
+++ b/Problems/NPComplete/NPC_BERNSTEINVAZIRANI/Verifiers/BernsteinVaziraniClassicalVerifier.cs
@@ -1,8 +1,12 @@
 using API.Interfaces;
+using SPADE;
 
 namespace API.Problems.NPComplete.NPC_BERNSTEINVAZIRANI.Verifiers;
 
 class BernsteinVaziraniClassicalVerifier : IVerifier<BERNSTEINVAZIRANI> {
+
+    public const string CertificateGrammar = "{f | f is list}";
+    public const string CertificateExample = "(1,0,1)";
 
     // --- Fields ---
     public string verifierName {get;} = "Bernstein Vazirani Classical Verifier";
@@ -19,14 +23,12 @@ class BernsteinVaziraniClassicalVerifier : IVerifier<BERNSTEINVAZIRANI> {
 
     // --- Methods Including Constructors ---
     public BernsteinVaziraniClassicalVerifier() {
-        
+
     }
 
     /// <summary>
     /// Count the number of bits set to 1 in an integer
     /// </summary>
-    /// <param name="value"></param>
-    /// <returns>The numver of bits that are 1 in value</returns>
     private static int CountBits(int value) {
         int count = 0;
         while (value != 0) {
@@ -35,18 +37,32 @@ class BernsteinVaziraniClassicalVerifier : IVerifier<BERNSTEINVAZIRANI> {
         }
         return count;
     }
-    public bool verify(BERNSTEINVAZIRANI problem, string certificate){
-        int certInt = Convert.ToInt32(certificate, 2);
+
+    public bool verify(BERNSTEINVAZIRANI problem, string certificate) {
+        StringParser parser = new(CertificateGrammar);
+        try {
+            parser.parse(certificate);
+        } catch (Exception ex) {
+            throw new CertificateParseException(problem, certificate, ex.Message);
+        }
+
+        UtilCollection bits = parser["f"];
+        int certInt = 0;
+        foreach (UtilCollection bit in bits) {
+            string bitStr = bit.ToString();
+            if (bitStr != "0" && bitStr != "1")
+                throw new CertificateParseException(problem, certificate,
+                    $"'{bitStr}' is not a valid bit; expected 0 or 1");
+            certInt = (certInt << 1) | (bitStr == "1" ? 1 : 0);
+        }
+
+        if (bits.ToList().Count != problem.NBits)
+            throw new CertificateParseException(problem, certificate,
+                $"certificate has {bits.ToList().Count} bits but problem requires {problem.NBits}");
 
         for (int x = 0; x < (1 << problem.NBits); x++) {
-
-            // Compute s · x
             int dotProduct = CountBits(certInt & x) % 2;
-            bool actual = (dotProduct == 1);
-
-            bool expected = problem.Func(x);
-
-            if (expected != actual)
+            if (problem.Func(x) != (dotProduct == 1))
                 return false;
         }
         return true;

--- a/redux-tests/Problems/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Tests.cs
+++ b/redux-tests/Problems/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Tests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using API.Interfaces;
 using API.Problems.NPComplete.NPC_BERNSTEINVAZIRANI;
 using API.Problems.NPComplete.NPC_BERNSTEINVAZIRANI.Verifiers;
 
@@ -31,6 +32,23 @@ public class BERNSTEINVAZIRANI_tests {
         bool result = verifier.verify(problem, certificate);
         Assert.Equal(expected, result);
 
+    }
+
+    // -------------------------------------------------------------------------
+    // Verifier — invalid certificates (all must throw CertificateParseException)
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("101")]         // old bare-string format — SPADE parse failure
+    [InlineData("")]            // empty — SPADE parse failure
+    [InlineData("(2,0,1)")]    // invalid bit value
+    [InlineData("(x,0,1)")]    // non-numeric value
+    [InlineData("(1,0)")]      // too few bits for a 3-bit problem
+    [InlineData("(1,0,1,0)")] // too many bits for a 3-bit problem
+    public void BERNSTEINVAZIRANI_Verifier_Throws_On_Invalid_Certificate(string certificate) {
+        var problem = new BERNSTEINVAZIRANI("(0,1,0,1,1,0,1,0)");
+        var verifier = new BernsteinVaziraniClassicalVerifier();
+        Assert.Throws<CertificateParseException>(() => verifier.verify(problem, certificate));
     }
 
     [Theory] //tests solver

--- a/redux-tests/Problems/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Tests.cs
+++ b/redux-tests/Problems/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Tests.cs
@@ -35,6 +35,21 @@ public class BERNSTEINVAZIRANI_tests {
     }
 
     // -------------------------------------------------------------------------
+    // Constructor — invalid instances (all must throw ProblemParseException)
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("101")]           // bare string — SPADE parse failure
+    [InlineData("")]              // empty — SPADE parse failure
+    [InlineData("(0,2,1,0)")]   // invalid bit value
+    [InlineData("(0,x,1,0)")]   // non-numeric value
+    [InlineData("(0,1,0)")]     // 3 entries — not a power of 2
+    [InlineData("(0,1,0,1,0)")] // 5 entries — not a power of 2
+    public void BERNSTEINVAZIRANI_Constructor_Throws_On_Invalid_Instance(string instance) {
+        Assert.Throws<ProblemParseException>(() => new BERNSTEINVAZIRANI(instance));
+    }
+
+    // -------------------------------------------------------------------------
     // Verifier — invalid certificates (all must throw CertificateParseException)
     // -------------------------------------------------------------------------
 

--- a/redux-tests/Problems/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Tests.cs
+++ b/redux-tests/Problems/NPC_BERNSTEINVAZIRANI/BERNSTEINVAZIRANI_Tests.cs
@@ -21,10 +21,10 @@ public class BERNSTEINVAZIRANI_tests {
     }
 
     [Theory] //tests verifier
-    [InlineData("(0,1,0,1,1,0,1,0)", "101", true)]
-    [InlineData("(0,1,1,0,1,0,0,1)", "111", true)]
-    [InlineData("(0,1,0,1,0,1,0,1)", "001", true)]
-    [InlineData("(0,0,0,0,0,0,0,0)", "000", true)]
+    [InlineData("(0,1,0,1,1,0,1,0)", "(1,0,1)", true)]
+    [InlineData("(0,1,1,0,1,0,0,1)", "(1,1,1)", true)]
+    [InlineData("(0,1,0,1,0,1,0,1)", "(0,0,1)", true)]
+    [InlineData("(0,0,0,0,0,0,0,0)", "(0,0,0)", true)]
     public void BERNSTEINVAZIRANI_verifier(string instance, string certificate, bool expected) {
         var problem = new BERNSTEINVAZIRANI(instance);
         var verifier = new BernsteinVaziraniClassicalVerifier();
@@ -34,10 +34,10 @@ public class BERNSTEINVAZIRANI_tests {
     }
 
     [Theory] //tests solver
-    [InlineData("(0,1,0,1,1,0,1,0)", "101")]
-    [InlineData("(0,1,1,0,1,0,0,1)", "111")]
-    [InlineData("(0,0,0,0,0,0,0,0)", "000")]
-    [InlineData("(0,1,0,1,0,1,0,1)", "001")]
+    [InlineData("(0,1,0,1,1,0,1,0)", "(1,0,1)")]
+    [InlineData("(0,1,1,0,1,0,0,1)", "(1,1,1)")]
+    [InlineData("(0,0,0,0,0,0,0,0)", "(0,0,0)")]
+    [InlineData("(0,1,0,1,0,1,0,1)", "(0,0,1)")]
     public void BERNSTEINVAZIRANI_solver(string instance, string certificate) {
         var problem = new BERNSTEINVAZIRANI(instance);
         var solver = problem.defaultSolver;


### PR DESCRIPTION
## Summary

- Changes the certificate format from a bare binary string (`101`) to a parenthesized comma-separated list of bits (`(1,0,1)`), consistent with the instance format already used by this problem
- Verifier now parses the certificate with SPADE (`{f | f is list}`), validates each element is `0` or `1`, validates bit count against `NBits`, and throws `CertificateParseException` on malformed input
- Constructor now throws `ProblemParseException` on SPADE parse failure, invalid bit values, and non-power-of-2 function table sizes (previously silently logged or let raw exceptions escape)
- Both solvers (`ClassicalSolver`, `QuantumSolver`) now build certificate strings via `UtilCollection` rather than manual string formatting, so the full round-trip is through SPADE
- SPADE grammar and example certificate defined as constants on the verifier (`CertificateGrammar`, `CertificateExample`); `instanceFormat` and `certificateFormat` properties added to the problem class
- Adds a theory of 6 invalid-instance cases that must throw `ProblemParseException` (bare string, empty, invalid bit value, non-numeric, non-power-of-2 entry count)
- Adds a theory of 6 invalid-certificate cases that must throw `CertificateParseException`
- All solver/verifier tests updated to use the new `(b0,b1,...,bN)` certificate format

## Test plan

- [ ] `dotnet test --filter BERNSTEINVAZIRANI` — all 22 tests pass
- [ ] Verify solver output round-trips through verifier for all four 3-bit instances
- [ ] Confirm malformed instances (`"101"`, `"(0,2,1,0)"`, `"(0,1,0)"`) raise `ProblemParseException`
- [ ] Confirm malformed certificates (`"101"`, `"(2,0,1)"`, `"(1,0)"`) raise `CertificateParseException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)