### PR TITLE
Feature/pump scheduling

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Solvers.cs
+++ b/AdditionalControllers/Navigation/Nav_Solvers.cs
@@ -133,11 +133,37 @@ public class Problem_SolversRefactorController : ControllerBase {
 
         }
         catch(System.IO.DirectoryNotFoundException){
-            
-            jsonString = JsonSerializer.Serialize(NOT_FOUND_ERR_SOLVER,options);
+            // Fallback: search every class directory under Problems/ for any folder
+            // whose name ends with _{chosenProblem}, regardless of prefix.
+            var fallback = FindSolversAcrossAllDirs(ProjectSourcePath.Value, chosenProblem);
+            jsonString = fallback.Count > 0
+                ? JsonSerializer.Serialize(fallback, options)
+                : JsonSerializer.Serialize(NOT_FOUND_ERR_SOLVER, options);
         }
         
         // Not completed. Needs to loop through these directories to get the rest of the problems
         return jsonString;
+    }
+
+    private static List<string> FindSolversAcrossAllDirs(string root, string chosenProblem) {
+        var result = new List<string>();
+        var problemsRoot = Path.Combine(root, "Problems");
+        if (!Directory.Exists(problemsRoot)) return result;
+        foreach (var classDir in Directory.GetDirectories(problemsRoot)) {
+            foreach (var problemDir in Directory.GetDirectories(classDir)) {
+                var dirName = Path.GetFileName(problemDir) ?? "";
+                var idx = dirName.IndexOf('_');
+                if (idx >= 0 && dirName[(idx + 1)..] == chosenProblem) {
+                    var solversPath = Path.Combine(problemDir, "Solvers");
+                    if (!Directory.Exists(solversPath)) continue;
+                    foreach (var file in Directory.GetFiles(solversPath)) {
+                        var name = Path.GetFileNameWithoutExtension(file);
+                        if (name != null) result.Add(name);
+                    }
+                    return result;
+                }
+            }
+        }
+        return result;
     }
 }

--- a/AdditionalControllers/Navigation/Nav_Verifiers.cs
+++ b/AdditionalControllers/Navigation/Nav_Verifiers.cs
@@ -136,9 +136,35 @@ public class Problem_VerifiersRefactorController : ControllerBase {
         }
         catch (System.IO.DirectoryNotFoundException)
         {
-            jsonString = JsonSerializer.Serialize(NOT_FOUND_ERR_VERIFIER, options);
-
+            // Fallback: search every class directory under Problems/ for any folder
+            // whose name ends with _{chosenProblem}, regardless of prefix.
+            var fallback = FindVerifiersAcrossAllDirs(ProjectSourcePath.Value, chosenProblem);
+            jsonString = fallback.Count > 0
+                ? JsonSerializer.Serialize(fallback, options)
+                : JsonSerializer.Serialize(NOT_FOUND_ERR_VERIFIER, options);
         }
         return jsonString;
