### PR TITLE
SubsetSum: fix solver/verifier bugs (#257, #259); SPADE parsing + HTTP 400

### DIFF
--- a/Problems/NPComplete/NPC_EXACTCOVER/ReduceTo/NPC_SUBSETSUM/KarpExactCoverToSubsetSum.cs
+++ b/Problems/NPComplete/NPC_EXACTCOVER/ReduceTo/NPC_SUBSETSUM/KarpExactCoverToSubsetSum.cs
@@ -1,5 +1,4 @@
 using API.Interfaces;
-using API.Problems.NPComplete.NPC_EXACTCOVER;
 using API.Problems.NPComplete.NPC_SUBSETSUM;
 
 namespace API.Problems.NPComplete.NPC_EXACTCOVER.ReduceTo.NPC_SUBSETSUM;
@@ -83,21 +82,20 @@ class KarpExactCoverToSubsetSum : IReduction<EXACTCOVER, SUBSETSUM>
             }
         }
 
-        string instance = "{{";
+        List<string> subsetSumS = new List<string>();
         double sum = 0;
         for(int j = 0; j < reductionFrom.S.Count; j++) {
             for(int i = 0; i < reductionFrom.X.Count; i++) {
                 sum += e[j,i] * Math.Pow(d,i);
             }
-            instance += sum.ToString() + ',';
+            subsetSumS.Add(sum.ToString());
             sum = 0;
         }
 
-        instance = instance.TrimEnd(',') + "} : ";
         string K = ((Math.Pow(d,reductionFrom.X.Count) - 1) / (d - 1)).ToString();
-        instance += K + '}';
+        string instance = "({" + string.Join(",", subsetSumS) + "}," + K + ")";
 
-        reducedSUBSETSUM.S = instance.Replace("{","").Replace("}","").Split(',').ToList();
+        reducedSUBSETSUM.S = subsetSumS;
         reducedSUBSETSUM.T = Int32.Parse(K);
         reducedSUBSETSUM.instance = instance;
 

--- a/Problems/NPComplete/NPC_SUBSETSUM/SUBSETSUM_Class.cs
+++ b/Problems/NPComplete/NPC_SUBSETSUM/SUBSETSUM_Class.cs
@@ -16,9 +16,13 @@ class SUBSETSUM : IProblem<SubsetSumBruteForce,SubsetSumVerifier, DummyVisualiza
     public string source {get;} = "Karp, Richard M. Reducibility among combinatorial problems. Complexity of computer computations. Springer, Boston, MA, 1972. 85-103.";
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
     public string[] contributors {get;} = { "Garret Stouffer", "Caleb Eardley"};
-    public static string _defaultInstance { get; } = "{{1,7,12,15} : 28}";
+    public const string InstanceGrammar = "{(S,T) | S is set, T is int}";
+    public static string _defaultInstance { get; } = "({1,7,12,15},28)";
     public string defaultInstance {get;} = _defaultInstance;
     public string instance {get;set;} = string.Empty;
+    public string instanceFormat {get;} = $"Format: {InstanceGrammar} Example: {_defaultInstance}";
+    public string certificateFormat {get;} =
+        $"Format: {SubsetSumVerifier.CertificateGrammar} Example: {SubsetSumVerifier.CertificateExample}";
     private List<string> _S = new List<string>();
     private int _T;
 
