### PR TITLE
Guard against null reduction in visualizeReduction (fix CS8602)

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -270,6 +270,11 @@ public class ProblemProvider : ControllerBase
             instance = red.reductionTo.instance;
         }
 
+        if (red is null)
+        {
+            throw new ArgumentException("No reductions provided", nameof(reduction));
+        }
+
         return getVisualize(red.visualization, new List<Object>(), solution, instance);
     }
 


### PR DESCRIPTION
## What

In `ProblemProvider.visualizeReduction`, `red` is declared `IReduction? red = null` and only assigned inside the `foreach` over the dash-split reduction names. The compiler flags **CS8602** (dereference of a possibly null reference) at `red.visualization`, since it cannot prove the loop body executed.

## Change

Add an explicit null guard after the loop that throws `ArgumentException("No reductions provided", nameof(reduction))` when no reductions were processed. This satisfies the nullable analysis and converts a latent `NullReferenceException` into a clear, attributable error for empty/malformed `reduction` input.

## Testing

- `dotnet build API.csproj` — 0 errors
- `dotnet test redux-tests/redux-tests.csproj` — 466 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)