### PR TITLE
Add null guards in PartitionDefaultVisualization (fix CS8602/CS8604)

### DIFF
--- a/Problems/NPComplete/NPC_PARTITION/Visualizations/PartitionDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_PARTITION/Visualizations/PartitionDefaultVisualization.cs
@@ -37,8 +37,9 @@ class PartitionDefaultVisualization : IVisualization<PARTITION>
             groups.Add(e);
         }
 
-        foreach (var e in ec.data.list)
+        foreach (var e in ec.data.list ?? [])
         {
+            if (e.value is null) continue;
             if (groups[0].Contains(new(e.value)))
             {
                 e.color = "Solution";


### PR DESCRIPTION
## Summary
- `ec.data.list` is `List<API_UtilCollection>?` — only populated when the `UtilCollection` is a set, not a value; guarded with `?? []`
- `e.value` is `string?` — only populated when the element is a value; guarded with a `null` check and `continue`

Both are always non-null for a valid PARTITION instance, but the guards make the code correct under the type system without resorting to `!` suppressors.

## Test plan
- [x] `dotnet build` — no warnings from `PartitionDefaultVisualization.cs`
- [x] `dotnet test` — existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)