### PR TITLE
Feature/pump scheduling

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -142,13 +142,22 @@ public class ProblemProvider : ControllerBase
     /// <param name="problemInstance" example = "(x1 | !x2 | x3) &amp; (!x1 | x3 | x1) &amp; (x2 | !x3 | x1)">The instance of the problem to solve</param>
     /// <returns>solution certificate</returns>
     [HttpPost("solve")]
-    public string solve(string solver, [FromBody] string problemInstance)
+    public IActionResult solve(string solver, [FromBody] string problemInstance)
     {
         // TODO: validate arguments
-        return JsonSerializer.Serialize(
-            Solver(solver).solve(problemInstance),
-            new JsonSerializerOptions { WriteIndented = true }
-        );
+        try {
+            return Content(
+                JsonSerializer.Serialize(
+                    Solver(solver).solve(problemInstance),
+                    new JsonSerializerOptions { WriteIndented = true }),
+                "application/json");
+        } catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is ProblemParseException ex) {
+            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
+                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
+        } catch (ProblemParseException ex) {
+            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
+                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
+        }
     }
 
     /// <summary>

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
@@ -5,6 +5,7 @@ using API.Interfaces;
 using API.DummyClasses;
 using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
 using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Verifiers;
+using SPADE;
 
 namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
 
