### PR TITLE
Fix TSP and Hamiltonian verifiers missing closing-edge check

### DIFF
--- a/Problems/NPComplete/NPC_HAMILTONIAN/Verifiers/HamiltonianVerifier.cs
+++ b/Problems/NPComplete/NPC_HAMILTONIAN/Verifiers/HamiltonianVerifier.cs
@@ -34,17 +34,25 @@ class HamiltonianVerifier : IVerifier<HAMILTONIAN> {
     {
         List<string> order = certificate.Replace("{","").Replace("}","").Split(',').ToList();
         List<string> check = new List<string>(problem.nodes);
-        
-        for (int i = 0; i < order.Count - 1; i++)
+
+        // Solvers repeat the starting node at the end (e.g. {1,2,3,4,5,1}).
+        // Work on the deduplicated node sequence so the closing edge is always checked explicitly.
+        int nodeCount = (order.Count > 1 && order[0] == order[order.Count - 1])
+            ? order.Count - 1
+            : order.Count;
+
+        for (int i = 0; i < nodeCount; i++)
         {
-            KeyValuePair<string, string> pairCheck1 = new KeyValuePair<string, string>(order[i], order[i + 1]);
-            KeyValuePair<string, string> pairCheck2 = new KeyValuePair<string, string>(order[i+1], order[i]);
+            string from = order[i];
+            string to   = order[(i + 1) % nodeCount];
+            KeyValuePair<string, string> pairCheck1 = new KeyValuePair<string, string>(from, to);
+            KeyValuePair<string, string> pairCheck2 = new KeyValuePair<string, string>(to, from);
             if (!(problem.edges.Contains(pairCheck1) || problem.edges.Contains(pairCheck2)))
             {
                 return false;
             }
-            if(check.Contains(order[i])) {
-                check.Remove(order[i]);
+            if(check.Contains(from)) {
+                check.Remove(from);
             } else {
                 return false;
             }
@@ -53,7 +61,7 @@ class HamiltonianVerifier : IVerifier<HAMILTONIAN> {
         if(check.Any()) {
             return false;
         }
-        
+
         return true;
         
     }

--- a/Problems/NPComplete/NPC_TSP/Verifiers/TSPVerifier.cs
+++ b/Problems/NPComplete/NPC_TSP/Verifiers/TSPVerifier.cs
@@ -35,17 +35,25 @@ class TSPVerifier : IVerifier<TSP> {
         List<string> order = certificate.Replace("{","").Replace("}","").Split(',').ToList();
         int sum = 0;
     
-        for (int i = 0; i < order.Count - 1; i++)
+        // Determine the effective node count — solvers repeat the starting node at the end
+        // (e.g. {A,B,C,D,A}), so clamp the loop to avoid checking A→A.
+        int nodeCount = (order.Count > 1 && order[0] == order[order.Count - 1])
+            ? order.Count - 1
+            : order.Count;
+
+        for (int i = 0; i < nodeCount; i++)
         {
-            bool check1 = problem.edges.Any(tuple => tuple.source == order[i] && tuple.target == order[i+1]);
-            bool check2 = problem.edges.Any(tuple => tuple.source == order[i+1] && tuple.target == order[i]);
+            string from = order[i];
+            string to   = order[(i + 1) % nodeCount];
+            bool check1 = problem.edges.Any(tuple => tuple.source == from && tuple.target == to);
+            bool check2 = problem.edges.Any(tuple => tuple.source == to   && tuple.target == from);
             if (check1) {
-                var matchingTuple = problem.edges.FirstOrDefault(tuple => tuple.Item1 == order[i] && tuple.Item2 == order[i+1]);
+                var matchingTuple = problem.edges.FirstOrDefault(tuple => tuple.Item1 == from && tuple.Item2 == to);
                 if(matchingTuple != default) {
                     sum += matchingTuple.Item3;
                 }
             } else if(check2) {
-                var matchingTuple = problem.edges.FirstOrDefault(tuple => tuple.Item1 == order[i+1] && tuple.Item2 == order[i]);
+                var matchingTuple = problem.edges.FirstOrDefault(tuple => tuple.Item1 == to && tuple.Item2 == from);
                 if(matchingTuple != default) {
                     sum += matchingTuple.Item3;
                 }


### PR DESCRIPTION
Both verifiers iterated order.Count - 1 times, leaving the return edge (last node → first node) unchecked when a certificate is submitted without the repeated starting node. The fix normalises the node sequence (stripping the solver-appended duplicate) and uses modular indexing so every edge in the cycle — including the closing one — is always validated.