@@ -53,34 +57,30 @@ class SUBSETSUM : IProblem<SubsetSumBruteForce,SubsetSumVerifier, DummyVisualiza
 
     public SUBSETSUM(string instance) {
         this.instance = instance;
-        S = getIntegers(instance);
-        T = getT(instance);
-    }
-    public List<string> getIntegers(string instance) {
 
-        List<string> allIntegers = new List<string>();
-        string strippedInput = instance.Replace("{", "").Replace("}", "").Replace(" ", "");
-        
-        // [0] is integers,  [1] is T.
-        string[] SSsections = strippedInput.Split(':');
-        string[] SSintegers = SSsections[0].Split(',');
-        
-        foreach(string integer in SSintegers) {
-            allIntegers.Add(integer);
+        StringParser parser = new(InstanceGrammar);
+        List<string> parsedS;
+        string tStr;
+        try {
+            parser.parse(instance);
+            // Materialize inside the try: SPADE may parse without error and only
+            // fail when the result is enumerated or a missing key is accessed.
+            parsedS = parser["S"].ToList().Select(x => x.ToString()).ToList();
+            tStr = parser["T"].ToString();
+        } catch (Exception ex) {
+            throw new ProblemParseException(problemName, instance, ex.Message);
         }
 
-        return allIntegers;
+        foreach (string element in parsedS) {
+            if (!int.TryParse(element, out _))
+                throw new ProblemParseException(problemName, instance,
+                    $"'{element}' is not a valid integer in S");
+        }
+        S = parsedS;
+
+        if (!int.TryParse(tStr, out int t))
+            throw new ProblemParseException(problemName, instance,
+                $"'{tStr}' is not a valid integer for T");
+        T = t;
     }
-    
-
-    public int getT(string instance) {
-        string strippedInput = instance.Replace("{", "").Replace("}", "").Replace(" ", "");
-        
-        // [0] is integers,  [1] is T.
-        string[] SSsections = strippedInput.Split(':');
-        
-        return Int32.Parse(SSsections[1]);
-    }
-
-
 }

--- a/Problems/NPComplete/NPC_SUBSETSUM/Solvers/SubsetSumBruteForce.cs
+++ b/Problems/NPComplete/NPC_SUBSETSUM/Solvers/SubsetSumBruteForce.cs
@@ -1,4 +1,5 @@
 using API.Interfaces;
