### PR TITLE
ShortestPathVerifier: pattern-match nullable shortest distance (CS8629)

### DIFF
--- a/Problems/NPComplete/NPC_SHORTESTPATH/Verifiers/ShortestPathVerifier.cs
+++ b/Problems/NPComplete/NPC_SHORTESTPATH/Verifiers/ShortestPathVerifier.cs
@@ -37,12 +37,11 @@ class ShortestPathVerifier : IVerifier<SHORTESTPATH>
 
         // Compute true shortest distance using Dijkstra's algorithm
         int? shortest = ShortestDistance(adjacency, nodes, sourceNode, targetNode);
-        bool reachable = shortest.HasValue;
 
         // Allow {} as a certificate meaning "no path"
         if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
-            return !reachable; // Valid if and only if target is unreachable
-        
+            return shortest is null; // Valid if and only if target is unreachable
+
         List<string> path;
         try
         {
@@ -55,7 +54,7 @@ class ShortestPathVerifier : IVerifier<SHORTESTPATH>
         }
 
         if (path.Count == 0)
-            return !reachable; // Empty path is only valid if target is unreachable
+            return shortest is null; // Empty path is only valid if target is unreachable
 
         if (path[0] != sourceNode || path[^1] != targetNode)
             return false; // Path must start at source and end at target
@@ -81,7 +80,7 @@ class ShortestPathVerifier : IVerifier<SHORTESTPATH>
             
             length += w;
         }
-        return reachable && length == shortest.Value; // Valid if path is correct and matches true shortest distance
+        return shortest is int s && length == s; // Valid if path is correct and matches true shortest distance
     }
 
     // ShortestDistance: helper method to compute shortest distance using Dijkstra's algorithm


### PR DESCRIPTION
## Summary
`verify()` computed `int? shortest` and cached `bool reachable = shortest.HasValue`,
then used `reachable && length == shortest.Value`. The `&&` short-circuit makes
`.Value` safe, but the compiler's nullable flow analysis can't connect the
separate `reachable` bool back to `shortest`'s state, so it raised **CS8629**
("nullable value type may be null") on `shortest.Value`.

## Change
Drop the `reachable` alias and express each condition directly against `shortest`:

- Unreachable-path returns → `return shortest is null;`
- Length check → `return shortest is int s && length == s;`

The `is int s` pattern proves non-null and binds the unwrapped `int`, so there's
no raw `.Value` dereference left for the analyzer to flag. Reads as a single,
consistent nullable idiom and removes the redundant intermediate variable.

Clears 1 CS8629; no behavior change.

## Testing
- `dotnet build` — 0 errors, no warnings on the file
- `dotnet test` — 393 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)