### PR TITLE
Make createNewSatState return SAT3PQObject? and filter nulls (fix CS8603)

### DIFF
--- a/Problems/NPComplete/NPC_SAT3/SAT3PQObject.cs
+++ b/Problems/NPComplete/NPC_SAT3/SAT3PQObject.cs
@@ -62,14 +62,17 @@ class SAT3PQObject{
     public List<SAT3PQObject> createSATChildren(int depth, int totalNumberOfVariables){
         // string var = this.varPQ.Dequeue();
         List<SAT3PQObject> outList = new List<SAT3PQObject>();
-        outList.Add(createNewSatState(true, depth, totalNumberOfVariables));
-        outList.Add(createNewSatState(false, depth, totalNumberOfVariables));
+        // createNewSatState returns null for an unviable state — skip those.
+        SAT3PQObject? trueChild = createNewSatState(true, depth, totalNumberOfVariables);
+        if (trueChild != null) outList.Add(trueChild);
+        SAT3PQObject? falseChild = createNewSatState(false, depth, totalNumberOfVariables);
+        if (falseChild != null) outList.Add(falseChild);
         return outList;
     }
 
     //Takes in a variable and a boolean value and returns the new SATState
     //Returns null if the new state would be unviable
-    private SAT3PQObject createNewSatState(bool boolValue, int depth, int totalNumberOfVariables){ //This is the meat and potatoes of the solver
+    private SAT3PQObject? createNewSatState(bool boolValue, int depth, int totalNumberOfVariables){ //This is the meat and potatoes of the solver
         //update the variables to the string representation of the boolean value
         //pass the modified clause to the evaluateBooleanExpression method
         //if the evaluation returns a viable expression it will return a string else it will returns null


### PR DESCRIPTION
## What
`createNewSatState` is documented to return null for an unviable state ("Returns null if the new state would be unviable") but was declared non-nullable → **CS8603** at line 173.

## Fix (contained to `SAT3PQObject.cs`)
- Return type → `SAT3PQObject?` (declares the truth).
- `createSATChildren` now skips null children rather than adding them, so `List<SAT3PQObject>` stays honest (no nulls in it, and no CS8604 pushed onto `.Add`).

**No behavior change**: the only consumer (`Sat3BacktrackingSolver`) already skipped null children with `if (childSAT != null)`; now they simply never enter the list.

## Coverage / verification
- The null-return path and **both** filter branches are exercised by the existing SAT3 solver tests — `return null` hits 8×, and both `if (... != null)` lines report **100% branch coverage (2/2)** (each child observed null *and* non-null).
- `dotnet build Redux.slnx -c Release` → succeeds; CS8603 gone, no new CS warnings (unique CS-warning count drops by one, so the warning gate holds).
- `dotnet test Redux.slnx -c Release` → **466 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)