### PR TITLE
DijkstraSolver: express predecessor nullability instead of casting it away

### DIFF
--- a/Problems/NPComplete/NPC_SHORTESTPATH/Solvers/DijkstraSolver.cs
+++ b/Problems/NPComplete/NPC_SHORTESTPATH/Solvers/DijkstraSolver.cs
@@ -35,7 +35,7 @@ class DijkstraSolver : ISolver<SHORTESTPATH>
 
 		//Initialize distances
 		var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
-        var prev = nodes.ToDictionary(n => n, _ => (string)null);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
         var visited = new HashSet<string>();
         var pq = new DijkstraPriorityQueue<string>();
 
@@ -185,7 +185,7 @@ class DijkstraSolver : ISolver<SHORTESTPATH>
 	internal static List<string> ReconstructPath(Dictionary<string, string?> prev, string source, string target)
 	{
 		var path = new List<string>();
-		string current = target;
+		string? current = target;
 
 		while (current != null)
 		{


### PR DESCRIPTION
## Summary

Clears the two **CS8600** warnings in `DijkstraSolver.cs`. Both came from null being cast away to a non-nullable type rather than modeled in the type.

- **`prev` predecessor map** (line 38) seeded each node with `(string)null`, forcing `ToDictionary` to infer `Dictionary<string, string>`. A node's predecessor is genuinely null (the source node, and any unreached node), so the value type should be `string?`. The cast is required for element-type inference — switching it to `(string?)null` produces the correct type and matches the `Dictionary<string, string?>` parameter that `ReconstructPath` already declares.
- **`ReconstructPath` loop** (line 195) declared `current` as non-nullable but assigned `prev[current]` (a `string?`). Widening `current` to `string?` is safe: the enclosing `while (current != null)` loop guards every dereference.

No behavioral change — purely making the existing null semantics explicit.

## Testing

- `dotnet build` → 0 errors, no DijkstraSolver warnings
- `dotnet test` → all tests pass (393)

🤖 Generated with [Claude Code](https://claude.com/claude-code)