### PR TITLE
Split tests into a separate project (redux-tests)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,16 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # A bare `dotnet build`/`test` at the repo root errors MSB1011 now that a
+      # .csproj and Redux.slnx sit side by side, so name the solution explicitly.
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore Redux.slnx
 
       - name: Build
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build Redux.slnx --no-restore --configuration Release
 
       - name: Unit tests
-        run: dotnet test --no-restore --no-build --configuration Release
+        run: dotnet test Redux.slnx --no-restore --no-build --configuration Release
 
   warning-gate:
     name: warning count gate
@@ -50,8 +52,11 @@ jobs:
         id: base
         run: |
           git checkout --quiet --force ${{ github.event.pull_request.base.sha }}
-          dotnet restore
-          dotnet build --no-restore --no-incremental --configuration Release > build-base.log 2>&1 || true
+          # Name the solution if it exists; commits predating Redux.slnx still
+          # build with a bare command (one .csproj at the root, no MSB1011).
+          if [ -f Redux.slnx ]; then T=Redux.slnx; else T=; fi
+          dotnet restore $T
+          dotnet build $T --no-restore --no-incremental --configuration Release > build-base.log 2>&1 || true
           count=$(grep -oE '[^ ]+\.cs\([0-9]+,[0-9]+\): warning CS[0-9]+' build-base.log | sort -u | wc -l | tr -d ' ' || true)
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "::notice title=Base warnings::$count"
@@ -60,8 +65,9 @@ jobs:
         id: head
         run: |
           git checkout --quiet --force ${{ github.sha }}
-          dotnet restore
-          dotnet build --no-restore --no-incremental --configuration Release > build-head.log 2>&1 || true
+          if [ -f Redux.slnx ]; then T=Redux.slnx; else T=; fi
+          dotnet restore $T
+          dotnet build $T --no-restore --no-incremental --configuration Release > build-head.log 2>&1 || true
           count=$(grep -oE '[^ ]+\.cs\([0-9]+,[0-9]+\): warning CS[0-9]+' build-head.log | sort -u | wc -l | tr -d ' ' || true)
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "::notice title=PR warnings::$count"

--- a/API.csproj
+++ b/API.csproj
@@ -12,20 +12,16 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SPADE" Version="0.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
-      <Content Include="Problems\**" CopyToPublishDirectory="PreserveNewest" />
-       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <Content Include="Problems\**" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- Tests live in their own project (redux-tests/redux-tests.csproj). The
+       Sdk.Web glob would otherwise pull redux-tests/**/*.cs into API.dll. -->
+  <ItemGroup>
+    <Compile Remove="redux-tests/**" />
   </ItemGroup>
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN dotnet restore
 
 # Copy the rest
 COPY . .
-RUN dotnet publish -c Release -o out
+RUN dotnet publish API.csproj -c Release -o out
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0

--- a/Problems/NPComplete/NPC_ARCSET/ARCSET_Class.cs
+++ b/Problems/NPComplete/NPC_ARCSET/ARCSET_Class.cs
@@ -11,7 +11,6 @@ using API.Problems.NPComplete.NPC_ARCSET.Solvers;
 using API.Problems.NPComplete.NPC_ARCSET.Verifiers;
 using API.Problems.NPComplete.NPC_ARCSET.Visualizations;
 using SPADE;
