### PR TITLE
Added modular unit tests for DFA and NFA

### DIFF
--- a/redux-tests/Problems/NPC_DFA/DFA_Tests.cs
+++ b/redux-tests/Problems/NPC_DFA/DFA_Tests.cs
@@ -1,0 +1,277 @@
+using Xunit;
+using API.Problems.NPComplete.NPC_DFA;
+using API.Problems.NPComplete.NPC_DFA.Solvers;
+using API.Problems.NPComplete.NPC_DFA.Verifiers;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class DFA_Tests
+{
+    private const string DefaultInstance =
+        "(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)";
+
+    // -------------------------------------------------------------------------
+    // Instantiation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DFA_Default_Instantiation()
+    {
+        DFA dfa = new DFA();
+        Assert.Equal(DefaultInstance, dfa.defaultInstance);
+        Assert.Equal(DefaultInstance, dfa.instance);
+    }
+
+    [Fact]
+    public void DFA_Custom_Instantiation()
+    {
+        // Even-number-of-b's machine over {a,b}
+        string instance = "(({even,odd},{a,b},{(even,a,even),(even,b,odd),(odd,a,odd),(odd,b,even)},even,{even}),bb)";
+        DFA dfa = new DFA(instance);
+        Assert.Equal(instance, dfa.instance);
+        Assert.Equal(2, dfa.nodes.Count);
+        Assert.Equal("even", dfa.startState);
+        Assert.Contains("even", dfa.acceptStates);
+    }
+
+    // -------------------------------------------------------------------------
+    // Parsing
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)", 3)]
+    [InlineData("(({even,odd},{a,b},{(even,a,even),(even,b,odd),(odd,a,odd),(odd,b,even)},even,{even}),bb)", 2)]
+    public void DFA_Parses_Correct_Node_Count(string instance, int expectedCount)
+    {
+        DFA dfa = new DFA(instance);
+        Assert.Equal(expectedCount, dfa.nodes.Count);
+    }
+
+    [Theory]
+    [InlineData("(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)", 6)]
+    [InlineData("(({even,odd},{a,b},{(even,a,even),(even,b,odd),(odd,a,odd),(odd,b,even)},even,{even}),bb)", 4)]
+    public void DFA_Parses_Correct_Edge_Count(string instance, int expectedCount)
+    {
+        DFA dfa = new DFA(instance);
+        Assert.Equal(expectedCount, dfa.edges.Count);
+    }
+
+    [Fact]
+    public void DFA_Parses_Start_State()
+    {
+        DFA dfa = new DFA(DefaultInstance);
+        Assert.Equal("1", dfa.startState);
+    }
+
+    [Fact]
+    public void DFA_Parses_Accept_States()
+    {
+        DFA dfa = new DFA(DefaultInstance);
+        Assert.Single(dfa.acceptStates);
+        Assert.Contains("2", dfa.acceptStates);
+    }
+
+    [Fact]
+    public void DFA_Parses_Alphabet()
+    {
+        DFA dfa = new DFA(DefaultInstance);
+        Assert.Equal(2, dfa.alphabet.Count);
+        Assert.Contains('a', dfa.alphabet);
+        Assert.Contains('b', dfa.alphabet);
+    }
+
+    [Fact]
+    public void DFA_Parses_Input_String()
+    {
+        DFA dfa = new DFA(DefaultInstance);
+        Assert.Equal("a", dfa.inputString);
+    }
+
+    // -------------------------------------------------------------------------
+    // Parsing — error cases
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DFA_Rejects_NFA_Instance_With_Epsilon_Edge()
+    {
+        // ε is not in the DFA alphabet {a,b}, so parsing an NFA instance must throw
+        string nfaInstance =
+            "(({1,2,3},{a,b},{(1,a,2),(1,ε,2),(1,b,3),(2,a,2),(2,ε,3),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)";
+        Assert.Throws<InvalidOperationException>(() => new DFA(nfaInstance));
+    }
+
+    [Fact]
+    public void DFA_Rejects_Edge_With_Symbol_Not_In_Alphabet()
+    {
+        string instance = "(({1,2},{a},{(1,c,2)},1,{2}),a)";
+        Assert.Throws<InvalidOperationException>(() => new DFA(instance));
+    }
+
+    [Fact]
+    public void DFA_Rejects_Unknown_Start_State()
+    {
+        string instance = "(({1,2},{a},{(1,a,2)},9,{2}),a)";
+        Assert.Throws<InvalidOperationException>(() => new DFA(instance));
+    }
+
+    [Fact]
+    public void DFA_Rejects_Unknown_Accept_State()
+    {
+        string instance = "(({1,2},{a},{(1,a,2)},1,{9}),a)";
+        Assert.Throws<InvalidOperationException>(() => new DFA(instance));
+    }
+
+    [Fact]
+    public void DFA_Rejects_Edge_From_Unknown_Node()
+    {
+        string instance = "(({1,2},{a},{(9,a,2)},1,{2}),a)";
+        Assert.Throws<InvalidOperationException>(() => new DFA(instance));
+    }
+
+    [Fact]
+    public void DFA_Rejects_Edge_To_Unknown_Node()
+    {
+        string instance = "(({1,2},{a},{(1,a,9)},1,{2}),a)";
+        Assert.Throws<InvalidOperationException>(() => new DFA(instance));
+    }
+
+    // -------------------------------------------------------------------------
+    // Solver
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DFA_Solver_Accepts_Valid_Input()
+    {
+        // Default instance: input "a" → 1 →a→ 2 (accept state)
+        DFA dfa = new DFA(DefaultInstance);
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains("sequence of states", result);
+        Assert.DoesNotContain("No Solution", result);
+    }
+
+    [Fact]
+    public void DFA_Solver_Rejects_Input_Ending_In_Non_Accept_State()
+    {
+        // Input "b": 1 →b→ 3 (non-accept state)
+        string instance = "(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),b)";
+        DFA dfa = new DFA(instance);
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains("No Solution", result);
+    }
+
+    [Theory]
+    [InlineData("(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),ba)")]
+    [InlineData("(({even,odd},{a,b},{(even,a,even),(even,b,odd),(odd,a,odd),(odd,b,even)},even,{even}),bb)")]
+    public void DFA_Solver_Accepts_Multi_Step_Input(string instance)
+    {
+        DFA dfa = new DFA(instance);
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains("sequence of states", result);
+        Assert.DoesNotContain("No Solution", result);
+    }
+
+    [Fact]
+    public void DFA_Solver_Rejects_Character_Not_In_Alphabet()
+    {
+        DFA dfa = new DFA("(({1,2},{a},{(1,a,2)},1,{2}),c)");
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains("No Solution", result);
+        Assert.Contains("'c'", result);
+    }
+
+    [Fact]
+    public void DFA_Solver_Accepts_Empty_String_When_Start_Is_Accept()
+    {
+        // Start state q0 is accept; ε input represents the empty string
+        DFA dfa = new DFA("(({q0,q1},{a},{(q0,a,q1)},q0,{q0}),ε)");
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains("sequence of states", result);
+    }
+
+    [Fact]
+    public void DFA_Solver_Rejects_Empty_String_When_Start_Is_Not_Accept()
+    {
+        // Start state q0 is NOT accept; ε input cannot reach q1
+        DFA dfa = new DFA("(({q0,q1},{a},{(q0,a,q1)},q0,{q1}),ε)");
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains("No Solution", result);
+    }
+
+    [Fact]
+    public void DFA_Solver_Output_Contains_Correct_State_Path()
+    {
+        // Input "ba": 1 →b→ 3 →a→ 2; all three state labels must appear in output
+        DFA dfa = new DFA("(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),ba)");
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains("1", result);
+        Assert.Contains("3", result);
+        Assert.Contains("2", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Verifier
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("1,2")]    // 1 →a→ 2 (accept)
+    [InlineData("1,3,2")]  // 1 →b→ 3 →a→ 2 (accept)
+    public void DFA_Verifier_Accepts_Valid_Path(string certificate)
+    {
+        DFA dfa = new DFA(DefaultInstance);
+        DFAVerifier verifier = new DFAVerifier();
+        Assert.True(verifier.verify(dfa, certificate));
+    }
+
+    [Theory]
+    [InlineData("1,3")]    // ends in non-accept state 3
+    [InlineData("1,3,3")]  // ends in non-accept state 3 after self-loop
+    public void DFA_Verifier_Rejects_Path_Not_Ending_In_Accept_State(string certificate)
+    {
+        DFA dfa = new DFA(DefaultInstance);
+        DFAVerifier verifier = new DFAVerifier();
+        Assert.False(verifier.verify(dfa, certificate));
+    }
+
+    [Theory]
+    [InlineData("2,2")]   // starts at "2", not the start state "1"
+    [InlineData("3,2")]   // starts at "3", not the start state "1"
+    public void DFA_Verifier_Rejects_Path_Not_Starting_At_Start_State(string certificate)
+    {
+        DFA dfa = new DFA(DefaultInstance);
+        DFAVerifier verifier = new DFAVerifier();
+        Assert.False(verifier.verify(dfa, certificate));
+    }
+
+    [Fact]
+    public void DFA_Verifier_Accepts_Single_Node_When_Start_Is_Accept()
+    {
+        // q0 is both start and accept; a one-node certificate "q0" is valid
+        DFA dfa = new DFA("(({q0,q1},{a},{(q0,a,q1)},q0,{q0}),ε)");
+        DFAVerifier verifier = new DFAVerifier();
+        Assert.True(verifier.verify(dfa, "q0"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Solver — output content
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)", "1, 2")]
+    [InlineData("(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),ba)", "1, 3, 2")]
+    [InlineData("(({even,odd},{a,b},{(even,a,even),(even,b,odd),(odd,a,odd),(odd,b,even)},even,{even}),bb)", "even, odd, even")]
+    public void DFA_Solver_Returns_Correct_State_Path_For_Accepted_Input(string instance, string expectedPath)
+    {
+        DFA dfa = new DFA(instance);
+        DFASolver solver = new DFASolver();
+        string result = solver.solve(dfa);
+        Assert.Contains(expectedPath, result);
+    }
+}

--- a/redux-tests/Problems/NPC_NFA/NFA_Tests.cs
+++ b/redux-tests/Problems/NPC_NFA/NFA_Tests.cs
@@ -1,0 +1,298 @@
+using Xunit;
+using API.Problems.NPComplete.NPC_NFA;
+using API.Problems.NPComplete.NPC_NFA.Solvers;
+using API.Problems.NPComplete.NPC_NFA.Verifiers;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class NFA_Tests
+{
+    private const string DefaultInstance =
+        "(({1,2,3},{a,b},{(1,a,2),(1,ε,2),(1,b,3),(2,a,2),(2,ε,3),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)";
+
+    private const char Epsilon = 'ε';
+
+    // -------------------------------------------------------------------------
+    // Instantiation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void NFA_Default_Instantiation()
+    {
+        NFA nfa = new NFA();
+        Assert.Equal(DefaultInstance, nfa.defaultInstance);
+        Assert.Equal(DefaultInstance, nfa.instance);
+    }
+
+    [Fact]
+    public void NFA_Custom_Instantiation_Without_Epsilon()
+    {
+        // A DFA-like NFA (no ε transitions) is a valid NFA
+        string instance = "(({p,q},{a,b},{(p,a,q),(p,b,p),(q,a,q),(q,b,q)},p,{q}),ab)";
+        NFA nfa = new NFA(instance);
+        Assert.Equal(instance, nfa.instance);
+        Assert.Equal(2, nfa.nodes.Count);
+        Assert.Equal(4, nfa.edges.Count);
+        Assert.DoesNotContain(nfa.edges, e => e.Symbol == Epsilon);
+    }
+
+    // -------------------------------------------------------------------------
+    // Parsing
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("(({1,2,3},{a,b},{(1,a,2),(1,ε,2),(1,b,3),(2,a,2),(2,ε,3),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)", 3)]
+    [InlineData("(({p,q},{a,b},{(p,a,q),(p,b,p),(q,a,q),(q,b,q)},p,{q}),ab)", 2)]
+    public void NFA_Parses_Correct_Node_Count(string instance, int expectedCount)
+    {
+        NFA nfa = new NFA(instance);
+        Assert.Equal(expectedCount, nfa.nodes.Count);
+    }
+
+    [Fact]
+    public void NFA_Parses_Epsilon_Transitions()
+    {
+        NFA nfa = new NFA(DefaultInstance);
+        // Default instance has 8 edges: 6 regular + 2 ε
+        Assert.Equal(8, nfa.edges.Count);
+        Assert.Equal(2, nfa.edges.Count(e => e.Symbol == Epsilon));
+        Assert.Contains(nfa.edges, e => e.From == "1" && e.Symbol == Epsilon && e.To == "2");
+        Assert.Contains(nfa.edges, e => e.From == "2" && e.Symbol == Epsilon && e.To == "3");
+    }
+
+    [Fact]
+    public void NFA_Allows_Epsilon_Edge_Even_When_Epsilon_Not_In_Declared_Alphabet()
+    {
+        // ε is always a valid edge label in NFA regardless of the declared alphabet
+        string instance = "(({s,t},{a},{(s,ε,t)},s,{t}),ε)";
+        NFA nfa = new NFA(instance);
+        Assert.Single(nfa.edges);
+        Assert.Equal(Epsilon, nfa.edges[0].Symbol);
+    }
+
+    [Fact]
+    public void NFA_Accepts_DFA_Instance_As_Valid_NFA()
+    {
+        // Every DFA is a valid NFA; constructing NFA from DFA's default instance must not throw
+        string dfaDefault =
+            "(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)";
+        NFA nfa = new NFA(dfaDefault);
+        Assert.Equal(3, nfa.nodes.Count);
+        Assert.Equal(6, nfa.edges.Count);
+        Assert.DoesNotContain(nfa.edges, e => e.Symbol == Epsilon);
+    }
+
+    // -------------------------------------------------------------------------
+    // Parsing — error cases
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void NFA_Rejects_Edge_With_Symbol_Not_In_Alphabet_And_Not_Epsilon()
+    {
+        string instance = "(({s,t},{a},{(s,c,t)},s,{t}),a)";
+        Assert.Throws<InvalidOperationException>(() => new NFA(instance));
+    }
+
+    [Fact]
+    public void NFA_Rejects_Unknown_Start_State()
+    {
+        string instance = "(({1,2},{a},{(1,a,2)},9,{2}),a)";
+        Assert.Throws<InvalidOperationException>(() => new NFA(instance));
+    }
+
+    [Fact]
+    public void NFA_Rejects_Unknown_Accept_State()
+    {
+        string instance = "(({1,2},{a},{(1,a,2)},1,{9}),a)";
+        Assert.Throws<InvalidOperationException>(() => new NFA(instance));
+    }
+
+    // -------------------------------------------------------------------------
+    // DFA vs NFA — structural asymmetry
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void NFA_Accepts_DFA_Default_Instance_And_Solver_Finds_Solution()
+    {
+        // DFA instance has no ε edges, so NFA accepts it and the solver runs normally.
+        // This is the backend root cause of the DFA→NFA visualization bug: the first
+        // visualization request uses the DFA instance, which NFA silently accepts,
+        // returning a DFA-looking graph before the correct NFA instance arrives.
+        string dfaDefault =
+            "(({1,2,3},{a,b},{(1,a,2),(1,b,3),(2,a,2),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)";
+        NFA nfa = new NFA(dfaDefault);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("sequence of states", result);
+    }
+
+    [Fact]
+    public void DFA_Rejects_NFA_Default_Instance_With_Epsilon()
+    {
+        // NFA instance has ε edges; the DFA constructor rejects them because ε ∉ {a,b}.
+        // This asymmetry is why NFA→DFA clears the visualization but DFA→NFA does not.
+        string nfaDefault =
+            "(({1,2,3},{a,b},{(1,a,2),(1,ε,2),(1,b,3),(2,a,2),(2,ε,3),(2,b,2),(3,a,2),(3,b,3)},1,{2}),a)";
+        Assert.Throws<InvalidOperationException>(
+            () => new API.Problems.NPComplete.NPC_DFA.DFA(nfaDefault));
+    }
+
+    // -------------------------------------------------------------------------
+    // Solver
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void NFA_Solver_Accepts_Input_Via_Direct_Path()
+    {
+        // Input "a": direct path 1 →a→ 2 (accept state)
+        NFA nfa = new NFA(DefaultInstance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("sequence of states", result);
+        Assert.DoesNotContain("No Solution", result);
+    }
+
+    [Fact]
+    public void NFA_Solver_Returns_Multiple_Accepting_Paths_For_Nondeterminism()
+    {
+        // Default instance + input "a" has three distinct accepting paths (direct,
+        // via ε, and via ε-chain), so the solver output must contain multiple lines
+        NFA nfa = new NFA(DefaultInstance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        string[] lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.True(lines.Length >= 2, "Expected multiple accepting paths for a nondeterministic run");
+    }
+
+    [Fact]
+    public void NFA_Solver_Accepts_Input_Via_Epsilon_Then_Regular_Transition()
+    {
+        // s →ε→ t →a→ u (accept); the only accepting run uses an ε transition
+        string instance = "(({s,t,u},{a},{(s,ε,t),(t,a,u)},s,{u}),a)";
+        NFA nfa = new NFA(instance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("sequence of states", result);
+        Assert.DoesNotContain("No Solution", result);
+    }
+
+    [Fact]
+    public void NFA_Solver_Accepts_Empty_String_Via_Epsilon_To_Accept_State()
+    {
+        // s →ε→ t (accept); empty input is accepted through the ε-closure of s
+        string instance = "(({s,t},{a},{(s,ε,t)},s,{t}),ε)";
+        NFA nfa = new NFA(instance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("sequence of states", result);
+        Assert.DoesNotContain("No Solution", result);
+    }
+
+    [Fact]
+    public void NFA_Solver_Rejects_Input_With_No_Accepting_Run()
+    {
+        // From s only 'a' transitions exist; input "b" has no valid run
+        string instance = "(({s,t},{a,b},{(s,a,t)},s,{t}),b)";
+        NFA nfa = new NFA(instance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("No Solution", result);
+    }
+
+    [Fact]
+    public void NFA_Solver_Rejects_Character_Not_In_Alphabet()
+    {
+        NFA nfa = new NFA("(({s,t},{a},{(s,a,t)},s,{t}),c)");
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("No Solution", result);
+        Assert.Contains("'c'", result);
+    }
+
+    [Fact]
+    public void NFA_Solver_Handles_Epsilon_Cycle_Without_Infinite_Loop()
+    {
+        // s →ε→ t →ε→ s creates a cycle; the visited set must prevent infinite recursion.
+        // The direct path s →a→ u (accept) must still be found.
+        string instance = "(({s,t,u},{a},{(s,ε,t),(t,ε,s),(s,a,u)},s,{u}),a)";
+        NFA nfa = new NFA(instance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("sequence of states", result);
+        Assert.DoesNotContain("No Solution", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Verifier
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("1,2")]      // direct path: 1 →a→ 2
+    [InlineData("1,2,2")]    // ε-then-regular: 1 →ε→ 2 →a→ 2
+    [InlineData("1,2,3,2")]  // ε-chain: 1 →ε→ 2 →ε→ 3 →a→ 2
+    public void NFA_Verifier_Accepts_Valid_Certificate(string certificate)
+    {
+        NFA nfa = new NFA(DefaultInstance);
+        NFAVerifier verifier = new NFAVerifier();
+        Assert.True(verifier.verify(nfa, certificate));
+    }
+
+    [Theory]
+    [InlineData("1,3")]     // no valid run for input "a" starts 1→3 (that requires reading 'b')
+    [InlineData("1,3,2")]   // would require reading 'b' then 'a', but input is only "a"
+    [InlineData("2,2")]     // doesn't start at start state "1"
+    public void NFA_Verifier_Rejects_Invalid_Certificate(string certificate)
+    {
+        NFA nfa = new NFA(DefaultInstance);
+        NFAVerifier verifier = new NFAVerifier();
+        Assert.False(verifier.verify(nfa, certificate));
+    }
+
+    [Fact]
+    public void NFA_Verifier_Accepts_Epsilon_Path_Certificate()
+    {
+        // s →ε→ t (accept), empty input; certificate "s,t" traces the ε transition
+        string instance = "(({s,t},{a},{(s,ε,t)},s,{t}),ε)";
+        NFA nfa = new NFA(instance);
+        NFAVerifier verifier = new NFAVerifier();
+        Assert.True(verifier.verify(nfa, "s,t"));
+    }
+
+    [Fact]
+    public void NFA_Verifier_Returns_False_When_No_Accepting_Run_Exists()
+    {
+        // Input "b" has no accepting run; the verifier must return false for any certificate
+        string instance = "(({s,t},{a,b},{(s,a,t)},s,{t}),b)";
+        NFA nfa = new NFA(instance);
+        NFAVerifier verifier = new NFAVerifier();
+        Assert.False(verifier.verify(nfa, "s,t"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Solver — output content
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("1, 2")]      // direct: 1 →a→ 2
+    [InlineData("1, 2, 2")]   // ε-then-regular: 1 →ε→ 2 →a→ 2
+    [InlineData("1, 2, 3, 2")] // ε-chain: 1 →ε→ 2 →ε→ 3 →a→ 2
+    public void NFA_Solver_Output_Contains_Known_Accepting_Path(string expectedPath)
+    {
+        NFA nfa = new NFA(DefaultInstance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains(expectedPath, result);
+    }
+
+    [Fact]
+    public void NFA_Solver_Returns_State_Path_For_Epsilon_Accepted_Input()
+    {
+        // s →ε→ t (accept), empty input; the only accepting path is "s, t"
+        string instance = "(({s,t},{a},{(s,ε,t)},s,{t}),ε)";
+        NFA nfa = new NFA(instance);
+        NFASolver solver = new NFASolver();
+        string result = solver.solve(nfa);
+        Assert.Contains("s, t", result);
+    }
+}


### PR DESCRIPTION
DFA Tests (30 tests)

Instantiation (2)
Default constructor sets instance = defaultInstance
Custom instance parses and exposes correct field values

Parsing (6)
Correct node count (Theory, 2 instances)
Correct edge count (Theory, 2 instances)
Start state, accept states, alphabet, and input string all parse to expected values

Parsing — error cases (6)
Rejects NFA instance containing ε edges (ε ∉ alphabet)
Rejects edge symbol not in alphabet
Rejects unknown start state, unknown accept state, edge from unknown node, edge to unknown node

Solver (8)
Accepts valid input (reaches accept state)
Rejects input ending in non-accept state
Accepts multi-step inputs (Theory, 2 instances)
Rejects character not in alphabet (verifies error message names the character)
Accepts empty string when start state is accept
Rejects empty string when start state is not accept
Output contains correct state labels for a known path

Verifier (5)
Accepts valid paths (Theory: direct path, multi-hop path)
Rejects path ending in non-accept state (Theory: 2 cases)
Rejects path not starting at start state (Theory: 2 cases)
Accepts single-node certificate when start equals accept

Solver output content (3)
Returns correct state path for accepted inputs (Theory: 3 instances with hardcoded expected paths)

NFA Tests (35 tests)

Instantiation (2)
Default constructor sets instance = defaultInstance
Custom DFA-like instance (no ε) parses correctly and has no ε edges

Parsing (7)
Correct node count (Theory, 2 instances)
ε edges parsed with symbol '\u03B5', correct count and from/to nodes
ε edge allowed even when ε is absent from the declared alphabet
DFA instance accepted as valid NFA (no ε edges in result)
Rejects edge symbol not in alphabet and not ε
Rejects unknown start state, unknown accept state

DFA vs NFA structural asymmetry (2)
NFA constructed from DFA default instance succeeds and solver finds a solution — documents the backend root cause of the frontend visualization bug
DFA constructed from NFA default instance throws InvalidOperationException — documents why NFA→DFA clears the visualization but DFA→NFA does not

Solver (8)
Accepts input via direct path
Returns multiple accepting paths for nondeterministic input (≥ 2 lines)
Accepts input via ε-then-regular transition
Accepts empty string via ε to accept state
Rejects input with no accepting run
Rejects character not in alphabet
Handles ε-cycle without infinite loop (visited set guard)

Verifier (5)
Accepts valid certificates (Theory: direct path, ε-then-regular, ε-chain)
Rejects invalid certificates (Theory: path requiring wrong input, path not from start state)
Accepts ε-transition path certificate
Returns false when no accepting run exists for the input

Solver output content (4)
Output contains each of the three known accepting paths for the default instance (Theory: 3 cases)
Output contains "s, t" for an ε-only accepting instance

Closes #207 
Closes #208 