+    }
+
+    private static List<string> FindVerifiersAcrossAllDirs(string root, string chosenProblem) {
+        var result = new List<string>();
+        var problemsRoot = Path.Combine(root, "Problems");
+        if (!Directory.Exists(problemsRoot)) return result;
+        foreach (var classDir in Directory.GetDirectories(problemsRoot)) {
+            foreach (var problemDir in Directory.GetDirectories(classDir)) {
+                var dirName = Path.GetFileName(problemDir) ?? "";
+                var idx = dirName.IndexOf('_');
+                if (idx >= 0 && dirName[(idx + 1)..] == chosenProblem) {
+                    var verifiersPath = Path.Combine(problemDir, "Verifiers");
+                    if (!Directory.Exists(verifiersPath)) continue;
+                    foreach (var file in Directory.GetFiles(verifiersPath)) {
+                        var name = Path.GetFileNameWithoutExtension(file);
+                        if (name != null) result.Add(name);
+                    }
+                    return result;
+                }
+            }
+        }
+        return result;
     }
 }

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using API.Interfaces;
+using API.DummyClasses;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Verifiers;
+
+namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
+
+record PumpData(string Name, double FlowRateGph, double PowerKw, double StartupCostDollars);
+
+class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifier, DummyVisualization>
+{
+    // --- Fields ---
+    public string problemName { get; } = "Pump Scheduling (Cost Minimization)";
+    public string problemLink { get; } = "";
+    public string formalDefinition { get; } =
+        "Given a storage tank, hourly water demand curve, time-of-use electricity tariff, and a set of pumps " +
+        "each with a flow rate, power draw, and startup cost, find the 24-hour on/off schedule for each pump " +
+        "that satisfies demand, keeps the tank within capacity, and minimizes total electricity cost.";
+    public string problemDefinition { get; } =
+        "Determine which pumps to activate each hour over a 24-hour period so that water demand is met, " +
+        "the storage tank never overflows or empties, and the total energy cost (based on peak/off-peak tariffs " +
+        "plus pump startup costs) is minimized.";
+    public string source { get; } = "";
+    public string wikiName { get; } = "";
+    public string[] contributors { get; } = { "SARE 2026 Team" };
+
+    public string instanceFormat { get; } =
+        "({tank_capacity_gal,tank_current_level_gal}," +
+        "{(demand_h0,...,demand_h23),(peak_h0,...),(on_peak_cost_per_kwh,off_peak_cost_per_kwh)}," +
+        "{(pump_name,flow_gph,kw,startup_cost_dollars),...}). " +
+        "Example: ({5000,2000},{(300,...,340),(8,9,10,11),(0.12,0.06)},{(PumpA,200,5.0,2.5),(PumpB,350,8.5,4.0)})";
+
+    public string certificateFormat { get; } =
+        "(total_cost_dollars,{(pump_name,h0,...,h23),...}) where each h_i is 0 (off) or 1 (on). " +
+        "Example: (63.28,{(PumpA,0,1,1,...,0),(PumpB,1,0,0,...,1)})";
+
+    private static readonly string _defaultInstance =
+        "({10000,5000}," +
+        "{(600,600,600,600,600,600,600,600,1000,1000,1000,1000,600,600,600,600,600,1000,1000,1000,1000,1000,600,600)," +
+        "(8,9,10,11,17,18,19,20),(0.12,0.06)}," +
+        "{(PumpA,200,5.0,2.5),(PumpB,350,8.5,4.0),(PumpC,500,12.0,6.0)})";
+
+    public string defaultInstance { get; } = _defaultInstance;
+    public string instance { get; set; } = string.Empty;
+
+    // --- Parsed properties ---
+    public double TankCapacity { get; private set; }
+    public double TankCurrentLevel { get; private set; }
+    public List<double> DemandGph { get; private set; } = new();
+    public HashSet<int> PeakHours { get; private set; } = new();
+    public double OnPeakCostPerKwh { get; private set; }
+    public double OffPeakCostPerKwh { get; private set; }
+    public List<PumpData> Pumps { get; private set; } = new();
+
+    public PumpSchedulingCMSolver defaultSolver { get; } = new();
+    public PumpSchedulingCMVerifier defaultVerifier { get; } = new();
+    public DummyVisualization defaultVisualization { get; } = new();
+
+    // --- Constructors ---
+    public PUMPSCHEDULINGCM() : this(_defaultInstance) { }
+
+    public PUMPSCHEDULINGCM(string instanceString)
+    {
+        instance = instanceString;
+
+        string s = instanceString.Trim();
+        if (s.StartsWith("(") && s.EndsWith(")"))
+            s = s[1..^1].Trim();
+
+        var sections = SplitTopLevel(s, ',');
+        if (sections.Count != 3)
+            throw new ArgumentException(
+                $"Instance must have 3 sections (tank, demand, pumps); got {sections.Count}.");
+
+        ParseTank(sections[0].Trim());
+        ParseDemand(sections[1].Trim());
+        ParsePumps(sections[2].Trim());
+    }
+
+    // --- Parsers ---
+
+    private void ParseTank(string s)
+    {
+        s = StripBraces(s);
+        var parts = SplitTopLevel(s, ',');
+        if (parts.Count != 2)
+            throw new ArgumentException("Tank section must be {capacity,currentLevel}.");
+        TankCapacity = ParseDouble(parts[0]);
+        TankCurrentLevel = ParseDouble(parts[1]);
+        if (TankCapacity <= 0)
+            throw new ArgumentException("Tank capacity must be positive.");
+        if (TankCurrentLevel < 0 || TankCurrentLevel > TankCapacity)
+            throw new ArgumentException("Tank current level must be in [0, capacity].");
+    }
+
+    private void ParseDemand(string s)
+    {
+        s = StripBraces(s);
+        var tuples = SplitTopLevel(s, ',');
+        if (tuples.Count != 3)
+            throw new ArgumentException(
+                "Demand section must have 3 tuples: (demands),(peak_hours),(costs).");
+
+        DemandGph = SplitTopLevel(StripParens(tuples[0]), ',')
+            .Select(p => ParseDouble(p))
+            .ToList();
+        if (DemandGph.Count != 24)
+            throw new ArgumentException(
+                $"Demand curve must have exactly 24 values; got {DemandGph.Count}.");
+
+        PeakHours = SplitTopLevel(StripParens(tuples[1]), ',')
+            .Select(p => int.Parse(p.Trim()))
+            .ToHashSet();
+
+        var costs = SplitTopLevel(StripParens(tuples[2]), ',');
+        if (costs.Count != 2)
+            throw new ArgumentException("Cost tuple must be (on_peak_rate,off_peak_rate).");
+        OnPeakCostPerKwh = ParseDouble(costs[0]);
+        OffPeakCostPerKwh = ParseDouble(costs[1]);
+    }
+
+    private void ParsePumps(string s)
+    {
+        s = StripBraces(s);
+        var pumpTuples = SplitTopLevel(s, ',');
+        foreach (var pt in pumpTuples)
+        {
+            var parts = SplitTopLevel(StripParens(pt.Trim()), ',');
+            if (parts.Count != 4)
+                throw new ArgumentException(
+                    $"Each pump needs 4 fields (name,flow_gph,kw,startup_cost); got {parts.Count} in '{pt}'.");
+            Pumps.Add(new PumpData(
+                Name:               parts[0].Trim(),
+                FlowRateGph:        ParseDouble(parts[1]),
+                PowerKw:            ParseDouble(parts[2]),
+                StartupCostDollars: ParseDouble(parts[3])
+            ));
+        }
+        if (Pumps.Count == 0)
+            throw new ArgumentException("At least one pump is required.");
+    }
+
+    // --- Shared parsing utilities (internal so solver/verifier can reuse) ---
+
+    // Splits s at top-level (depth=0) occurrences of sep, respecting (), {}, [].
+    internal static List<string> SplitTopLevel(string s, char sep)
+    {
+        var parts = new List<string>();
+        int depth = 0;
+        var cur = new System.Text.StringBuilder();
+        foreach (char c in s)
+        {
+            if (c is '(' or '{' or '[') depth++;
+            else if (c is ')' or '}' or ']') depth--;
+            if (c == sep && depth == 0) { parts.Add(cur.ToString()); cur.Clear(); }
+            else cur.Append(c);
+        }
+        if (cur.Length > 0) parts.Add(cur.ToString());
+        return parts;
+    }
+
+    // Strips outermost { } if present.
+    internal static string StripBraces(string s)
+    {
+        s = s.Trim();
+        return s.StartsWith("{") && s.EndsWith("}") ? s[1..^1].Trim() : s;
+    }
+
+    // Strips outermost ( ) if present.
+    internal static string StripParens(string s)
+    {
+        s = s.Trim();
+        return s.StartsWith("(") && s.EndsWith(")") ? s[1..^1].Trim() : s;
+    }
+
+    private static double ParseDouble(string s) =>
+        double.Parse(s.Trim(), System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using API.Interfaces;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
+
+namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
+
+class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
+{
+    // --- Fields ---
+    public string solverName { get; } = "Pump Scheduling CM — DAG Dynamic Programming";
+    public string solverDefinition { get; } =
+        "Models the 24-hour pump scheduling problem as a DAG where each node represents " +
+        "(hour, tank-level-bucket, previous-pump-mask). A forward pass computes the minimum-cost " +
+        "path from the initial state to any valid end state. The optimal schedule is recovered " +
+        "by backtracking through parent pointers.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "SARE 2026 Team" };
+    public bool timerHasExpired { get; set; }
+
+    private const int Hours = 24;
+    private const int Buckets = 1000; // tank discretization resolution
+    private const double Inf = double.MaxValue / 2;
+
+    public string solve(PUMPSCHEDULINGCM problem)
+    {
+        int n = problem.Pumps.Count;
+        int nMasks = 1 << n;
+        double cap = problem.TankCapacity;
+        double bucketSize = cap / Buckets;
+
+        // Converts a continuous tank level to the nearest bucket index [0, Buckets].
+        int ToBucket(double level) =>
+            Math.Clamp((int)Math.Round(level / bucketSize), 0, Buckets);
+
+        double ToLevel(int b) => b * bucketSize;
+
+        // Precompute total flow (gph) for each pump bitmask.
+        double[] maskFlow = new double[nMasks];
+        for (int mask = 0; mask < nMasks; mask++)
+            for (int p = 0; p < n; p++)
+                if ((mask & (1 << p)) != 0)
+                    maskFlow[mask] += problem.Pumps[p].FlowRateGph;
+
+        // Energy cost (dollars) of running pump mask for one hour at hour h.
+        double EnergyCost(int mask, int h)
+        {
+            double rate = problem.PeakHours.Contains(h)
+                ? problem.OnPeakCostPerKwh
+                : problem.OffPeakCostPerKwh;
+            double kw = 0;
+            for (int p = 0; p < n; p++)
+                if ((mask & (1 << p)) != 0)
+                    kw += problem.Pumps[p].PowerKw;
+            return kw * rate;
+        }
+
+        // Startup cost (dollars) for pumps that switch from off to on.
+        double StartupCost(int prevMask, int currMask)
+        {
+            double cost = 0;
+            int startups = (~prevMask) & currMask & (nMasks - 1);
+            for (int p = 0; p < n; p++)
+                if ((startups & (1 << p)) != 0)
+                    cost += problem.Pumps[p].StartupCostDollars;
+            return cost;
+        }
+
+        // DP state: dp[h, bucket, prevMask] = min cost to start hour h at that bucket
+        //           with prevMask being the pump action used during hour h-1.
+        int stateB = Buckets + 1;
+        double[,,] dp       = new double[Hours + 1, stateB, nMasks];
+        int[,,]    parentB  = new int   [Hours + 1, stateB, nMasks];
+        int[,,]    parentM  = new int   [Hours + 1, stateB, nMasks];
+
+        for (int h = 0; h <= Hours; h++)
+            for (int b = 0; b < stateB; b++)
+                for (int m = 0; m < nMasks; m++)
+                {
+                    dp[h, b, m] = Inf;
+                    parentB[h, b, m] = -1;
+                    parentM[h, b, m] = -1;
+                }
+
+        // Initial state: hour 0, initial tank bucket, no pumps previously running.
+        int initB = ToBucket(problem.TankCurrentLevel);
+        dp[0, initB, 0] = 0.0;
+
+        // Forward pass — propagate cheapest cost hour by hour.
+        for (int h = 0; h < Hours; h++)
+        {
+            if (timerHasExpired) return "{}";
+
+            double demand = problem.DemandGph[h];
+
+            for (int b = 0; b < stateB; b++)
+            {
+                double levelNow = ToLevel(b);
+
+                for (int prevMask = 0; prevMask < nMasks; prevMask++)
+                {
+                    double stateCost = dp[h, b, prevMask];
+                    if (stateCost >= Inf) continue;
+
+                    for (int mask = 0; mask < nMasks; mask++)
+                    {
+                        double newLevel = levelNow - demand + maskFlow[mask];
+                        if (newLevel < 0 || newLevel > cap) continue;
+
+                        int newB = ToBucket(newLevel);
+                        double stepCost = EnergyCost(mask, h) + StartupCost(prevMask, mask);
+                        double candidate = stateCost + stepCost;
+
+                        if (candidate < dp[h + 1, newB, mask])
+                        {
+                            dp[h + 1, newB, mask] = candidate;
+                            parentB[h + 1, newB, mask] = b;
+                            parentM[h + 1, newB, mask] = prevMask;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Find the minimum-cost reachable final state.
+        double minCost = Inf;
+        int bestB = -1, bestM = -1;
+        for (int b = 0; b < stateB; b++)
+            for (int m = 0; m < nMasks; m++)
+                if (dp[Hours, b, m] < minCost)
+                {
+                    minCost = dp[Hours, b, m];
+                    bestB = b;
+                    bestM = m;
+                }
+
+        if (bestB == -1) return "{}"; // No feasible schedule exists.
+
+        // Backtrack to recover the per-hour pump mask schedule.
+        // At state (h+1, b, m): m is the pump action applied during hour h.
+        int[] schedMasks = new int[Hours];
+        int curB = bestB, curM = bestM;
+        for (int h = Hours; h > 0; h--)
+        {
+            schedMasks[h - 1] = curM;
+            int pb = parentB[h, curB, curM];
+            int pm = parentM[h, curB, curM];
+            curB = pb;
+            curM = pm;
+        }
+
+        // Build certificate: (cost,{(PumpA,0,1,...),(PumpB,1,0,...)})
+        var sb = new StringBuilder("(");
+        sb.Append(Math.Round(minCost, 2).ToString(System.Globalization.CultureInfo.InvariantCulture));
+        sb.Append(",{");
+        for (int p = 0; p < n; p++)
+        {
+            if (p > 0) sb.Append(',');
+            sb.Append('(');
+            sb.Append(problem.Pumps[p].Name);
+            for (int h = 0; h < Hours; h++)
+            {
+                sb.Append(',');
+                sb.Append((schedMasks[h] & (1 << p)) != 0 ? 1 : 0);
+            }
+            sb.Append(')');
+        }
+        sb.Append("})");
+        return sb.ToString();
+    }
+}

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using API.Interfaces;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
+
+namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Verifiers;
+
+class PumpSchedulingCMVerifier : IVerifier<PUMPSCHEDULINGCM>
+{
+    // --- Fields ---
+    public string verifierName { get; } = "Pump Scheduling CM Verifier";
+    public string verifierDefinition { get; } =
+        "Parses the pump schedule from the certificate, simulates the 24-hour tank trajectory " +
+        "using exact arithmetic, and accepts if: (1) the tank stays within [0, capacity] at every hour, " +
+        "(2) the reported cost matches the computed energy and startup costs within $0.01 tolerance.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "SARE 2026 Team" };
+    public string certificate { get; private set; } = string.Empty;
+
+    private const double CostTolerance = 0.01;
+
+    public bool verify(PUMPSCHEDULINGCM problem, string cert)
+    {
+        certificate = cert ?? string.Empty;
+
+        // Strip outer parens: (cost,{schedule})
+        string s = certificate.Trim();
+        if (s.StartsWith("(") && s.EndsWith(")"))
+            s = s[1..^1].Trim();
+        if (s == "{}" || s.Length == 0) return false;
+
+        // Split into cost part and schedule part at the first top-level comma.
+        int splitIdx = FindFirstTopLevelComma(s);
+        if (splitIdx < 0) return false;
+
+        string costStr = s[..splitIdx].Trim();
+        string schedStr = s[(splitIdx + 1)..].Trim();
+
+        if (!double.TryParse(costStr, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out double reportedCost))
+            return false;
+
+        // Parse schedule: {(PumpName,h0,...,h23),...}
+        schedStr = PUMPSCHEDULINGCM.StripBraces(schedStr);
+        var pumpTuples = PUMPSCHEDULINGCM.SplitTopLevel(schedStr, ',');
+
+        int n = problem.Pumps.Count;
+        if (pumpTuples.Count != n) return false;
+
+        // schedules[p][h] = true if pump p is on during hour h
+        bool[,] on = new bool[n, 24];
+
+        for (int p = 0; p < n; p++)
+        {
+            string inner = PUMPSCHEDULINGCM.StripParens(pumpTuples[p].Trim());
+            var parts = PUMPSCHEDULINGCM.SplitTopLevel(inner, ',');
+            if (parts.Count != 25) return false;  // name + 24 hours
+
+            if (!string.Equals(parts[0].Trim(), problem.Pumps[p].Name, StringComparison.Ordinal))
+                return false;
+
+            for (int h = 0; h < 24; h++)
+            {
+                if (!int.TryParse(parts[h + 1].Trim(), out int v) || v is not (0 or 1))
+                    return false;
+                on[p, h] = v == 1;
+            }
+        }
+
+        // Simulate the schedule exactly — no bucket discretization.
+        double level = problem.TankCurrentLevel;
+        double totalCost = 0.0;
+        int prevMask = 0;
+
+        for (int h = 0; h < 24; h++)
+        {
+            int mask = 0;
+            double flowIn = 0.0;
+            double kw = 0.0;
+
+            for (int p = 0; p < n; p++)
+            {
+                if (!on[p, h]) continue;
+                mask |= (1 << p);
+                flowIn += problem.Pumps[p].FlowRateGph;
+                kw += problem.Pumps[p].PowerKw;
+            }
+
+            // Energy cost for this hour.
+            double rate = problem.PeakHours.Contains(h)
+                ? problem.OnPeakCostPerKwh
+                : problem.OffPeakCostPerKwh;
+            totalCost += kw * rate;
+
+            // Startup cost for pumps newly turned on this hour.
+            int startups = (~prevMask) & mask & ((1 << n) - 1);
+            for (int p = 0; p < n; p++)
+                if ((startups & (1 << p)) != 0)
+                    totalCost += problem.Pumps[p].StartupCostDollars;
+
+            prevMask = mask;
+
+            // Update tank level and check bounds.
+            level = level + flowIn - problem.DemandGph[h];
+            if (level < 0 || level > problem.TankCapacity)
+                return false;
+        }
+
+        // Reported cost must match the simulated cost within tolerance.
+        return Math.Abs(totalCost - reportedCost) <= CostTolerance;
+    }
+
+    // Returns the index of the first comma at bracket depth 0, or -1 if none.
+    private static int FindFirstTopLevelComma(string s)
+    {
+        int depth = 0;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c is '(' or '{' or '[') depth++;
+            else if (c is ')' or '}' or ']') depth--;
+            else if (c == ',' && depth == 0) return i;
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
Added Water-Energy Problem for Redux
This problem aims to find the cheapest combination of pumps chosen over 24 hours that provides the cheapest cost and still meets the demand water flow to a city and does not overflow the water tank.

Given inputs:
Tank capacity, tank current level
Demand gallons per minute each hour, on-peak hours, on-peak electrical cost, off-peak electrical cost
Pump Data (consisting of name, flow rate (in gallons per minute), cost per kW hour, and startup cost)

Outputs:
Minimum cost of using the system
The 24-hour schedule of how the pumps were turned on / off the get the cheapest possible cost

I also added support for all future NP-Hard problems in Problems/NPHard. This support is added here so this problem could be placed in the correct complexity under Problems/
I have this in the same pull request because the folder setup needs a problem to be able to check that it works.