### PR TITLE
Null-check List.Find result in GareyJohnson reduction (fix CS8600)

### DIFF
--- a/Problems/NPComplete/NPC_SAT3/ReduceTo/NPC_DM3/GareyJohnson.cs
+++ b/Problems/NPComplete/NPC_SAT3/ReduceTo/NPC_DM3/GareyJohnson.cs
@@ -91,7 +91,10 @@ class GareyJohnson : IReduction<SAT3, DM3> {
         List<string> unusedLiterals = new List<string>(Z);
         for(int i = 0; i < SAT3Instance.clauses.Count; i++) {
             foreach(var literal in SAT3Instance.clauses[i]) {
-                string found = unusedLiterals.Find(x => x.Contains("z_" + literal));
+                string? found = unusedLiterals.Find(x => x.Contains("z_" + literal));
+                if(found is null) {
+                    continue;
+                }
                 M.Add(new List<string>{"x_clause_" + i.ToString(), "y_clause" + i.ToString(), found});
                 unusedLiterals.Remove(found);
             }


### PR DESCRIPTION
In `GareyJohnson.cs`, the SAT3→DM3 reduction assigned the result of `List<string>.Find(...)` to a non-nullable `string`. `Find` returns `null` when no element matches, so this produces a CS8600 ("converting null literal or possible null value to non-nullable type") warning, and a null `found` would silently be added to the matching set `M`.

## Fix
Declare the local as `string?` and `continue` when no unused literal is found for the clause's literal, rather than appending a null entry to `M`.

## Verification
- `dotnet build API.csproj` — 0 errors; the GareyJohnson CS8600 warning is gone.
- `dotnet test` — 466/466 pass (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)