### PR TITLE
Null-check Activator.CreateInstance in ISolver string paths (fix CS8600/CS8604)

### DIFF
--- a/Interfaces/SolverInterface.cs
+++ b/Interfaces/SolverInterface.cs
@@ -35,18 +35,22 @@ interface ISolver<T> : ISolver where T : IProblem {
         // Should there be some sort of contraint that assures there is a constructor
         // that matches the signature of a single `string` argument?
         // Perhaps a static `FromInstance(string instance)` method for `IProblem` will work.
-        T problemInstance = (T)Activator.CreateInstance(typeof(T), problem);
-        if (problemInstance == null)
+        object? instance = Activator.CreateInstance(typeof(T), problem);
+        if (instance == null)
             throw new ArgumentException($"Could not create problem instance for {problem}.");
 
-        return solve(problemInstance);
+        return solve((T)instance);
     }
 
     string solve(T problem);
 
     List<Object> ISolver.GetSteps(string instance)
     {
-        return GetSteps((T)Activator.CreateInstance(typeof(T), instance));
+        object? problemInstance = Activator.CreateInstance(typeof(T), instance);
+        if (problemInstance == null)
+            throw new ArgumentException($"Could not create problem instance for {instance}.");
+
+        return GetSteps((T)problemInstance);
     }
 
     List<Object> GetSteps(T problem)


### PR DESCRIPTION
The explicit `ISolver.solve(string)` and `ISolver.GetSteps(string)` implementations in `Interfaces/SolverInterface.cs` cast `Activator.CreateInstance(...)` — which is typed `object?` under nullable reference types — directly to non-nullable `T`. This produces three warnings:

- `SolverInterface.cs(38)` CS8600
- `SolverInterface.cs(49)` CS8600
- `SolverInterface.cs(49)` CS8604

`solve` already null-checked, but only *after* the offending cast, so the warning fired anyway. `GetSteps` had no guard at all and would have thrown an unhelpful `NullReferenceException` on a failed instantiation.

## Fix
Capture the `Activator.CreateInstance` result into an `object?`, null-check it, then cast to `T`. Clears all three warnings and adds a real null-guard to `GetSteps`.

## Verification
- `dotnet build API.csproj` — 0 errors; the three SolverInterface warnings are gone.
- `dotnet test` — 466/466 pass (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)