### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - CSharpAPI
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ReduxISU/Redux/security/code-scanning/2](https://github.com/ReduxISU/Redux/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/main.yml` at the workflow root so it applies to both jobs unless overridden.  
Best minimal fix without changing behavior: set:

- `contents: read`

This is sufficient for `actions/checkout` and read-only repository operations used by this workflow. No imports, methods, or dependencies are needed—just YAML edit near the top of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
