### PR TITLE
LosslessDataCompressionVisualization: wire up real solver instead of null

### DIFF
--- a/Problems/NPComplete/NPC_LOSSLESSDATACOMPRESSION/Visualizations/LosslessDataCompressionVisualization.cs
+++ b/Problems/NPComplete/NPC_LOSSLESSDATACOMPRESSION/Visualizations/LosslessDataCompressionVisualization.cs
@@ -1,6 +1,7 @@
 using API.Interfaces;
 using API.Interfaces.JSON_Objects;
 using API.Problems.NPComplete.NPC_LOSSLESSDATACOMPRESSION;
+using API.Problems.NPComplete.NPC_LOSSLESSDATACOMPRESSION.Solvers;
 
 namespace API.Problems.NPComplete.NPC_LOSSLESSDATACOMPRESSION.Visualizations;
 
@@ -12,7 +13,7 @@ class LosslessDataCompressionVisualization : IVisualization<LOSSLESSDATACOMPRESS
     public string sourceLink {get;} = "TODO";
     public string[] contributors { get; } = { "TODO" };
     public string visualizationType { get; } = "TODO"; //either "Boolean Satisfiability" or "Graph D3" most likely
-    public ISolver solver { get; } = null; //TODO fill in solver to use for this visualization
+    public ISolver solver { get; } = new LosslessDataCompressionSolver();
 
     // --- Methods Including Constructors ---
     public LosslessDataCompressionVisualization()


### PR DESCRIPTION
## Summary
`LosslessDataCompressionVisualization` left its `solver` property as the
scaffold default `= null`, the only `IVisualization` in the codebase to do so —
every other visualizer assigns a concrete solver (e.g. the `WeightedCut`
visualization, scaffolded from the identical template, uses
`new WeightedCutBruteForce()`). The null literal tripped **CS8625** (null
assigned to non-nullable `ISolver`).

## Change
- `public ISolver solver { get; } = new LosslessDataCompressionSolver();`
- Add `using API.Problems.NPComplete.NPC_LOSSLESSDATACOMPRESSION.Solvers;`.

## Why this over suppression
This class is a reflection-discovered `IVisualization`, so `ProblemProvider`'s
`/visualize` calls `solver.GetSteps(...)` / `solver.solve(...)` on it — with a
null solver that was a latent `NullReferenceException` at runtime. Wiring the
real (existing) solver both clears the warning and makes that path functional,
matching every sibling. `= null!` would only mute the analyzer while leaving the
NPE in place.

The `visualize()` body itself is still a stub (returns `API_empty`); that's
unchanged and out of scope here.

Clears 1 CS8625.

## Testing
- `dotnet build` — 0 errors, no warnings on the file
- `dotnet test` — 393 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)