### PR TITLE
Added Pump Schedule Visualization for official Redux Frontend

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Visualizations.cs
+++ b/AdditionalControllers/Navigation/Nav_Visualizations.cs
@@ -101,43 +101,50 @@ public class Problem_VisualizationsRefactorController : ControllerBase {
     [HttpGet]
     public String getDefault([FromQuery]string chosenProblem,[FromQuery]string problemType) {
         List<string> NOT_FOUND_ERR_Visualization = new();
-
-        // Determine the directory to search based on prefix. chosenProblem expected to be a problemName like "NPC_PROBLEM"\
-        string problemTypeDirectory = "";
-        string jsonString = "";
         var options = new JsonSerializerOptions { WriteIndented = true };
-
-        if (problemType == "NPC") {
-            problemTypeDirectory = "NPComplete";
-        }
-        else if (problemType == "P") {
-            problemTypeDirectory = "Polynomial";
-        }
 
         try
         {
             string projectSourcePath = ProjectSourcePath.Value;
-            string?[] subfiles = Directory.GetFiles(projectSourcePath+ @"Problems/" + problemTypeDirectory + "/" + problemType + "_" + chosenProblem + "/Visualizations")
-                                .Select(Path.GetFileName)
-                                .ToArray();
+            string problemsRoot = Path.Combine(projectSourcePath, "Problems");
 
-            ArrayList subFilesList = new ArrayList();
-
-            foreach (var file in subfiles)
+            // Search all complexity-class subdirectories for any folder ending with _<chosenProblem>
+            // so that NPH, NPC, P, and any future types are all found regardless of the
+            // problemType query parameter (which the Redux_GUI client hardcodes to "NPC").
+            string[]? visFiles = null;
+            foreach (string typeDir in Directory.GetDirectories(problemsRoot))
             {
-                if (file is null)
-                    continue;
-                string fileNoExt = file.Split('.')[0]; //gets the file without the file extension
-                subFilesList.Add(fileNoExt);
+                foreach (string probDir in Directory.GetDirectories(typeDir))
+                {
+                    string folderName = Path.GetFileName(probDir);
+                    if (!folderName.EndsWith("_" + chosenProblem, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string visPath = Path.Combine(probDir, "Visualizations");
+                    if (!Directory.Exists(visPath))
+                        continue;
+
+                    visFiles = Directory.GetFiles(visPath)
+                                       .Select(Path.GetFileName)
+                                       .Where(f => f is not null)
+                                       .ToArray()!;
+                    break;
+                }
+                if (visFiles is not null) break;
             }
 
-            // Not completed. Needs to loop through these directories to get the rest of the problems
-            jsonString = JsonSerializer.Serialize(subFilesList, options);
+            if (visFiles is null)
+                return JsonSerializer.Serialize(NOT_FOUND_ERR_Visualization, options);
+
+            var subFilesList = new ArrayList();
+            foreach (var file in visFiles)
+                subFilesList.Add(file!.Split('.')[0]); // strip .cs extension
+
+            return JsonSerializer.Serialize(subFilesList, options);
         }
         catch (System.IO.DirectoryNotFoundException)
         {
-            jsonString = JsonSerializer.Serialize(NOT_FOUND_ERR_Visualization, options);
+            return JsonSerializer.Serialize(NOT_FOUND_ERR_Visualization, options);
         }
-        return jsonString;
     }
 }

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/PUMPSCHEDULINGCM_Class.cs
@@ -1,16 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using API.Interfaces;
-using API.DummyClasses;
 using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
 using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Verifiers;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Visualizations;
 using SPADE;
 
 namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM;
 
 record PumpData(string Name, double FlowRateGph, double PowerKw, double StartupCostDollars);
 
-class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifier, DummyVisualization>
+class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifier, PumpSchedulingCMVisualization>
 {
     public string problemName { get; } = "Pump Scheduling (Cost Minimization)";
     public string problemLink { get; } = "";
@@ -58,7 +58,7 @@ class PUMPSCHEDULINGCM : IProblem<PumpSchedulingCMSolver, PumpSchedulingCMVerifi
 
     public PumpSchedulingCMSolver defaultSolver { get; } = new();
     public PumpSchedulingCMVerifier defaultVerifier { get; } = new();
-    public DummyVisualization defaultVisualization { get; } = new();
+    public PumpSchedulingCMVisualization defaultVisualization { get; } = new();
 
     public PUMPSCHEDULINGCM() : this(DefaultInstance) { }
 

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
@@ -17,6 +17,11 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
     public string[] contributors { get; } = { "SARE 2026 Team" };
     public bool timerHasExpired { get; set; }
 
+    // Return a non-empty sentinel so the IVisualization<T> default dispatch in
+    // VisualizationInterface.cs does not short-circuit StepsVisualization when
+    // the steps list is empty.
+    public List<object> GetSteps(PUMPSCHEDULINGCM _) => [true];
+
     private const int Hours = 24;
     private const int Buckets = 1000;
     private const double Inf = double.MaxValue / 2;

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Visualizations/PumpSchedulingCMVisualization.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Visualizations/PumpSchedulingCMVisualization.cs
@@ -1,0 +1,168 @@
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Solvers;
+using SPADE;
+
+namespace API.Problems.NPHard.NPH_PUMPSCHEDULINGCM.Visualizations;
+
+// --- Frame data types (lowercase property names serialize to camelCase JSON) ---
+
+record PumpStatusEntry(string name, bool isOn, double flowGph, double powerKw);
+
+record PumpFrameMetrics(
+    int hour,
+    double stepCost,
+    double cumulativeCost,
+    double tankLevel,
+    double tankCapacity,
+    double tankFillRatio,
+    double flowIn,
+    double demand,
+    bool isPeakHour
+);
+
+record PumpFrameState(List<PumpStatusEntry> pumps);
+
+class API_PumpFrame : API_JSON
+{
+    public string action { get; }
+    public PumpFrameMetrics metrics { get; }
+    public PumpFrameState state { get; }
+
+    public API_PumpFrame(string action, PumpFrameMetrics metrics, PumpFrameState state)
+    {
+        this.action = action;
+        this.metrics = metrics;
+        this.state = state;
+    }
+}
+
+// --- Visualization ---
+
+class PumpSchedulingCMVisualization : IVisualization<PUMPSCHEDULINGCM>
+{
+    public string visualizationName { get; } = "Pump Scheduling CM — DAG Animation";
+    public string visualizationDefinition { get; } =
+        "Animates the 24-hour optimal pump schedule, showing per-hour pump states, " +
+        "tank levels, and cumulative costs produced by the DAG dynamic programming solver.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "SARE 2026 Team" };
+    public string visualizationType { get; } = "pump";
+    public ISolver solver { get; } = new PumpSchedulingCMSolver();
+
+    public API_JSON visualize(PUMPSCHEDULINGCM problem) => new API_empty();
+
+    public API_JSON SolvedVisualization(PUMPSCHEDULINGCM problem, string solution) => new API_empty();
+
+    // Explicitly override the default interface dispatch, which skips the typed method
+    // when steps is empty (which it always is since GetSteps() returns [] by default).
+    List<API_JSON> IVisualization.StepsVisualization(string instance, List<object> steps)
+        => StepsVisualization(new PUMPSCHEDULINGCM(instance), steps);
+
+    public List<API_JSON> StepsVisualization(PUMPSCHEDULINGCM problem, List<object> _steps)
+    {
+        string certificate = new PumpSchedulingCMSolver().solve(problem);
+        if (string.IsNullOrEmpty(certificate))
+            return new List<API_JSON>();
+
+        // Parse certificate: (totalCost,((PumpName,h0,...,h23),...))
+        int n = problem.Pumps.Count;
+        int[] schedMasks = new int[24];
+
+        try
+        {
+            var cert = new UtilCollection(certificate);
+            var certParts = cert.ToList();
+            var schedSection = (UtilCollection)certParts[1];
+
+            int pumpIdx = 0;
+            foreach (UtilCollection pumpRow in schedSection)
+            {
+                var parts = pumpRow.ToList();
+                for (int h = 0; h < 24 && h + 1 < parts.Count; h++)
+                {
+                    if (parts[h + 1].ToString().Trim() == "1")
+                        schedMasks[h] |= (1 << pumpIdx);
+                }
+                pumpIdx++;
+            }
+        }
+        catch
+        {
+            return new List<API_JSON>();
+        }
+
+        // Build one frame per hour
+        var frames = new List<API_JSON>();
+        double tankLevel = problem.TankCurrentLevel;
+        double cumulativeCost = 0.0;
+        int prevMask = 0;
+        int nMasks = 1 << n;
+
+        for (int h = 0; h < 24; h++)
+        {
+            int mask = schedMasks[h];
+            bool isPeak = problem.PeakHours.Contains(h);
+            double rate = isPeak ? problem.OnPeakCostPerKwh : problem.OffPeakCostPerKwh;
+
+            double energyCost = 0.0;
+            double flowIn = 0.0;
+            double startupCost = 0.0;
+            int startups = (~prevMask) & mask & (nMasks - 1);
+
+            for (int p = 0; p < n; p++)
+            {
+                if ((mask & (1 << p)) != 0)
+                {
+                    energyCost += problem.Pumps[p].PowerKw * rate;
+                    flowIn += problem.Pumps[p].FlowRateGph;
+                }
+                if ((startups & (1 << p)) != 0)
+                    startupCost += problem.Pumps[p].StartupCostDollars;
+            }
+
+            double stepCost = energyCost + startupCost;
+            cumulativeCost += stepCost;
+            double hourDemand = problem.DemandGph[h];
+            tankLevel = Math.Clamp(tankLevel - hourDemand + flowIn, 0.0, problem.TankCapacity);
+
+            var pumpStatuses = new List<PumpStatusEntry>();
+            var activeNames = new List<string>();
+            for (int p = 0; p < n; p++)
+            {
+                bool isOn = (mask & (1 << p)) != 0;
+                if (isOn) activeNames.Add(problem.Pumps[p].Name);
+                pumpStatuses.Add(new PumpStatusEntry(
+                    problem.Pumps[p].Name,
+                    isOn,
+                    isOn ? problem.Pumps[p].FlowRateGph : 0.0,
+                    problem.Pumps[p].PowerKw
+                ));
+            }
+
+            string pumpsLabel = activeNames.Count > 0
+                ? string.Join(", ", activeNames) + " ON"
+                : "All pumps OFF";
+
+            frames.Add(new API_PumpFrame(
+                $"Hour {h} [{(isPeak ? "Peak" : "Off-Peak")}]: {pumpsLabel} — tank {tankLevel:F0} gal",
+                new PumpFrameMetrics(
+                    h,
+                    Math.Round(stepCost, 4),
+                    Math.Round(cumulativeCost, 4),
+                    Math.Round(tankLevel, 1),
+                    problem.TankCapacity,
+                    Math.Round(problem.TankCapacity > 0 ? tankLevel / problem.TankCapacity : 0.0, 4),
+                    Math.Round(flowIn, 2),
+                    Math.Round(hourDemand, 2),
+                    isPeak
+                ),
+                new PumpFrameState(pumpStatuses)
+            ));
+
+            prevMask = mask;
+        }
+
+        return frames;
+    }
+}


### PR DESCRIPTION
Pump Scheduling Visualization — Implementation Summary
Goal
Connect the existing SARE_2026 frontend's pump scheduling animations to the C# backend (instead of Python), and add a matching step-through visualization to the older Redux_GUI frontend — all without creating new API endpoints.

C# Backend (c:\Users\mtros\Programming\Redux)
PumpSchedulingCMVisualization.cs (new file)

Implemented IVisualization<PUMPSCHEDULINGCM> inside the existing /ProblemProvider/visualize endpoint pipeline. The visualization:

Runs the DAG DP solver internally to obtain the optimal 24-hour certificate
Parses the SPADE certificate format (totalCost,((PumpName,h0,...,h23),...))
Builds 24 API_PumpFrame objects — one per hour — each carrying:
action: human-readable label ("Hour 7 [Peak]: Pump 2 ON — tank 17300 gal")
metrics: hour, stepCost, cumulativeCost, tankLevel, tankCapacity, tankFillRatio, flowIn, demand, isPeakHour
state.pumps: per-pump on/off status, flow rate, power draw
A key design challenge: the IVisualization<T> default interface method short-circuits with an empty result when the solver returns no step objects (which is always the case here, since GetSteps defaults to []). Two fixes were applied together:

An explicit IVisualization.StepsVisualization override in the visualization class that bypasses the guard entirely
A GetSteps instance method override in the solver returning a non-empty sentinel [true]
PumpSchedulingCMSolver.cs (modified)

Added the GetSteps sentinel override. The static keyword was intentionally avoided — it must be an instance method to properly override the interface default.

PUMPSCHEDULINGCM_Class.cs (modified)

Swapped DummyVisualization for PumpSchedulingCMVisualization in the IProblem<> type parameters and defaultVisualization property.

Nav_Visualizations.cs (modified)

The Problem_VisualizationsRefactorController previously constructed filesystem paths using a hardcoded type-to-directory mapping (NPC → NPComplete, P → Polynomial). Since Redux_GUI hardcodes problemType="NPC" for all problems, NPHard problems were never found and their visualization dropdowns were always empty.

Replaced the hardcoded lookup with a directory scan across all subdirectories of Problems/, matching any folder ending in _<chosenProblem> regardless of type prefix. This fixes the dropdown for all NPHard problems without requiring any client-side changes.

SARE_2026 Frontend (c:\Users\mtros\Programming\SARE_2026)
GenericProblemWorkspace.tsx (modified)

Changed the fetch URL from /animate to /csharp-api/ProblemProvider/visualize?visualization=PumpSchedulingCMVisualization. The frontend:

Builds a SPADE-format instance string from the live pump topology state (tank capacity/level, 24-hour demand curve, peak hours, tariff rates, pump specs with flowGpm × 60 conversion to gph)
Receives the 24 frames and enriches the final frame with pump_schedule_matrix, simulated_storage_trajectory, and energy_cost_total derived from the frame data
Feeds the enriched frames into the existing pump topology animation — the same animated canvas with hour-by-hour pump on/off states, tank fill level, and cost display that the Python backend path uses
Redux_GUI Frontend (c:\Users\mtros\Programming\Redux_GUI)
PumpSchedulingSvgReact.js (new file)

A MUI-based step renderer for a single API_PumpFrame. Displays:

Hour number and peak/off-peak badge
Action description string
Tank fill LinearProgress bar with gallon count and percentage
Pump status table (name, ON/OFF chip, flow gph, power kW)
Grid of key metrics: flow in, demand, step cost, cumulative cost
Visualizations.js (modified)

Added "pump" to the visualization type dispatch map, pointing to the new component. Redux_GUI's built-in step controls (◀◀ ◀ ▶ ▶▶) handle hour-by-hour navigation across all 24 frames automatically.