### PR TITLE
WeightedDirectedGraph: throw from unsupported base Node/Edge accessors

### DIFF
--- a/Interfaces/graphs/WeightedDirectedGraph.cs
+++ b/Interfaces/graphs/WeightedDirectedGraph.cs
@@ -11,8 +11,6 @@ class WeightedDirectedGraph : Graph
 {
     private List<string> _nodeList;
     private List<WeightedEdge> _edgeList;
-    private List<Node> _nodes;
-    private List<Edge> _edges;
     private List<string> _acceptStates;
     private string _startState;
 
@@ -32,21 +30,16 @@ class WeightedDirectedGraph : Graph
         _acceptStates = F;
     }
 
+    // This graph stores its data in the string-based DFA model (Nodes/Edges below),
+    // not the base class's Node/Edge view, so the inherited accessors are unsupported.
+    // Use Nodes/Edges instead. See ToAPIGraph for how the data is surfaced.
     public override List<Node> nodes
-    {
-        get
-        {
-            return _nodes;
-        }
-    }
+        => throw new NotSupportedException(
+            "WeightedDirectedGraph does not expose the base Node/Edge view; use Nodes/Edges instead.");
 
     public override List<Edge> edges
-    {
-        get
-        {
-            return _edges;
-        }
-    }
+        => throw new NotSupportedException(
+            "WeightedDirectedGraph does not expose the base Node/Edge view; use Nodes/Edges instead.");
     
     public List<string> Nodes { get => _nodeList; }
     public List<WeightedEdge> Edges { get => _edgeList; }


### PR DESCRIPTION
## Summary
`WeightedDirectedGraph` overrides the abstract `Graph.nodes` / `Graph.edges`
(`List<Node>` / `List<Edge>`) by returning two private fields, `_nodes` and
`_edges`, that are **never assigned** anywhere. As a result:

- `.nodes`, `.edges`, and the base `getNodeList` / `getEdgeList` (which delegate
  to them) **silently return `null`** on every instance.
- The fields trip `CS0649` (never assigned) ×2 and `CS8618` (non-nullable field
  uninitialized) ×2.

The class actually works because it stores its data in a separate string-based
model — `Nodes` (`List<string>`) and `Edges` (`List<WeightedEdge>`) — and
overrides `ToAPIGraph()` to build the visualization directly from those, never
touching `nodes`/`edges`.

## Change
- Remove the dead `_nodes` / `_edges` fields.
- Make the `nodes` / `edges` overrides throw `NotSupportedException` pointing
  callers at `Nodes` / `Edges`, with a comment explaining the string-based DFA model.

This turns a latent `NullReferenceException` into a clear, self-documenting
signal. Verified no caller uses the base accessors on this type (only DFA/NFA
use it, via `ToAPIGraph()` + the typed `Nodes`/`Edges`).

Clears `CS0649` ×2 and `CS8618` ×2.

## Note
This is a **middle-ground fix**. The deeper question — whether DFA/NFA should
adopt the real `Node`/`Edge` model instead of the bolted-on string fields in
`WeightedEdge` — is left for a design discussion with the original author.

## Testing
- `dotnet build` — 0 errors, the 4 warnings on this file gone
- `dotnet test` — 393 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)