### PR TITLE
Make DFAVerifier.nodes a local variable (fix CS8618)

### DIFF
--- a/Problems/NPComplete/NPC_DFA/Verifiers/DFAVerifier.cs
+++ b/Problems/NPComplete/NPC_DFA/Verifiers/DFAVerifier.cs
@@ -12,7 +12,6 @@ class DFAVerifier : IVerifier<DFA>
     public string[] contributors { get; } = { "Michael Trosper" };
     private string _certificate = "";
 
-    private string[] nodes;
     public string certificate { get => _certificate; }
 
     // --- Methods Including Constructors ---
@@ -23,7 +22,7 @@ class DFAVerifier : IVerifier<DFA>
         // Trim Unwanted Space //
         certificate.Trim();
         // Get Each Node //
-        nodes = certificate.Split(',');
+        string[] nodes = certificate.Split(',');
 
         // Start State //
         string currentNode = nodes[0];


### PR DESCRIPTION
## Summary
- `nodes` in `DFAVerifier` was a private instance field (`private string[] nodes`) but was only ever assigned and read within the `verify()` method — it carried no meaningful state between calls
- Moved it to a local variable inside `verify()`, eliminating the CS8618 uninitialized-field warning without needing a `null!` suppressor

## Test plan
- [x] `dotnet build` — no warnings from `DFAVerifier.cs`
- [x] `dotnet test` — existing DFA tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)