### PR TITLE
Remove stale <param name="solver"> tag from visualize XML doc (CS1572)

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -218,7 +218,6 @@ public class ProblemProvider : ControllerBase
     /// Gets the visualization of an object
     /// </summary>
     /// <param name="visualization" example = "Sat3DefaultVisualization">The visualization to use</param>
-    /// <param name="solver" example = "Sat3BacktrackingSolver">The solver to use for steps and solution</param>
     /// <param name="instance" example = "(x1 | !x2 | x3) &amp; (!x1 | x3 | x1) &amp; (x2 | !x3 | x1)">the instance of the problem</param>
     /// <returns>a list containing the basic visualization, any steps from the solver, and the solved visualization</returns>
     [HttpPost("visualize")]


### PR DESCRIPTION
## Summary

- Removes a stale `<param name="solver">` XML doc tag from `ProblemProvider.visualize`. The `solver` parameter was removed from the method signature at some point but the doc tag was left behind, producing a CS1572 warning on every build.

## Test plan

- [x] `dotnet build` — CS1572 warning gone from `ProblemProvider.cs`
- [x] `dotnet test` — 393 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)