### PR TITLE
Migrate test project to xunit.v3 (part 2 of #148)

### DIFF
--- a/API.csproj
+++ b/API.csproj
@@ -19,9 +19,12 @@
   </ItemGroup>
 
   <!-- Tests live in their own project (redux-tests/redux-tests.csproj). The
-       Sdk.Web glob would otherwise pull redux-tests/**/*.cs into API.dll. -->
+       Sdk.Web globs would otherwise pull redux-tests/**/*.cs into API.dll and
+       copy redux-tests/**/*.json (e.g. obj/project.assets.json) to the output. -->
   <ItemGroup>
     <Compile Remove="redux-tests/**" />
+    <Content Remove="redux-tests/**" />
+    <None Remove="redux-tests/**" />
   </ItemGroup>
 
 

--- a/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
@@ -20,15 +20,15 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
     [Fact]
     public async Task AllProblems_Returns200()
     {
-        var response = await _client.GetAsync("/Navigation/ALL_ProblemsRefactor");
+        var response = await _client.GetAsync("/Navigation/ALL_ProblemsRefactor", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task AllProblems_ReturnsNonEmptyJsonArray()
     {
-        var response = await _client.GetAsync("/Navigation/ALL_ProblemsRefactor");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.GetAsync("/Navigation/ALL_ProblemsRefactor", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var arr = JsonSerializer.Deserialize<JsonElement[]>(body);
         Assert.NotNull(arr);
         Assert.NotEmpty(arr);
@@ -39,15 +39,15 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
     [Fact]
     public async Task NpcProblems_Returns200()
     {
-        var response = await _client.GetAsync("/Navigation/NPC_ProblemsRefactor");
+        var response = await _client.GetAsync("/Navigation/NPC_ProblemsRefactor", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task NpcProblems_ReturnsNonEmptyJsonArray()
     {
-        var response = await _client.GetAsync("/Navigation/NPC_ProblemsRefactor");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.GetAsync("/Navigation/NPC_ProblemsRefactor", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var arr = JsonSerializer.Deserialize<JsonElement[]>(body);
         Assert.NotNull(arr);
         Assert.NotEmpty(arr);
@@ -58,15 +58,15 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
     [Fact]
     public async Task AllVerifiers_WithProblem_Returns200()
     {
-        var response = await _client.GetAsync("/Navigation/All_Verifiers?chosenProblem=NPC_SAT3");
+        var response = await _client.GetAsync("/Navigation/All_Verifiers?chosenProblem=NPC_SAT3", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task AllVerifiers_WithProblem_ReturnsNonEmptyJsonArray()
     {
-        var response = await _client.GetAsync("/Navigation/All_Verifiers?chosenProblem=NPC_SAT3");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.GetAsync("/Navigation/All_Verifiers?chosenProblem=NPC_SAT3", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var arr = JsonSerializer.Deserialize<JsonElement[]>(body);
         Assert.NotNull(arr);
         Assert.NotEmpty(arr);
@@ -77,15 +77,15 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
     [Fact]
     public async Task AllVisualizations_WithProblem_Returns200()
     {
-        var response = await _client.GetAsync("/Navigation/All_Visualizations?chosenProblem=NPC_SAT3");
+        var response = await _client.GetAsync("/Navigation/All_Visualizations?chosenProblem=NPC_SAT3", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task AllVisualizations_WithProblem_ReturnsNonEmptyJsonArray()
     {
-        var response = await _client.GetAsync("/Navigation/All_Visualizations?chosenProblem=NPC_SAT3");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.GetAsync("/Navigation/All_Visualizations?chosenProblem=NPC_SAT3", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var arr = JsonSerializer.Deserialize<JsonElement[]>(body);
         Assert.NotNull(arr);
         Assert.NotEmpty(arr);
@@ -96,15 +96,15 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
     [Fact]
     public async Task Reductions_Returns200()
     {
-        var response = await _client.GetAsync("/Navigation/Reductions");
+        var response = await _client.GetAsync("/Navigation/Reductions", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task Reductions_ReturnsNonEmptyGraph()
     {
-        var response = await _client.GetAsync("/Navigation/Reductions");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.GetAsync("/Navigation/Reductions", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         // Returns a nested adjacency map, not an array
         var graph = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(body);
         Assert.NotNull(graph);

--- a/redux-tests/Endpoints/ProblemProvider_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/ProblemProvider_Endpoint_Tests.cs
@@ -26,7 +26,7 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     [InlineData("independentset")]
     public async Task Info_KnownProblem_Returns200(string name)
     {
-        var response = await _client.GetAsync($"/ProblemProvider/info?interface={name}");
+        var response = await _client.GetAsync($"/ProblemProvider/info?interface={name}", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -35,8 +35,8 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     [InlineData("clique")]
     public async Task Info_KnownProblem_ReturnsNonEmptyBody(string name)
     {
-        var response = await _client.GetAsync($"/ProblemProvider/info?interface={name}");
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.GetAsync($"/ProblemProvider/info?interface={name}", TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.False(string.IsNullOrWhiteSpace(body));
     }
 
@@ -46,9 +46,9 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     public async Task Verify_ValidSAT3Certificate_ReturnsTrue()
     {
         var body = new { Certificate = "x1:True,x2:False,x3:True", ProblemInstance = "(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)" };
-        var response = await _client.PostAsJsonAsync("/ProblemProvider/verify?verifier=sat3verifier", body);
+        var response = await _client.PostAsJsonAsync("/ProblemProvider/verify?verifier=sat3verifier", body, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await response.Content.ReadAsStringAsync();
+        var result = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains("True", result, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -56,9 +56,9 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     public async Task Verify_InvalidSAT3Certificate_ReturnsFalse()
     {
         var body = new { Certificate = "x1:False,x2:False,x3:False", ProblemInstance = "(x1 | x2 | x3) & (!x1 | !x2 | !x3) & (x1 | !x2 | x3)" };
-        var response = await _client.PostAsJsonAsync("/ProblemProvider/verify?verifier=sat3verifier", body);
+        var response = await _client.PostAsJsonAsync("/ProblemProvider/verify?verifier=sat3verifier", body, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await response.Content.ReadAsStringAsync();
+        var result = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains("False", result, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -69,7 +69,7 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     {
         var instance = "\"(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)\"";
         var content = new StringContent(instance, Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/ProblemProvider/solve?solver=sat3backtrackingsolver", content);
+        var response = await _client.PostAsync("/ProblemProvider/solve?solver=sat3backtrackingsolver", content, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -78,8 +78,8 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     {
         var instance = "\"(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)\"";
         var content = new StringContent(instance, Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/ProblemProvider/solve?solver=sat3backtrackingsolver", content);
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.PostAsync("/ProblemProvider/solve?solver=sat3backtrackingsolver", content, TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.False(string.IsNullOrWhiteSpace(body));
     }
 
@@ -90,7 +90,7 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     {
         var instance = "\"(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)\"";
         var content = new StringContent(instance, Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/ProblemProvider/reduce?reduction=sipserreducetocliquestandard", content);
+        var response = await _client.PostAsync("/ProblemProvider/reduce?reduction=sipserreducetocliquestandard", content, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -99,8 +99,8 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
     {
         var instance = "\"(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)\"";
         var content = new StringContent(instance, Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync("/ProblemProvider/reduce?reduction=sipserreducetocliquestandard", content);
-        var body = await response.Content.ReadAsStringAsync();
+        var response = await _client.PostAsync("/ProblemProvider/reduce?reduction=sipserreducetocliquestandard", content, TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.False(string.IsNullOrWhiteSpace(body));
     }
 }

--- a/redux-tests/redux-tests.csproj
+++ b/redux-tests/redux-tests.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <!-- xunit.v3 runs the test assembly as a standalone process. -->
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Part 2 of #148, following the test-project split (#268). With `redux-tests` now a plain library separate from the API web app, the `xunit` → `xunit.v3` swap is safe: the v3 runner executes the test assembly as a standalone process, which pre-split would have booted the web app and hung. **466 tests pass on v3.**

## Changes
- **`redux-tests.csproj`** — `xunit` 2.9.3 → **`xunit.v3` 3.2.2**; add `<OutputType>Exe</OutputType>` (v3 test projects are executables). `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio` (3.1.5, supports v3) unchanged.
- **`API.csproj`** — exclude `redux-tests` from `Content`/`None`, not just `Compile`. The `Sdk.Web` default Content glob (`**/*.json`) was sweeping `redux-tests/**/*.json` (e.g. `obj/project.assets.json`) into the output, creating a `redux-tests/` folder there. Harmless under v2 (library output) but it collides with the v3 apphost executable named `redux-tests` → **MSB3024**.
- **Endpoint tests** — thread `TestContext.Current.CancellationToken` through the `HttpClient` calls (`GetAsync`/`PostAsync`/`PostAsJsonAsync`/`ReadAsStringAsync`) to satisfy the v3 `xUnit1051` analyzer. **No suppressions** — all 56 warnings resolved at the source (28 sites in the two endpoint-test files).

## Verification
- `dotnet build Redux.slnx -c Release` → succeeds; **0** `xUnit1051` warnings; total warnings back to 36 (pre-existing production nullable warnings only).
- `dotnet test Redux.slnx -c Release` → **466 passed, 0 failed**.
- Warning gate: unique CS-warning count is **29**, identical to base (`upstream/CSharpAPI`), so the gate holds.

Closes #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)