### PR TITLE
bump Microsoft.NET.Test.Sdk 18.0.1 → 18.6.0

### DIFF
--- a/API.csproj
+++ b/API.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="SPADE" Version="0.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
       <Content Include="Problems\**" CopyToPublishDirectory="PreserveNewest" />
-       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- Updates `Microsoft.NET.Test.Sdk` from 18.0.1 to 18.6.0 (minor version bump, no breaking changes).

## Test plan

- [x] `dotnet test` — 393 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)