### PR TITLE
Initialize gadgets in KarpDirectedHamiltonianToUndirectedHamiltonian (fix CS8618)

### DIFF
--- a/Problems/NPComplete/NPC_DIRECTEDHAMILTONIAN/ReduceTo/NPC_HAMILTONIAN/KarpDirectedHamiltonianToUndirectedHamiltonian.cs
+++ b/Problems/NPComplete/NPC_DIRECTEDHAMILTONIAN/ReduceTo/NPC_HAMILTONIAN/KarpDirectedHamiltonianToUndirectedHamiltonian.cs
@@ -45,6 +45,7 @@ class KarpDirectedHamiltonianToUndirectedHamiltonian : IReduction<DIRECTEDHAMILT
 
     public KarpDirectedHamiltonianToUndirectedHamiltonian(DIRECTEDHAMILTONIAN from)
     {
+        gadgets = new();
         _reductionFrom = from;
         _reductionTo = reduce();
     }


### PR DESCRIPTION
## What
`KarpDirectedHamiltonianToUndirectedHamiltonian` declared the `IReduction.gadgets` property but never initialized it, so it was `null` when the constructor exited — the only reduction with this warning (**CS8618**). It also meant `POST /ProblemProvider/gadgets` returned `null` for this reduction, whereas every other returns `[]` or a populated gadget map.

## Fix
Initialize `gadgets = new();` in the constructor, matching the convention every sibling reduction already uses (e.g. `KarpSATToSAT3`, `SipserReduceToSAT3`). 9/9 reductions declare and initialize `gadgets`; this was the lone one that forgot.

One-line change; behavior is now consistent (`gadgets` → `[]` instead of `null`).

## Verification
- `dotnet build Redux.slnx -c Release` → succeeds; the `gadgets` CS8618 warning is gone (warning count drops by one, so the warning gate holds).
- `dotnet test Redux.slnx -c Release` → **466 passed, 0 failed**.

Note: this reduction *builds* the v1/v2/v3 Karp gadget in `reduce()` but doesn't yet record it as `Gadget` objects — actually populating the gadget map (like the other 7 reductions) would be a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)