### PR TITLE
LosslessDataCompression: make HuffmanNode children nullable

### DIFF
--- a/Problems/NPComplete/NPC_LOSSLESSDATACOMPRESSION/Solvers/LosslessDataCompressionSolver.cs
+++ b/Problems/NPComplete/NPC_LOSSLESSDATACOMPRESSION/Solvers/LosslessDataCompressionSolver.cs
@@ -165,7 +165,8 @@ class LosslessDataCompressionSolver : ISolver<LOSSLESSDATACOMPRESSION> {
         });
     }
 
-    private void BuildCodeTable(HuffmanNode node, string currentCode, Dictionary<char, string> codes) {
+    private void BuildCodeTable(HuffmanNode? node, string currentCode, Dictionary<char, string> codes)
+    {
         if (node == null) {
             return;
         }
@@ -234,8 +235,8 @@ class LosslessDataCompressionSolver : ISolver<LOSSLESSDATACOMPRESSION> {
         public int Frequency { get; set; }
         public int LowestCharacterValue { get; set; }
         public int SerialNumber { get; set; }
-        public HuffmanNode Left { get; set; }
-        public HuffmanNode Right { get; set; }
+        public HuffmanNode? Left { get; set; }
+        public HuffmanNode? Right { get; set; }
 
         public bool IsLeaf() {
             return Left == null && Right == null;


### PR DESCRIPTION
## Summary
`HuffmanNode.Left` / `HuffmanNode.Right` were declared as non-nullable
`HuffmanNode`, but a leaf node legitimately has no children — `IsLeaf()` is
literally defined as `Left == null && Right == null`. The non-nullable type was
inaccurate and tripped **CS8618** (non-nullable property uninitialized) ×2.

## Change
- Mark the children nullable: `public HuffmanNode? Left/Right { get; set; }`.
- Widen `BuildCodeTable(HuffmanNode? node, …)` to match — it already opens with
  `if (node == null) return;`, so the body stays valid, and this avoids a new
  **CS8604** when recursing on the now-nullable children.

This makes the type honest about leaf nodes and keeps the existing null checks
(`IsLeaf()`, the `node == null` guard) semantically correct rather than
looking like dead code.

Clears 2 CS8618; introduces no new warnings.

## Testing
- `dotnet build` — 0 errors, no warnings on the file
- `dotnet test` — 393 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)