### PR TITLE
Program: clear last CS1591 with documented public partial class

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -70,3 +70,6 @@ app.MapControllers();
 
 
 app.Run();
+
+/// <summary>Application entry point and composition root for the API.</summary>
+public partial class Program { }


### PR DESCRIPTION
## Summary
With `GenerateDocumentationFile` enabled, the implicit `Program` class generated
from top-level statements trips `CS1591` (missing XML comment for a publicly
visible member) — the last remaining CS1591 in the project.

## Change
Add an explicit, documented declaration at the end of `Program.cs`:

```csharp
/// <summary>Application entry point and composition root for the API.</summary>
public partial class Program { }
```

Chosen over a `#pragma warning disable` suppression because:
- It **documents** the entry point rather than hiding the warning.
- A pragma can't cleanly wrap the compiler-synthesized `Program` class (there's
  no source declaration to bracket), so it would amount to a file-scoped suppression.
- It makes `Program`'s public visibility **explicit in source**, which
  `WebApplicationFactory<Program>` integration tests depend on.

Clears the last CS1591 warning.

## Testing
- `dotnet build` — 0 errors, no CS1591
- `dotnet test` — 393 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)