-using Xunit.Sdk;
 namespace API.Problems.NPComplete.NPC_ARCSET;
 
 class ARCSET : IGraphProblem<ArcSetBruteForce,ArcSetVerifier,ArcSetDefaultVisualization,UtilCollectionGraph>{

--- a/Problems/NPComplete/NPC_DFA/DFA_Class.cs
+++ b/Problems/NPComplete/NPC_DFA/DFA_Class.cs
@@ -4,7 +4,6 @@ using API.Problems.NPComplete.NPC_DFA.Solvers;
 using API.Problems.NPComplete.NPC_DFA.Verifiers;
 using API.Problems.NPComplete.NPC_DFA.Visualizations;
 using SPADE;
-using Xunit;
 using System.Linq;
 using System.Collections.Generic;
 using API.Interfaces.Graphs;

--- a/Problems/NPComplete/NPC_DFA/Solvers/DFASolver.cs
+++ b/Problems/NPComplete/NPC_DFA/Solvers/DFASolver.cs
@@ -1,7 +1,6 @@
 ﻿using API.Interfaces;
 using API.Interfaces.Graphs;
 using API.Problems.NPComplete.NPC_DFA;
-using Xunit;
 
 namespace API.Problems.NPComplete.NPC_DFA.Solvers;
 

--- a/Problems/NPComplete/NPC_NFA/NFA_Class.cs
+++ b/Problems/NPComplete/NPC_NFA/NFA_Class.cs
@@ -4,7 +4,6 @@ using API.Problems.NPComplete.NPC_NFA.Solvers;
 using API.Problems.NPComplete.NPC_NFA.Verifiers;
 using API.Problems.NPComplete.NPC_NFA.Visualizations;
 using SPADE;
-using Xunit;
 using System.Linq;
 using System.Collections.Generic;
 using API.Interfaces.Graphs;

--- a/Problems/NPComplete/NPC_NFA/Solvers/NFASolver.cs
+++ b/Problems/NPComplete/NPC_NFA/Solvers/NFASolver.cs
@@ -1,7 +1,6 @@
 ﻿using API.Interfaces;
 using API.Interfaces.Graphs;
 using API.Problems.NPComplete.NPC_NFA;
-using Xunit;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/ProjectSourcePath.cs
+++ b/ProjectSourcePath.cs
@@ -6,6 +6,12 @@
 // Solution is based off StackOverflow (https://stackoverflow.com/a/66285728)
 
 using System.Runtime.CompilerServices;
+
+// Lets the test project (assembly name "redux-tests") see internal members:
+// ProjectSourcePath below, and the top-level internal Program class used by
+// WebApplicationFactory<Program> in redux-tests/Endpoints/EndpointFixture.cs.
+[assembly: InternalsVisibleTo("redux-tests")]
+
 internal static class ProjectSourcePath
 {
     private const  string  myRelativePath = nameof(ProjectSourcePath) + ".cs";

--- a/Redux.slnx
+++ b/Redux.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="API.csproj" />
+  <Project Path="redux-tests/redux-tests.csproj" />
+</Solution>

--- a/redux-tests/redux-tests.csproj
+++ b/redux-tests/redux-tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="../API.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Phase 1 of #148. Production code stays at the repo root; only the tests get their own project.

## Why
Tests previously compiled into the single `API.dll` (an `Sdk.Web` app). This blocks the `xunit.v3` migration (#148): v3 runs the test assembly as a standalone subprocess, which would boot the web app and hang. It also unblocks code coverage (currently 0% because tests + product share one assembly).

This PR stays on **xunit v2** so the split is verified in isolation — **466 tests, all green**. The `xunit` → `xunit.v3` swap is a trivial follow-up PR.

## Changes
- **New `redux-tests/redux-tests.csproj`** (`Microsoft.NET.Sdk`) with `ProjectReference` to `../API.csproj` and `FrameworkReference` `Microsoft.AspNetCore.App`. The test-only packages move here: `Microsoft.NET.Test.Sdk`, `xunit` 2.9.3, `xunit.runner.visualstudio`, `coverlet.collector`, `Microsoft.AspNetCore.Mvc.Testing`; `Newtonsoft.Json` declared explicitly.
- **`API.csproj`** — production only: drop the test packages, add `Newtonsoft.Json` (used directly by `ProblemProvider.cs`, previously only transitive), and `<Compile Remove="redux-tests/**" />` so the `Sdk.Web` glob stops pulling test files into `API.dll`.
- **`ProjectSourcePath.cs`** — `[assembly: InternalsVisibleTo("redux-tests")]`, covering both `ProjectSourcePath` and the internal top-level `Program` used by `WebApplicationFactory<Program>`.
- **Remove stray `using Xunit;` imports** from five production files (`*_Class.cs`/`*Solver.cs`) that only compiled because xunit was in the shared assembly.
- **New `Redux.slnx`** ties both projects together; **`main.yml`** names the solution explicitly since a bare `dotnet build`/`test` at the root now errors MSB1011. The warning-gate steps guard with `[ -f Redux.slnx ]` so the base (pre-solution) commit still builds.

## Verification
- `dotnet build Redux.slnx -c Release` → succeeds, `API.dll` contains no test types.
- `dotnet test Redux.slnx -c Release` → **466 passed, 0 failed**.
- Bare `dotnet build` at root → MSB1011 (expected; confirms CI must name the solution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)