### PR TITLE
ExactCover viz: parse solution with SPADE, fix nullable warnings

### DIFF
--- a/Problems/NPComplete/NPC_EXACTCOVER/Visualizations/ExactCoverDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_EXACTCOVER/Visualizations/ExactCoverDefaultVisualization.cs
@@ -27,29 +27,32 @@ class ExactCoverDefaultVisualization : IVisualization<EXACTCOVER>
     }
     public API_JSON SolvedVisualization(EXACTCOVER exactCover, string solution)
     {
-        //return new API_SET(new UtilCollection(exactCover.instance));
         API_SET ec = new API_SET(new UtilCollection(exactCover.instance));
 
-        List<string> results = solution
-            .Trim('{', '}')
-            .Split("},{")
-            .Select(x => x.Trim('{', '}'))
-            .Select(x => "{" + x + "}")
-            .ToList();
-
-        foreach (var id in results)
+        // The instance is the ordered pair (X, S); ec.data.list[1] is the
+        // collection S, whose elements are the subsets we may colour.
+        List<API_UtilCollection>? subsets = ec.data.list?[1].list;
+        if (subsets is null)
         {
-            foreach (var set in ec.data.list[1].list)
+            return ec;
+        }
+
+        // Each subset in S was given the id "r-1-" + uc.ToString() (see
+        // API_UtilCollection). Parsing the solution with SPADE yields the same
+        // ToString() form, so the chosen subsets match those ids by construction.
+        foreach (UtilCollection chosen in new UtilCollection(solution))
+        {
+            string id = "r-1-" + chosen.ToString();
+            API_UtilCollection? set = subsets.FirstOrDefault(s => s.id == id);
+            if (set is null)
             {
-                if (set.id == "r-1-" + id)
-                {
-                    set.color = "Solution";
-                    foreach (var elem in set.list)
-                    {
-                        elem.color = "Solution";
-                    }
-                    break;
-                }
+                continue;
+            }
+
+            set.color = "Solution";
+            foreach (var elem in set.list ?? Enumerable.Empty<API_UtilCollection>())
+            {
+                elem.color = "Solution";
             }
         }
 


### PR DESCRIPTION
## Changes

`ExactCoverDefaultVisualization.SolvedVisualization` previously parsed the solver's solution string by hand (`Trim('{','}')` + `Split("},{")` + manual `"{" + x + "}"` reconstruction). That only matched the visualization's subset ids by coincidence of formatting.

This PR parses the solution with SPADE's `UtilCollection` instead. The subset ids are generated as `"r-1-" + uc.ToString()` (see `API_UtilCollection`), so parsing the solution through the same `UtilCollection.ToString()` makes the chosen subsets match those ids **by construction** rather than by string-formatting luck. Verified empirically that both sides render compact `{2,3}` form, and that an empty solution `{}` iterates zero times (clean no-op).

## Warnings

Resolves the three `CS8602` nullable-dereference warnings in this file (the nullable `API_UtilCollection.list` at the old lines 42 and 47):
- `ec.data.list[1].list` → null-conditional `ec.data.list?[1].list` with an explicit guard
- `set.list` → coalesced to `Enumerable.Empty<API_UtilCollection>()`

Local warning count on the `CSharpAPI` base drops 51 → 48; the warning gate is satisfied (decrease, not increase).

## Testing

- `dotnet build` — 0 errors
- `dotnet test` — 408 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)