+using SPADE;
 
 namespace API.Problems.NPComplete.NPC_SUBSETSUM.Solvers;
 class SubsetSumBruteForce : ISolver<SUBSETSUM> {
@@ -12,40 +13,30 @@ class SubsetSumBruteForce : ISolver<SUBSETSUM> {
 
     // --- Methods Including Constructors ---
     public SubsetSumBruteForce() {
-        
-    }
-    private string BinaryToCertificate(List<int> binary, List<string> S ){
-        string certificate = "";
-        for(int i = 0; i< binary.Count; i++){
-            if(binary[i] == 1){
-                certificate += S[i]+",";
-            }
-        }
-        return "{" + certificate.TrimEnd(',') + "}";
 
     }
-    private void nextBinary(List<int> binary){
-        for(int i = 0; i< binary.Count; i++){
-            if(binary[i] == 0){
-                binary[i] += 1;
-                return;
-            }
-            else if(binary[i] == 1){
-                binary[i] = 0;
-            }
+
+    private static string SubsetToCertificate(int mask, List<string> S) {
+        UtilCollection certificate = new UtilCollection("{}");
+        for (int i = 0; i < S.Count; i++) {
+            if ((mask & (1 << i)) != 0)
+                certificate.Add(new UtilCollection(S[i]));
         }
+        return certificate.ToString();
     }
-       
+
     public string solve(SUBSETSUM subsetSum){
-        List<int> binary = new List<int>(){1};
-        for(int i = 0; i < subsetSum.S.Count-1; i++){
-            binary.Add(0);
-        }
-        string certificate = BinaryToCertificate(binary, subsetSum.S);
-        while(certificate != "{}"){
-            nextBinary(binary);
-            certificate = BinaryToCertificate(binary, subsetSum.S);
-            if(subsetSum.defaultVerifier.verify(subsetSum, certificate)){
+        int n = subsetSum.S.Count;
+
+        // Enumerate every subset by its bitmask so that all 2^n subsets -- including
+        // the singleton {S[0]} -- are tested exactly once. Mask 0 (the empty subset)
+        // is skipped: with positive integers and T > 0 it is never a witness, and
+        // "{}" doubles as the no-solution sentinel.
+        for (int mask = 1; mask < (1 << n); mask++) {
+            if (timerHasExpired) return "{}";
+
+            string certificate = SubsetToCertificate(mask, subsetSum.S);
+            if (subsetSum.defaultVerifier.verify(subsetSum, certificate)) {
                 return certificate;
             }
         }

--- a/Problems/NPComplete/NPC_SUBSETSUM/Verifiers/SubsetSumVerifier.cs
+++ b/Problems/NPComplete/NPC_SUBSETSUM/Verifiers/SubsetSumVerifier.cs
@@ -1,12 +1,16 @@
 using API.Interfaces;
+using SPADE;
 
 namespace API.Problems.NPComplete.NPC_SUBSETSUM.Verifiers;
 
 class SubsetSumVerifier : IVerifier<SUBSETSUM> {
 
+    public const string CertificateGrammar = "{K | K is set}";
+    public const string CertificateExample = "{1,12,15}";
+
     // --- Fields ---
     public string verifierName {get;} = "Subset Sum Verifier";
-    public string verifierDefinition {get;} = "This is a verifier for Subset Summ";
+    public string verifierDefinition {get;} = "This is a verifier for Subset Sum";
     public string source {get;} = "";
     public string[] contributors {get;} = { "Garret Stouffer"};
 
@@ -21,25 +25,44 @@ class SubsetSumVerifier : IVerifier<SUBSETSUM> {
 
     // --- Methods Including Constructors ---
     public SubsetSumVerifier() {
-        
+
     }
 
     public bool verify(SUBSETSUM problem, string certificate){
-        List<string> c = certificate.Replace("{","").Replace("}","").Replace(" ","").Split(",").ToList();
+        StringParser parser = new(CertificateGrammar);
+        List<UtilCollection> elements;
+        try {
+            parser.parse(certificate);
+            // Materialize inside the try: SPADE may parse a scalar (e.g. "101")
+            // without error and only fail when the result is enumerated.
+            elements = parser["K"].ToList();
+        } catch (Exception ex) {
+            throw new CertificateParseException(problem, certificate, ex.Message);
+        }
+
+        // Multiset of S (value -> remaining count): each element may be used at
+        // most as many times as it occurs in S, so a certificate that reuses an
+        // element is rejected. Using a count map keeps membership checks O(1).
+        Dictionary<string, int> available = new Dictionary<string, int>();
+        foreach (string s in problem.S)
+            available[s] = available.GetValueOrDefault(s) + 1;
+
         int sum = 0;
-        foreach(string a in c){
-            if(problem.S.Contains(a)){    
-                sum += int.Parse(a);
-            }
-            else{
+
+        foreach (UtilCollection element in elements) {
+            string a = element.ToString();
+            if (!int.TryParse(a, out int value))
+                throw new CertificateParseException(problem, certificate,
+                    $"'{a}' is not a valid integer");
+
+            // Not a member of S, or every copy of it has already been used.
+            if (available.GetValueOrDefault(a) == 0)
                 return false;
-            }
-        }
-        if(sum == problem.T){
-            return true;
+
+            available[a]--;
+            sum += value;
         }
 
-
-        return false;
+        return sum == problem.T;
     }
 }

--- a/redux-tests/Problems/NPC_SUBSETSUM/SUBSETSUM_Tests.cs
+++ b/redux-tests/Problems/NPC_SUBSETSUM/SUBSETSUM_Tests.cs
@@ -1,0 +1,170 @@
+using Xunit;
+using API.Interfaces;
+using API.Problems.NPComplete.NPC_SUBSETSUM;
+using API.Problems.NPComplete.NPC_SUBSETSUM.Solvers;
+using API.Problems.NPComplete.NPC_SUBSETSUM.Verifiers;
+using API.Problems.NPComplete.NPC_SUBSETSUM.ReduceTo.NPC_KNAPSACK;
+using API.Problems.NPComplete.NPC_SUBSETSUM.ReduceTo.NPC_PARTITION;
+using API.Problems.NPComplete.NPC_EXACTCOVER.ReduceTo.NPC_SUBSETSUM;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class SUBSETSUM_Tests
+{
+    // -------------------------------------------------------------------------
+    // Instantiation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void SUBSETSUM_Default_Instantiation()
+    {
+        SUBSETSUM problem = new SUBSETSUM();
+        Assert.Equal("({1,7,12,15},28)", problem.instance);
+        Assert.Equal("({1,7,12,15},28)", problem.defaultInstance);
+        Assert.Equal(4, problem.S.Count);
+        Assert.Equal(28, problem.T);
+    }
+
+    [Fact]
+    public void SUBSETSUM_Custom_Instantiation()
+    {
+        SUBSETSUM problem = new SUBSETSUM("({3,5,9},14)");
+        Assert.Equal("({3,5,9},14)", problem.instance);
+        Assert.Equal(3, problem.S.Count);
+        Assert.Equal(14, problem.T);
+        Assert.Contains("3", problem.S);
+        Assert.Contains("5", problem.S);
+        Assert.Contains("9", problem.S);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor — invalid instances (all must throw ProblemParseException)
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("{{1,7,12,15} : 28}")] // old colon format
+    [InlineData("")]                    // empty
+    [InlineData("101")]                 // bare string
+    [InlineData("({1,x,3},5)")]         // non-integer element in S
+    [InlineData("({1,2,3},y)")]         // non-integer T
+    public void SUBSETSUM_Constructor_Throws_On_Invalid_Instance(string instance)
+    {
+        Assert.Throws<ProblemParseException>(() => new SUBSETSUM(instance));
+    }
+
+    // -------------------------------------------------------------------------
+    // Verifier — valid certificates
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("({1,7,12,15},28)", "{1,12,15}")] // 1 + 12 + 15 = 28
+    [InlineData("({5,1,2},5)", "{5}")]             // singleton {S[0]} is a valid witness
+    [InlineData("({3,5,9},8)", "{3,5}")]           // 3 + 5 = 8
+    public void SUBSETSUM_Verifier_Accepts_Valid_Certificate(string instance, string certificate)
+    {
+        SUBSETSUM problem = new SUBSETSUM(instance);
+        SubsetSumVerifier verifier = new SubsetSumVerifier();
+        Assert.True(verifier.verify(problem, certificate));
+    }
+
+    // -------------------------------------------------------------------------
+    // Verifier — well-formed but wrong certificates (must return false)
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("({1,7,12,15},28)", "{1,7}")]   // sum 8 != 28
+    [InlineData("({1,7,12,15},28)", "{1,99}")]  // 99 is not a member of S
+    [InlineData("({1,7,12,15},28)", "101")]     // SPADE reads a bare scalar as {101}; 101 is not in S
+    [InlineData("({7,1},14)", "{7,7}")]         // reuses 7 beyond its multiplicity in S (#259)
+    public void SUBSETSUM_Verifier_Rejects_Invalid_Certificate(string instance, string certificate)
+    {
+        SUBSETSUM problem = new SUBSETSUM(instance);
+        SubsetSumVerifier verifier = new SubsetSumVerifier();
+        Assert.False(verifier.verify(problem, certificate));
+    }
+
+    // -------------------------------------------------------------------------
+    // Verifier — malformed certificates (must throw CertificateParseException)
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("")]          // empty — SPADE parse failure
+    [InlineData("{1,x,3}")]   // non-integer token
+    public void SUBSETSUM_Verifier_Throws_On_Malformed_Certificate(string certificate)
+    {
+        SUBSETSUM problem = new SUBSETSUM("({1,7,12,15},28)");
+        SubsetSumVerifier verifier = new SubsetSumVerifier();
+        Assert.Throws<CertificateParseException>(() => verifier.verify(problem, certificate));
+    }
+
+    // -------------------------------------------------------------------------
+    // Solver
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("({1,7,12,15},28)")]
+    [InlineData("({3,5,9},14)")] // 5 + 9
+    [InlineData("({2,4,6},10)")] // 4 + 6
+    public void SUBSETSUM_Solver_ProducesVerifiableCertificate(string instance)
+    {
+        SUBSETSUM problem = new SUBSETSUM(instance);
+        SubsetSumBruteForce solver = new SubsetSumBruteForce();
+        SubsetSumVerifier verifier = new SubsetSumVerifier();
+        string solution = solver.solve(problem);
+        Assert.True(verifier.verify(problem, solution));
+    }
+
+    [Fact]
+    public void SUBSETSUM_Solver_Finds_FirstElement_Only_Solution()
+    {
+        // Regression for the enumeration bug: the only subset summing to 5 is {5},
+        // the singleton of the first element, which the old solver never tested.
+        SUBSETSUM problem = new SUBSETSUM("({5,1,2},5)");
+        SubsetSumBruteForce solver = new SubsetSumBruteForce();
+        string solution = solver.solve(problem);
+        Assert.Equal("{5}", solution);
+    }
+
+    [Fact]
+    public void SUBSETSUM_Solver_Returns_Empty_When_No_Solution()
+    {
+        SUBSETSUM problem = new SUBSETSUM("({2,4,6},5)");
+        SubsetSumBruteForce solver = new SubsetSumBruteForce();
+        Assert.Equal("{}", solver.solve(problem));
+    }
+
+    // -------------------------------------------------------------------------
+    // Reductions — must accept / produce the SPADE instance format
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void SUBSETSUM_FengReduction_Accepts_New_Instance_Format()
+    {
+        FengReduction reduction = new FengReduction("({3,5,7},8)");
+        Assert.Equal(3, reduction.reductionFrom.S.Count);
+        Assert.Equal(8, reduction.reductionFrom.T);
+        Assert.NotNull(reduction.reductionTo);
+    }
+
+    [Fact]
+    public void SUBSETSUM_PartitionReduction_Accepts_New_Instance_Format()
+    {
+        SubsetSumToPartitionReduction reduction = new SubsetSumToPartitionReduction("({3,5,7},8)");
+        Assert.Equal(3, reduction.reductionFrom.S.Count);
+        Assert.NotNull(reduction.reductionTo);
+    }
+
+    [Fact]
+    public void SUBSETSUM_KarpExactCoverReduction_Produces_Parseable_Instance()
+    {
+        KarpExactCoverToSubsetSum reduction = new KarpExactCoverToSubsetSum();
+        string producedInstance = reduction.reductionTo.instance;
+        Assert.StartsWith("({", producedInstance);
+
+        // The produced instance must round-trip through the SPADE constructor.
+        SUBSETSUM roundTrip = new SUBSETSUM(producedInstance);
+        Assert.Equal(reduction.reductionTo.S.Count, roundTrip.S.Count);
+        Assert.Equal(reduction.reductionTo.T, roundTrip.T);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two SubsetSum correctness bugs and brings the problem in line with the SPADE-parsing / structured-HTTP-400 model (cf. #237).

- **Solver (closes #257):** the hand-rolled binary counter never tested the singleton `{S[0]}` — its initial assignment `[1,0,…]` was only used in the loop guard, and the counter was advanced before the first `verify`, then the loop terminated on wrap to all-zeros, so value 1 was never revisited. Replaced with a `1 .. 2^n-1` bitmask sweep that tests every subset exactly once.
- **Verifier (closes #259):** membership used `List.Contains` without consuming, so a certificate could reuse an element more times than it occurs in `S` (e.g. `{7,7}` accepted against `S={7,1}`). Membership is now checked against a `Dictionary<string,int>` multiset of `S` (O(1) per element, preserves multiplicity).

## SPADE parsing + HTTP 400

- Instance migrated to SPADE grammar `{(S,T) | S is set, T is int}`. **Format change:** `{ {1,7,12,15} : 28 }` → `({1,7,12,15},28)`. Constructor throws `ProblemParseException` on malformed input / non-integer `S` element / non-integer `T`.
- Certificate parsed with SPADE `{K | K is set}`; verifier throws `CertificateParseException` on malformed input.
- Added `instanceFormat`/`certificateFormat` overrides. Both exceptions are already mapped to **HTTP 400** by `ProblemProvider`, so no controller changes were needed.
- Parsed values are materialized inside the `try` so SPADE's lazy scalar-enumeration errors (e.g. a bare `"101"` instance) are caught rather than escaping as `InvalidOperationException`.

## Reductions

- `KarpExactCoverToSubsetSum` updated to emit the new `({…},T)` instance format.
- `FengReduction` (→Knapsack) and `SubsetSumToPartitionReduction` (→Partition) read only `S`/`T`, so they are unaffected (covered by tests).

## Tests

Adds `redux-tests/Problems/NPC_SUBSETSUM/SUBSETSUM_Tests.cs` (24 cases): instantiation, instance parse-error theory, verifier accept/reject (including the #259 multiplicity regression), malformed-certificate theory, solver round-trips, the `{S[0]}` regression (#257), no-solution, and reduction format sanity. (closes #136)

## Validation

- `dotnet build` — 0 errors.
- `dotnet test` — **417/417 pass** (24 new SubsetSum + all existing suites, including the reduction-affected Knapsack/Partition/ExactCover tests).

## Note for reviewers

The instance string format changed (colon → SPADE tuple). The frontend (`Redux_GUI`) has no SubsetSum-specific parsing — instances flow from the API's `defaultInstance` and SubsetSum isn't client-side validated — so no GUI change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
