### PR TITLE
Remove dead graph property from three default visualizations

### DIFF
--- a/Problems/NPComplete/NPC_NODESET/Visualizations/NodeSetDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_NODESET/Visualizations/NodeSetDefaultVisualization.cs
@@ -15,7 +15,6 @@ class NodeSetDefaultVisualization : IVisualization<NODESET>
     public string visualizationDefinition { get; } = "This is a default visualization for Node Set";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Andrija Sevaljevic" };
-    public UtilCollectionGraph graph { get; set; }
     public string visualizationType { get; } = "Graph D3";
     public ISolver solver { get; } = new NodeSetBruteForce();
 

--- a/Problems/NPComplete/NPC_STEINERTREE/Visualizations/SteinerTreeDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_STEINERTREE/Visualizations/SteinerTreeDefaultVisualization.cs
@@ -15,7 +15,6 @@ class SteinerTreeDefaultVisualization : IVisualization<STEINERTREE>
     public string visualizationDefinition { get; } = "This is a default visualization for Steiner Tree";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Andrija Sevaljevic" };
-    public UtilCollectionGraph graph { get; set; }
     public string visualizationType { get; } = "Graph D3";
     public ISolver solver { get; } = new SteinerTreeBruteForce();
 

--- a/Problems/NPComplete/NPC_WEIGHTEDCUT/Visualizations/WeightedCutDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_WEIGHTEDCUT/Visualizations/WeightedCutDefaultVisualization.cs
@@ -16,7 +16,6 @@ class WeightedCutDefaultVisualization : IVisualization<WEIGHTEDCUT>
     public string visualizationDefinition { get; } = "This is a default visualization for Cut";
     public string source { get; } = "";
     public string[] contributors { get; } = { "Andrija Sevaljevic" };
-    public UtilCollectionGraph graph { get; set; }
     public string visualizationType { get; } = "Graph D3";
     public ISolver solver { get; } = new WeightedCutBruteForce(); //TODO fill in solver to use for this visualization
 


### PR DESCRIPTION
## Summary

The `NodeSetDefaultVisualization`, `SteinerTreeDefaultVisualization`, and `WeightedCutDefaultVisualization` classes each declared a non-nullable `UtilCollectionGraph graph { get; set; }` property that:

- triggered **CS8618** (non-nullable property never initialized in the constructor),
- was **never read or written** anywhere in the codebase, and
- is **not** part of the `IVisualization` interface.

The visualize/SolvedVisualization methods operate on the *problem's* graph (e.g. `steinerTree.graph`), not the visualization's own property. The property was dead code — most likely copied from the problem classes, where `graph` legitimately lives and is constructed.

Removing it clears 3 CS8618 warnings at the source rather than papering over them with an initializer.

## Testing

- `dotnet build` → 0 errors
- `dotnet test` → all tests pass (326)

🤖 Generated with [Claude Code](https://claude.com/claude-code)