### PR TITLE
Upgrade Swashbuckle.AspNetCore 7.3.2 → 10.2.1

### DIFF
--- a/API.csproj
+++ b/API.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="SPADE" Version="0.1.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
       <Content Include="Problems\**" CopyToPublishDirectory="PreserveNewest" />
        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
## Summary

- Bumps `Swashbuckle.AspNetCore` from 7.3.2 to 10.2.1
- Updates `using Microsoft.OpenApi.Models;` → `using Microsoft.OpenApi;` in `Program.cs` — the `Models` namespace was flattened into `Microsoft.OpenApi` in OpenAPI.NET v2, which Swashbuckle 10 depends on

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 393/393 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)