### PR TITLE
Initialize _startState/_inputString to string.Empty in DFA/NFA (fix CS8618)

### DIFF
--- a/Problems/NPComplete/NPC_DFA/DFA_Class.cs
+++ b/Problems/NPComplete/NPC_DFA/DFA_Class.cs
@@ -53,9 +53,9 @@ class DFA : IGraphProblem<DFASolver, DFAVerifier, DFAVisualization, WeightedDire
     private List<string> _nodes = new();
     private List<char> _alphabet = new();
     private List<DFAEdge> _edges = new();
-    private string _startState;
+    private string _startState = string.Empty;
     private List<string> _acceptStates = new();
-    private string _inputString;
+    private string _inputString = string.Empty;
 
     public List<string> nodes { get => _nodes; set => _nodes = value; }
     public List<char> alphabet { get => _alphabet; set => _alphabet = value; }

--- a/Problems/NPComplete/NPC_NFA/NFA_Class.cs
+++ b/Problems/NPComplete/NPC_NFA/NFA_Class.cs
@@ -53,9 +53,9 @@ class NFA : IGraphProblem<NFASolver, NFAVerifier, NFAVisualization, WeightedDire
     private List<string> _nodes = new();
     private List<char> _alphabet = new();
     private List<NFAEdge> _edges = new();
-    private string _startState;
+    private string _startState = string.Empty;
     private List<string> _acceptStates = new();
-    private string _inputString;
+    private string _inputString = string.Empty;
 
     public List<string> nodes { get => _nodes; set => _nodes = value; }
     public List<char> alphabet { get => _alphabet; set => _alphabet = value; }


### PR DESCRIPTION
## Summary
- `DFA_Class.cs` and `NFA_Class.cs` both declare `_startState` and `_inputString` without initializers, which is inconsistent with every other field in the same block (`_nodes = new()`, `_alphabet = new()`, etc.)
- Both fields are always assigned before the constructor exits normally, but the compiler can't prove that through the `throw` paths, so it reports CS8618
- Initialized both to `string.Empty`, matching the pattern used by the `instance` property in the same class

## Test plan
- [x] `dotnet build` — no CS8618 warnings from `DFA_Class.cs` or `NFA_Class.cs`
- [x] `dotnet test` — existing DFA/NFA tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)