### PR TITLE
Make GetContributorInfo return ContributorInfo? (fix CS8603)

### DIFF
--- a/AdditionalControllers/Navigation/ContributerProfile.cs
+++ b/AdditionalControllers/Navigation/ContributerProfile.cs
@@ -286,7 +286,7 @@ public class ContributorProfileController : ControllerBase {
         return reductions.Distinct();
     }
 
-    private ContributorInfo GetContributorInfo(string contributorName) {
+    private ContributorInfo? GetContributorInfo(string contributorName) {
         try {
             string projectSourcePath = ProjectSourcePath.Value;
             string infoFilePath = Path.Combine(projectSourcePath, "wwwroot", "contributorInfo.json");


### PR DESCRIPTION
## What
`GetContributorInfo` returns `null` when `contributorInfo.json` is missing or the contributor isn't found, but was declared to return non-nullable `ContributorInfo` — two **CS8603** "possible null reference return" warnings (lines 295 and 314).

## Fix
Mark the return type `ContributorInfo?`. Its only caller (`GetContributorProfile`) already treats the result as nullable — `contributorInfo?.Email ?? "Not specified"` for every field — so this just declares the truth. **No behavior change**, no suppression.

## Verification
- `dotnet build Redux.slnx -c Release` → succeeds; both CS8603 warnings in `ContributerProfile.cs` gone (warning count drops by two, so the warning gate holds).
- `dotnet test Redux.slnx -c Release` → **466 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)