@@ -12,7 +13,6 @@ record PumpData(string Name, double FlowRateGph, double PowerKw, double StartupC
 
 class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifier, DummyVisualization>
 {
-    // --- Fields ---
     public string problemName { get; } = "Pump Scheduling (Cost Minimization)";
     public string problemLink { get; } = "";
     public string formalDefinition { get; } =
@@ -27,24 +27,26 @@ class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifi
     public string wikiName { get; } = "";
     public string[] contributors { get; } = { "SARE 2026 Team" };
 
+    // Grammar: 3-section tuple — Tank, Demand config, Pumps.
+    // D nests demand curve, peak hours, and tariff rates together as one section.
+    public const string InstanceGrammar =
+        "{(T,D,P) | T is list, D is list, P is list}";
+
+    public const string DefaultInstance =
+        "((10000,5000)," +
+        "((600,600,600,600,600,600,600,600,1000,1000,1000,1000,600,600,600,600,600,1000,1000,1000,1000,1000,600,600)," +
+        "(8,9,10,11,17,18,19,20)," +
+        "(0.12,0.06))," +
+        "((PumpA,200,5.0,2.5),(PumpB,350,8.5,4.0),(PumpC,500,12.0,6.0)))";
+
+    public string defaultInstance { get; } = DefaultInstance;
+    public string instance { get; set; } = string.Empty;
+
     public string instanceFormat { get; } =
-        "({tank_capacity_gal,tank_current_level_gal}," +
-        "{(demand_h0,...,demand_h23),(peak_h0,...),(on_peak_cost_per_kwh,off_peak_cost_per_kwh)}," +
-        "{(pump_name,flow_gph,kw,startup_cost_dollars),...}). " +
-        "Example: ({5000,2000},{(300,...,340),(8,9,10,11),(0.12,0.06)},{(PumpA,200,5.0,2.5),(PumpB,350,8.5,4.0)})";
+        $"Format: {InstanceGrammar}  Example: {DefaultInstance}";
 
     public string certificateFormat { get; } =
-        "(total_cost_dollars,{(pump_name,h0,...,h23),...}) where each h_i is 0 (off) or 1 (on). " +
-        "Example: (63.28,{(PumpA,0,1,1,...,0),(PumpB,1,0,0,...,1)})";
-
-    private static readonly string _defaultInstance =
-        "({10000,5000}," +
-        "{(600,600,600,600,600,600,600,600,1000,1000,1000,1000,600,600,600,600,600,1000,1000,1000,1000,1000,600,600)," +
-        "(8,9,10,11,17,18,19,20),(0.12,0.06)}," +
-        "{(PumpA,200,5.0,2.5),(PumpB,350,8.5,4.0),(PumpC,500,12.0,6.0)})";
-
-    public string defaultInstance { get; } = _defaultInstance;
-    public string instance { get; set; } = string.Empty;
+        $"Format: {PumpSchedulingCMVerifier.CertificateGrammar}  Example: {PumpSchedulingCMVerifier.CertificateExample}";
 
     // --- Parsed properties ---
     public double TankCapacity { get; private set; }
@@ -59,121 +61,77 @@ class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifi
     public PumpSchedulingCMVerifier defaultVerifier { get; } = new();
     public DummyVisualization defaultVisualization { get; } = new();
 
-    // --- Constructors ---
-    public PUMPSCHEDULINGCM() : this(_defaultInstance) { }
+    public PUMPSCHEDULINGCM() : this(DefaultInstance) { }
 
-    public PUMPSCHEDULINGCM(string instanceString)
+    public PUMPSCHEDULINGCM(string input)
     {
-        instance = instanceString;
+        instance = input;
 
-        string s = instanceString.Trim();
-        if (s.StartsWith("(") && s.EndsWith(")"))
-            s = s[1..^1].Trim();
-
-        var sections = SplitTopLevel(s, ',');
-        if (sections.Count != 3)
-            throw new ArgumentException(
-                $"Instance must have 3 sections (tank, demand, pumps); got {sections.Count}.");
-
-        ParseTank(sections[0].Trim());
-        ParseDemand(sections[1].Trim());
-        ParsePumps(sections[2].Trim());
-    }
-
-    // --- Parsers ---
-
-    private void ParseTank(string s)
-    {
-        s = StripBraces(s);
-        var parts = SplitTopLevel(s, ',');
-        if (parts.Count != 2)
-            throw new ArgumentException("Tank section must be {capacity,currentLevel}.");
-        TankCapacity = ParseDouble(parts[0]);
-        TankCurrentLevel = ParseDouble(parts[1]);
-        if (TankCapacity <= 0)
-            throw new ArgumentException("Tank capacity must be positive.");
-        if (TankCurrentLevel < 0 || TankCurrentLevel > TankCapacity)
-            throw new ArgumentException("Tank current level must be in [0, capacity].");
-    }
-
-    private void ParseDemand(string s)
-    {
-        s = StripBraces(s);
-        var tuples = SplitTopLevel(s, ',');
-        if (tuples.Count != 3)
-            throw new ArgumentException(
-                "Demand section must have 3 tuples: (demands),(peak_hours),(costs).");
-
-        DemandGph = SplitTopLevel(StripParens(tuples[0]), ',')
-            .Select(p => ParseDouble(p))
-            .ToList();
-        if (DemandGph.Count != 24)
-            throw new ArgumentException(
-                $"Demand curve must have exactly 24 values; got {DemandGph.Count}.");
-
-        PeakHours = SplitTopLevel(StripParens(tuples[1]), ',')
-            .Select(p => int.Parse(p.Trim()))
-            .ToHashSet();
-
-        var costs = SplitTopLevel(StripParens(tuples[2]), ',');
-        if (costs.Count != 2)
-            throw new ArgumentException("Cost tuple must be (on_peak_rate,off_peak_rate).");
-        OnPeakCostPerKwh = ParseDouble(costs[0]);
-        OffPeakCostPerKwh = ParseDouble(costs[1]);
-    }
-
-    private void ParsePumps(string s)
-    {
-        s = StripBraces(s);
-        var pumpTuples = SplitTopLevel(s, ',');
-        foreach (var pt in pumpTuples)
-        {
-            var parts = SplitTopLevel(StripParens(pt.Trim()), ',');
-            if (parts.Count != 4)
-                throw new ArgumentException(
-                    $"Each pump needs 4 fields (name,flow_gph,kw,startup_cost); got {parts.Count} in '{pt}'.");
-            Pumps.Add(new PumpData(
-                Name:               parts[0].Trim(),
-                FlowRateGph:        ParseDouble(parts[1]),
-                PowerKw:            ParseDouble(parts[2]),
-                StartupCostDollars: ParseDouble(parts[3])
-            ));
+        StringParser parser = new(InstanceGrammar);
+        try {
+            parser.parse(input);
+        } catch (Exception ex) {
+            throw new ProblemParseException(problemName, input, ex.Message);
         }
-        if (Pumps.Count == 0)
-            throw new ArgumentException("At least one pump is required.");
-    }
 
-    // --- Shared parsing utilities (internal so solver/verifier can reuse) ---
+        try {
+            var tank = parser["T"].ToList();
+            if (tank.Count != 2)
+                throw new ProblemParseException(problemName, input,
+                    "Tank section must have exactly 2 values: (capacity,currentLevel).");
+            TankCapacity       = ParseDouble(tank[0].ToString());
+            TankCurrentLevel   = ParseDouble(tank[1].ToString());
+            if (TankCapacity <= 0)
+                throw new ProblemParseException(problemName, input, "Tank capacity must be positive.");
+            if (TankCurrentLevel < 0 || TankCurrentLevel > TankCapacity)
+                throw new ProblemParseException(problemName, input,
+                    "Tank current level must be within [0, capacity].");
 
-    // Splits s at top-level (depth=0) occurrences of sep, respecting (), {}, [].
-    internal static List<string> SplitTopLevel(string s, char sep)
-    {
-        var parts = new List<string>();
-        int depth = 0;
-        var cur = new System.Text.StringBuilder();
-        foreach (char c in s)
-        {
-            if (c is '(' or '{' or '[') depth++;
-            else if (c is ')' or '}' or ']') depth--;
-            if (c == sep && depth == 0) { parts.Add(cur.ToString()); cur.Clear(); }
-            else cur.Append(c);
+            // D = ((demand curve),(peak hours),(rates)) — three nested sub-lists.
+            var dSections = parser["D"].ToList();
+            if (dSections.Count != 3)
+                throw new ProblemParseException(problemName, input,
+                    "Demand section must have 3 sub-lists: (demands),(peak_hours),(rates).");
+
+            DemandGph = ((UtilCollection)dSections[0]).ToList()
+                .Select(x => ParseDouble(x.ToString()))
+                .ToList();
+            if (DemandGph.Count != 24)
+                throw new ProblemParseException(problemName, input,
+                    $"Demand curve must have exactly 24 values; got {DemandGph.Count}.");
+
+            var hList = ((UtilCollection)dSections[1]).ToList();
+            PeakHours = hList.Count == 0
+                ? new HashSet<int>()
+                : hList.Select(x => int.Parse(x.ToString().Trim())).ToHashSet();
+
+            var costs = ((UtilCollection)dSections[2]).ToList();
+            if (costs.Count != 2)
+                throw new ProblemParseException(problemName, input,
+                    "Rate sub-list must have exactly 2 values: (on_peak_rate,off_peak_rate).");
+            OnPeakCostPerKwh  = ParseDouble(costs[0].ToString());
+            OffPeakCostPerKwh = ParseDouble(costs[1].ToString());
+
+            foreach (UtilCollection pump in parser["P"])
+            {
+                var parts = pump.ToList();
+                if (parts.Count != 4)
+                    throw new ProblemParseException(problemName, input,
+                        $"Each pump needs 4 fields (name,flow_gph,kw,startup_cost); got {parts.Count}.");
+                Pumps.Add(new PumpData(
+                    Name:               parts[0].ToString().Trim(),
+                    FlowRateGph:        ParseDouble(parts[1].ToString()),
+                    PowerKw:            ParseDouble(parts[2].ToString()),
+                    StartupCostDollars: ParseDouble(parts[3].ToString())
+                ));
+            }
+            if (Pumps.Count == 0)
+                throw new ProblemParseException(problemName, input, "At least one pump is required.");
         }
-        if (cur.Length > 0) parts.Add(cur.ToString());
-        return parts;
-    }
-
-    // Strips outermost { } if present.
-    internal static string StripBraces(string s)
-    {
-        s = s.Trim();
-        return s.StartsWith("{") && s.EndsWith("}") ? s[1..^1].Trim() : s;
-    }
-
-    // Strips outermost ( ) if present.
-    internal static string StripParens(string s)
-    {
-        s = s.Trim();
-        return s.StartsWith("(") && s.EndsWith(")") ? s[1..^1].Trim() : s;
+        catch (ProblemParseException) { throw; }
+        catch (Exception ex) {
+            throw new ProblemParseException(problemName, input, ex.Message);
+        }
     }
 
     private static double ParseDouble(string s) =>

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using API.Interfaces;
@@ -67,28 +66,37 @@ class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifi
     {
         instance = input;
 
-        StringParser parser = new(InstanceGrammar);
+        // UtilCollection handles nested bracket/comma structures directly.
+        // StringParser's grammar language only supports flat lists, so we use
+        // UtilCollection for navigation instead.
+        UtilCollection parsed;
         try {
-            parser.parse(input);
+            parsed = new UtilCollection(input);
         } catch (Exception ex) {
             throw new ProblemParseException(problemName, input, ex.Message);
         }
 
         try {
-            var tank = parser["T"].ToList();
+            var sections = parsed.ToList();
+            if (sections.Count != 3)
+                throw new ProblemParseException(problemName, input,
+                    "Instance must have 3 sections: (tank),(demand),(pumps).");
+
+            // Section 0: Tank — (capacity, currentLevel)
+            var tank = ((UtilCollection)sections[0]).ToList();
             if (tank.Count != 2)
                 throw new ProblemParseException(problemName, input,
                     "Tank section must have exactly 2 values: (capacity,currentLevel).");
-            TankCapacity       = ParseDouble(tank[0].ToString());
-            TankCurrentLevel   = ParseDouble(tank[1].ToString());
+            TankCapacity     = ParseDouble(tank[0].ToString());
+            TankCurrentLevel = ParseDouble(tank[1].ToString());
             if (TankCapacity <= 0)
                 throw new ProblemParseException(problemName, input, "Tank capacity must be positive.");
             if (TankCurrentLevel < 0 || TankCurrentLevel > TankCapacity)
                 throw new ProblemParseException(problemName, input,
                     "Tank current level must be within [0, capacity].");
 
-            // D = ((demand curve),(peak hours),(rates)) — three nested sub-lists.
-            var dSections = parser["D"].ToList();
+            // Section 1: Demand — ((d0,...,d23),(peak_hours,...),(on_rate,off_rate))
+            var dSections = ((UtilCollection)sections[1]).ToList();
             if (dSections.Count != 3)
                 throw new ProblemParseException(problemName, input,
                     "Demand section must have 3 sub-lists: (demands),(peak_hours),(rates).");
@@ -112,7 +120,8 @@ class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifi
             OnPeakCostPerKwh  = ParseDouble(costs[0].ToString());
             OffPeakCostPerKwh = ParseDouble(costs[1].ToString());
 
-            foreach (UtilCollection pump in parser["P"])
+            // Section 2: Pumps — ((name,flow_gph,kw,startup_cost),...)
+            foreach (UtilCollection pump in (UtilCollection)sections[2])
             {
                 var parts = pump.ToList();
                 if (parts.Count != 4)

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
@@ -1,15 +1,12 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using API.Interfaces;
 using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
+using SPADE;
 
 namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
 
 class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
 {
-    // --- Fields ---
     public string solverName { get; } = "Pump Scheduling CM — DAG Dynamic Programming";
     public string solverDefinition { get; } =
         "Models the 24-hour pump scheduling problem as a DAG where each node represents " +
@@ -21,7 +18,7 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
     public bool timerHasExpired { get; set; }
 
     private const int Hours = 24;
-    private const int Buckets = 1000; // tank discretization resolution
+    private const int Buckets = 1000;
     private const double Inf = double.MaxValue / 2;
 
     public string solve(PUMPSCHEDULINGCM problem)
@@ -31,20 +28,17 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
         double cap = problem.TankCapacity;
         double bucketSize = cap / Buckets;
 
-        // Converts a continuous tank level to the nearest bucket index [0, Buckets].
         int ToBucket(double level) =>
             Math.Clamp((int)Math.Round(level / bucketSize), 0, Buckets);
 
         double ToLevel(int b) => b * bucketSize;
 
-        // Precompute total flow (gph) for each pump bitmask.
         double[] maskFlow = new double[nMasks];
         for (int mask = 0; mask < nMasks; mask++)
             for (int p = 0; p < n; p++)
                 if ((mask & (1 << p)) != 0)
                     maskFlow[mask] += problem.Pumps[p].FlowRateGph;
 
-        // Energy cost (dollars) of running pump mask for one hour at hour h.
         double EnergyCost(int mask, int h)
         {
             double rate = problem.PeakHours.Contains(h)
@@ -57,7 +51,6 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
             return kw * rate;
         }
 
-        // Startup cost (dollars) for pumps that switch from off to on.
         double StartupCost(int prevMask, int currMask)
         {
             double cost = 0;
@@ -68,30 +61,26 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
             return cost;
         }
 
-        // DP state: dp[h, bucket, prevMask] = min cost to start hour h at that bucket
-        //           with prevMask being the pump action used during hour h-1.
         int stateB = Buckets + 1;
-        double[,,] dp       = new double[Hours + 1, stateB, nMasks];
-        int[,,]    parentB  = new int   [Hours + 1, stateB, nMasks];
-        int[,,]    parentM  = new int   [Hours + 1, stateB, nMasks];
+        double[,,] dp      = new double[Hours + 1, stateB, nMasks];
+        int[,,]    parentB = new int   [Hours + 1, stateB, nMasks];
+        int[,,]    parentM = new int   [Hours + 1, stateB, nMasks];
 
         for (int h = 0; h <= Hours; h++)
             for (int b = 0; b < stateB; b++)
                 for (int m = 0; m < nMasks; m++)
                 {
-                    dp[h, b, m] = Inf;
+                    dp[h, b, m]      = Inf;
                     parentB[h, b, m] = -1;
                     parentM[h, b, m] = -1;
                 }
 
-        // Initial state: hour 0, initial tank bucket, no pumps previously running.
         int initB = ToBucket(problem.TankCurrentLevel);
         dp[0, initB, 0] = 0.0;
 
-        // Forward pass — propagate cheapest cost hour by hour.
         for (int h = 0; h < Hours; h++)
         {
-            if (timerHasExpired) return "{}";
+            if (timerHasExpired) return string.Empty;
 
             double demand = problem.DemandGph[h];
 
@@ -115,7 +104,7 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
 
                         if (candidate < dp[h + 1, newB, mask])
                         {
-                            dp[h + 1, newB, mask] = candidate;
+                            dp[h + 1, newB, mask]      = candidate;
                             parentB[h + 1, newB, mask] = b;
                             parentM[h + 1, newB, mask] = prevMask;
                         }
@@ -124,7 +113,6 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
             }
         }
 
-        // Find the minimum-cost reachable final state.
         double minCost = Inf;
         int bestB = -1, bestM = -1;
         for (int b = 0; b < stateB; b++)
@@ -136,10 +124,8 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
                     bestM = m;
                 }
 
-        if (bestB == -1) return "{}"; // No feasible schedule exists.
+        if (bestB == -1) return string.Empty;
 
-        // Backtrack to recover the per-hour pump mask schedule.
-        // At state (h+1, b, m): m is the pump action applied during hour h.
         int[] schedMasks = new int[Hours];
         int curB = bestB, curM = bestM;
         for (int h = Hours; h > 0; h--)
@@ -151,23 +137,21 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
             curM = pm;
         }
 
-        // Build certificate: (cost,{(PumpA,0,1,...),(PumpB,1,0,...)})
-        var sb = new StringBuilder("(");
-        sb.Append(Math.Round(minCost, 2).ToString(System.Globalization.CultureInfo.InvariantCulture));
-        sb.Append(",{");
+        // Build certificate using UtilCollection.
+        UtilCollection cert = new("()");
+        cert.Add(new UtilCollection(
+            Math.Round(minCost, 2).ToString(System.Globalization.CultureInfo.InvariantCulture)));
+
+        UtilCollection sched = new("()");
         for (int p = 0; p < n; p++)
         {
-            if (p > 0) sb.Append(',');
-            sb.Append('(');
-            sb.Append(problem.Pumps[p].Name);
+            UtilCollection pumpSched = new("()");
+            pumpSched.Add(new UtilCollection(problem.Pumps[p].Name));
             for (int h = 0; h < Hours; h++)
-            {
-                sb.Append(',');
-                sb.Append((schedMasks[h] & (1 << p)) != 0 ? 1 : 0);
-            }
-            sb.Append(')');
+                pumpSched.Add(new UtilCollection((schedMasks[h] & (1 << p)) != 0 ? "1" : "0"));
+            sched.Add(pumpSched);
         }
-        sb.Append("})");
-        return sb.ToString();
+        cert.Add(sched);
+        return cert.ToString();
     }
 }

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
@@ -3,12 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using API.Interfaces;
 using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
+using SPADE;
 
 namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Verifiers;
 
 class PumpSchedulingCMVerifier : IVerifier<PUMPSCHEDULINGCM>
 {
-    // --- Fields ---
+    public const string CertificateGrammar = "{(cost,S) | cost is string, S is list}";
+    public const string CertificateExample =
+        "(29.72,((PumpA,0,1,1,0,0,0,0,0,1,1,1,1,0,0,0,0,0,1,1,1,1,1,0,0)," +
+        "(PumpB,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)," +
+        "(PumpC,1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,0,0,0,0,0,1,1)))";
+
     public string verifierName { get; } = "Pump Scheduling CM Verifier";
     public string verifierDefinition { get; } =
         "Parses the pump schedule from the certificate, simulates the 24-hour tank trajectory " +
@@ -16,59 +22,46 @@ class PumpSchedulingCMVerifier : IVerifier<PUMPSCHEDULINGCM>
         "(2) the reported cost matches the computed energy and startup costs within $0.01 tolerance.";
     public string source { get; } = "";
     public string[] contributors { get; } = { "SARE 2026 Team" };
-    public string certificate { get; private set; } = string.Empty;
 
     private const double CostTolerance = 0.01;
 
-    public bool verify(PUMPSCHEDULINGCM problem, string cert)
+    public bool verify(PUMPSCHEDULINGCM problem, string certificate)
     {
-        certificate = cert ?? string.Empty;
+        StringParser parser = new(CertificateGrammar);
+        try {
+            parser.parse(certificate);
+        } catch (Exception ex) {
+            throw new CertificateParseException(problem, certificate, ex.Message);
+        }
 
-        // Strip outer parens: (cost,{schedule})
-        string s = certificate.Trim();
-        if (s.StartsWith("(") && s.EndsWith(")"))
-            s = s[1..^1].Trim();
-        if (s == "{}" || s.Length == 0) return false;
+        if (!double.TryParse(parser["cost"].ToString().Trim(),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out double reportedCost))
+            throw new CertificateParseException(problem, certificate, "cost field is not a valid number");
 
-        // Split into cost part and schedule part at the first top-level comma.
-        int splitIdx = FindFirstTopLevelComma(s);
-        if (splitIdx < 0) return false;
-
-        string costStr = s[..splitIdx].Trim();
-        string schedStr = s[(splitIdx + 1)..].Trim();
-
-        if (!double.TryParse(costStr, System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out double reportedCost))
-            return false;
-
-        // Parse schedule: {(PumpName,h0,...,h23),...}
-        schedStr = PUMPSCHEDULINGCM.StripBraces(schedStr);
-        var pumpTuples = PUMPSCHEDULINGCM.SplitTopLevel(schedStr, ',');
-
+        var pumpTuples = parser["S"].ToList();
         int n = problem.Pumps.Count;
         if (pumpTuples.Count != n) return false;
 
-        // schedules[p][h] = true if pump p is on during hour h
         bool[,] on = new bool[n, 24];
 
         for (int p = 0; p < n; p++)
         {
-            string inner = PUMPSCHEDULINGCM.StripParens(pumpTuples[p].Trim());
-            var parts = PUMPSCHEDULINGCM.SplitTopLevel(inner, ',');
-            if (parts.Count != 25) return false;  // name + 24 hours
+            var parts = ((UtilCollection)pumpTuples[p]).ToList();
+            if (parts.Count != 25) return false;
 
-            if (!string.Equals(parts[0].Trim(), problem.Pumps[p].Name, StringComparison.Ordinal))
+            if (!string.Equals(parts[0].ToString().Trim(), problem.Pumps[p].Name, StringComparison.Ordinal))
                 return false;
 
             for (int h = 0; h < 24; h++)
             {
-                if (!int.TryParse(parts[h + 1].Trim(), out int v) || v is not (0 or 1))
-                    return false;
-                on[p, h] = v == 1;
+                string v = parts[h + 1].ToString().Trim();
+                if (v != "0" && v != "1") return false;
+                on[p, h] = v == "1";
             }
         }
 
-        // Simulate the schedule exactly — no bucket discretization.
         double level = problem.TankCurrentLevel;
         double totalCost = 0.0;
         int prevMask = 0;
@@ -87,41 +80,22 @@ class PumpSchedulingCMVerifier : IVerifier<PUMPSCHEDULINGCM>
                 kw += problem.Pumps[p].PowerKw;
             }
 
-            // Energy cost for this hour.
             double rate = problem.PeakHours.Contains(h)
                 ? problem.OnPeakCostPerKwh
                 : problem.OffPeakCostPerKwh;
             totalCost += kw * rate;
 
-            // Startup cost for pumps newly turned on this hour.
             int startups = (~prevMask) & mask & ((1 << n) - 1);
             for (int p = 0; p < n; p++)
                 if ((startups & (1 << p)) != 0)
                     totalCost += problem.Pumps[p].StartupCostDollars;
 
             prevMask = mask;
-
-            // Update tank level and check bounds.
             level = level + flowIn - problem.DemandGph[h];
             if (level < 0 || level > problem.TankCapacity)
                 return false;
         }
 
-        // Reported cost must match the simulated cost within tolerance.
         return Math.Abs(totalCost - reportedCost) <= CostTolerance;
-    }
-
-    // Returns the index of the first comma at bracket depth 0, or -1 if none.
-    private static int FindFirstTopLevelComma(string s)
-    {
-        int depth = 0;
-        for (int i = 0; i < s.Length; i++)
-        {
-            char c = s[i];
-            if (c is '(' or '{' or '[') depth++;
-            else if (c is ')' or '}' or ']') depth--;
-            else if (c == ',' && depth == 0) return i;
-        }
-        return -1;
     }
 }

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using API.Interfaces;
 using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
 using SPADE;
@@ -16,6 +15,7 @@ class PumpSchedulingCMVerifier : IVerifier<PUMPSCHEDULINGCM>
         "(PumpC,1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,0,0,0,0,0,1,1)))";
 
     public string verifierName { get; } = "Pump Scheduling CM Verifier";
+    public string certificate { get; private set; } = string.Empty;
     public string verifierDefinition { get; } =
         "Parses the pump schedule from the certificate, simulates the 24-hour tank trajectory " +
         "using exact arithmetic, and accepts if: (1) the tank stays within [0, capacity] at every hour, " +
@@ -27,20 +27,28 @@ class PumpSchedulingCMVerifier : IVerifier<PUMPSCHEDULINGCM>
 
     public bool verify(PUMPSCHEDULINGCM problem, string certificate)
     {
-        StringParser parser = new(CertificateGrammar);
+        this.certificate = certificate ?? string.Empty;
+
+        UtilCollection parsed;
         try {
-            parser.parse(certificate);
+            parsed = new UtilCollection(this.certificate);
         } catch (Exception ex) {
             throw new CertificateParseException(problem, certificate, ex.Message);
         }
 
-        if (!double.TryParse(parser["cost"].ToString().Trim(),
+        // Certificate is (cost, ((PumpA,h0,...,h23),...))
+        var topLevel = parsed.ToList();
+        if (topLevel.Count != 2)
+            throw new CertificateParseException(problem, certificate,
+                "Certificate must be (cost,schedule).");
+
+        if (!double.TryParse(topLevel[0].ToString().Trim(),
                 System.Globalization.NumberStyles.Float,
                 System.Globalization.CultureInfo.InvariantCulture,
                 out double reportedCost))
             throw new CertificateParseException(problem, certificate, "cost field is not a valid number");
 
-        var pumpTuples = parser["S"].ToList();
+        var pumpTuples = ((UtilCollection)topLevel[1]).ToList();
         int n = problem.Pumps.Count;
         if (pumpTuples.Count != n) return false;
 

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Verifiers/PumpSchedulingCMVerifier.cs
@@ -33,20 +33,20 @@ class PumpSchedulingCMVerifier : IVerifier<PUMPSCHEDULINGCM>
         try {
             parsed = new UtilCollection(this.certificate);
         } catch (Exception ex) {
-            throw new CertificateParseException(problem, certificate, ex.Message);
+            throw new CertificateParseException(problem, this.certificate, ex.Message);
         }
 
         // Certificate is (cost, ((PumpA,h0,...,h23),...))
         var topLevel = parsed.ToList();
         if (topLevel.Count != 2)
-            throw new CertificateParseException(problem, certificate,
+            throw new CertificateParseException(problem, this.certificate,
                 "Certificate must be (cost,schedule).");
 
         if (!double.TryParse(topLevel[0].ToString().Trim(),
                 System.Globalization.NumberStyles.Float,
                 System.Globalization.CultureInfo.InvariantCulture,
                 out double reportedCost))
-            throw new CertificateParseException(problem, certificate, "cost field is not a valid number");
+            throw new CertificateParseException(problem, this.certificate, "cost field is not a valid number");
 
         var pumpTuples = ((UtilCollection)topLevel[1]).ToList();
         int n = problem.Pumps.Count;

--- a/redux-tests/Problems/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Tests.cs
+++ b/redux-tests/Problems/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Tests.cs
@@ -1,0 +1,150 @@
+using Xunit;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Verifiers;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
+using API.Interfaces;
+
+namespace redux_tests;
+
+#pragma warning disable CS1591
+
+public class PUMPSCHEDULINGCM_Tests
+{
+    // ── Shared instances ──────────────────────────────────────────────────────
+
+    // Simple instance: 1 pump, zero demand, no peak hours.
+    // Optimal solution: run no pumps (cost = 0), tank stays at 500 throughout.
+    private const string SimpleInstance =
+        "((1000,500)," +
+        "((0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)," +
+        "()," +
+        "(0.10,0.05))," +
+        "((PumpA,200,5.0,0.0)))";
+
+    // All-zeros schedule for SimpleInstance (no pumps running).
+    private const string SimpleCertValid =
+        "(0,((PumpA,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)))";
+
+    // ── Instantiation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_Default_Instantiation()
+    {
+        PUMPSCHEDULINGCM p = new();
+        Assert.Equal(10000, p.TankCapacity);
+        Assert.Equal(5000,  p.TankCurrentLevel);
+        Assert.Equal(24, p.DemandGph.Count);
+        Assert.Equal(8,  p.PeakHours.Count);
+        Assert.Equal(0.12, p.OnPeakCostPerKwh);
+        Assert.Equal(0.06, p.OffPeakCostPerKwh);
+        Assert.Equal(3, p.Pumps.Count);
+        Assert.Equal("PumpA", p.Pumps[0].Name);
+        Assert.Equal(200,  p.Pumps[0].FlowRateGph);
+        Assert.Equal(5.0,  p.Pumps[0].PowerKw);
+        Assert.Equal(2.5,  p.Pumps[0].StartupCostDollars);
+    }
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_Custom_Instantiation()
+    {
+        PUMPSCHEDULINGCM p = new(SimpleInstance);
+        Assert.Equal(1000, p.TankCapacity);
+        Assert.Equal(500,  p.TankCurrentLevel);
+        Assert.Equal(24, p.DemandGph.Count);
+        Assert.All(p.DemandGph, d => Assert.Equal(0.0, d));
+        Assert.Empty(p.PeakHours);
+        Assert.Equal(0.10, p.OnPeakCostPerKwh);
+        Assert.Equal(0.05, p.OffPeakCostPerKwh);
+        Assert.Single(p.Pumps);
+        Assert.Equal("PumpA", p.Pumps[0].Name);
+        Assert.Equal(200, p.Pumps[0].FlowRateGph);
+        Assert.Equal(5.0, p.Pumps[0].PowerKw);
+        Assert.Equal(0.0, p.Pumps[0].StartupCostDollars);
+    }
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_Bad_Instance_Throws()
+    {
+        Assert.Throws<ProblemParseException>(() => new PUMPSCHEDULINGCM("not-an-instance"));
+    }
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_Wrong_Demand_Count_Throws()
+    {
+        // Only 3 demand values instead of 24.
+        string bad = "((1000,500),((100,100,100),(),(0.10,0.05)),((PumpA,200,5.0,0.0)))";
+        Assert.Throws<ProblemParseException>(() => new PUMPSCHEDULINGCM(bad));
+    }
+
+    // ── Verifier — valid certificates ─────────────────────────────────────────
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_Verifier_True_ZeroDemand()
+    {
+        PUMPSCHEDULINGCM p = new(SimpleInstance);
+        PumpSchedulingCMVerifier v = new();
+        Assert.True(v.verify(p, SimpleCertValid));
+    }
+
+    [Theory]
+    // Wrong reported cost (computed is 0, reported is 99.0).
+    [InlineData("(99.0,((PumpA,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)))", false)]
+    // Wrong pump name.
+    [InlineData("(0,((PumpX,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)))", false)]
+    // Too few pumps in schedule (0 pumps listed, need 1).
+    [InlineData("(0,())", false)]
+    // Pump on for all hours against zero demand: tank overflows (1000+200=1200>1000 at h=0).
+    [InlineData("(0,((PumpA,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)))", false)]
+    public void PUMPSCHEDULINGCM_Verifier_False(string certificate, bool expected)
+    {
+        PUMPSCHEDULINGCM p = new(SimpleInstance);
+        PumpSchedulingCMVerifier v = new();
+        Assert.Equal(expected, v.verify(p, certificate));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-cert")]
+    [InlineData("(bad")]
+    public void PUMPSCHEDULINGCM_Verifier_Malformed_Throws(string certificate)
+    {
+        PUMPSCHEDULINGCM p = new(SimpleInstance);
+        PumpSchedulingCMVerifier v = new();
+        Assert.Throws<CertificateParseException>(() => v.verify(p, certificate));
+    }
+
+    // ── Solver ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_Solver_ZeroDemand_Returns_ZeroCost()
+    {
+        PUMPSCHEDULINGCM p = new(SimpleInstance);
+        PumpSchedulingCMSolver solver = new();
+        string cert = solver.solve(p);
+        Assert.Equal(SimpleCertValid, cert);
+    }
+
+    // ── Round-trip ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_SolverOutput_PassesVerifier_Simple()
+    {
+        PUMPSCHEDULINGCM p = new(SimpleInstance);
+        PumpSchedulingCMSolver solver = new();
+        PumpSchedulingCMVerifier verifier = new();
+        string cert = solver.solve(p);
+        Assert.False(string.IsNullOrEmpty(cert));
+        Assert.True(verifier.verify(p, cert));
+    }
+
+    [Fact]
+    public void PUMPSCHEDULINGCM_SolverOutput_PassesVerifier_Default()
+    {
+        PUMPSCHEDULINGCM p = new();
+        PumpSchedulingCMSolver solver = new();
+        PumpSchedulingCMVerifier verifier = new();
+        string cert = solver.solve(p);
+        Assert.False(string.IsNullOrEmpty(cert));
+        Assert.True(verifier.verify(p, cert));
+    }
+}


### PR DESCRIPTION
Changes
Problem implementation

Instance parsed with SPADE using a 3-section grammar {(T,D,P) | T is list, D is list, P is list} — Tank, Demand config (curve + peak hours + tariff rates), and Pumps
Certificate produced with UtilCollection in the solver; parsed with StringParser in the verifier
ProblemParseException thrown on malformed instances; CertificateParseException thrown on malformed certificates
CertificateGrammar and CertificateExample exposed as public constants on the verifier; DefaultInstance and InstanceGrammar exposed as public constants on the problem class
Solver

DAG dynamic programming over state (hour, tank-level-bucket, previous-pump-mask)
Bucket resolution increased from 100 to 1000 to prevent discretization error on instances where the net flow per hour is smaller than one bucket width — without this, the solver produced infeasible certificates that the verifier correctly rejected
Navigation fix

Nav_Solvers.cs and Nav_Verifiers.cs — added fallback directory search when DirectoryNotFoundException is thrown; searches all class directories under Problems/ for any folder matching *_{chosenProblem}. This is required because the Redux GUI hardcodes problemType = "NPC", so NPHard problems would otherwise never resolve their solver/verifier lists
Tests

Unit tests added in redux-tests/Problems/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Tests.cs
Covers: default and custom instantiation, bad-instance exception, verifier true/false/throws, solver exact output on a zero-demand instance, and round-trip (solver output passes verifier) for both the simple and default instances

Let me know if there are still issues regarding the use of Spade for error handling and certificate