### PR TITLE
bump coverlet.collector 3.1.0 → 10.0.1

### DIFF
--- a/API.csproj
+++ b/API.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Updates `coverlet.collector` from 3.1.0 to 10.0.1 (major version bump, but no breaking changes affecting this project).

## Test plan

- [x] `dotnet test` — 393 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)