### PR TITLE
Use $default-branch in workflow branch filters instead of hardcoded name

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "CSharpAPI" ]
+    branches: [ $default-branch ]
   pull_request:
-    branches: [ "CSharpAPI" ]
+    branches: [ $default-branch ]
   schedule:
     - cron: '29 1 * * 6'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker build and push
 on:
   push:
     branches:
-      - CSharpAPI
+      - $default-branch
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: dotnet build
 on:
   pull_request:
     branches:
-      - CSharpAPI
+      - $default-branch
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Replaces hardcoded `CSharpAPI` in `main.yml`, `docker.yml`, and `codeql.yml` branch filters with the `$default-branch` token
- `$default-branch` resolves to whatever the repository's current default branch is set to, so CI triggers automatically survive a branch rename

## Test plan

- [ ] Verify the three workflow files no longer reference `CSharpAPI` literally
- [ ] Confirm workflows still trigger as expected on a PR to `CSharpAPI`

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)