### PR TITLE
Fix HttpClient socket exhaustion in QuantumServerAPI (#291)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,6 +8,12 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.Configure<QuantumSolverSettings>(
     builder.Configuration.GetSection("QuantumSolver"));
+builder.Services.AddHttpClient("quantum", (sp, client) =>
+{
+    var settings = sp.GetRequiredService<IOptionsMonitor<QuantumSolverSettings>>().CurrentValue;
+    client.BaseAddress = new Uri(settings.BaseURL);
+    client.Timeout = TimeSpan.FromSeconds(30);
+});
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -40,9 +46,9 @@ var app = builder.Build();
 
 app.UseStaticFiles();
 
-QuantumSolverSettingsGlobal.QuantumSolver = app.Services
-    .GetRequiredService<IOptionsMonitor<QuantumSolverSettings>>()
-    .CurrentValue;
+var optionsMonitor = app.Services.GetRequiredService<IOptionsMonitor<QuantumSolverSettings>>();
+QuantumSolverSettingsGlobal.QuantumSolver = optionsMonitor.CurrentValue;
+QuantumSolverSettingsGlobal.HttpClientFactory = app.Services.GetRequiredService<IHttpClientFactory>();
 
 // Somewhat of a security concern. But since we are not doing POSTS im not concerned about it
 app.Use((context, next) =>

--- a/QuantumSolverSettings.cs
+++ b/QuantumSolverSettings.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Authentication;
-
 /// <summary>
 /// Manages configuration settings for the Quantum Solver service.
 /// Provides a default base URL and allows customization through constructors.
@@ -8,6 +6,9 @@ public static class QuantumSolverSettingsGlobal
 {
     /// <summary>Global Quantum Solver configuration instance, populated at startup.</summary>
     public static QuantumSolverSettings QuantumSolver { get; internal set; } = null!;
+
+    /// <summary>Shared IHttpClientFactory for QuantumServerAPI, populated at startup.</summary>
+    public static IHttpClientFactory HttpClientFactory { get; internal set; } = null!;
 }
 
 /// <summary>Configuration settings for the Quantum Solver service.</summary>

--- a/Tools/QuantumServerAPI.cs
+++ b/Tools/QuantumServerAPI.cs
@@ -1,7 +1,5 @@
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.Options;
 
 namespace API.Tools;
 
@@ -17,16 +15,12 @@ public class QuantumServerAPI
     // --- Constructor ---
 
     /// <summary>
-    /// Creates a new QuantumServerAPI instance.
+    /// Creates a new QuantumServerAPI instance using the shared IHttpClientFactory.
     /// </summary>
     public QuantumServerAPI()
     {
         _baseUrl = QuantumSolverSettingsGlobal.QuantumSolver.BaseURL;
-        _httpClient = new HttpClient
-        {
-            BaseAddress = new Uri(_baseUrl),
-            Timeout = TimeSpan.FromSeconds(30)
-        };
+        _httpClient = QuantumSolverSettingsGlobal.HttpClientFactory.CreateClient("quantum");
     }
 
     // --- Public Methods ---


### PR DESCRIPTION
Fixes #291.

## Summary

- `QuantumServerAPI` was creating `new HttpClient()` per call across 14 solver/visualization call sites, leaking sockets into `TIME_WAIT` and never calling `Dispose()`.
- Registers a named `"quantum"` typed client via `AddHttpClient` in `Program.cs`, which lets `IHttpClientFactory` manage the underlying `SocketsHttpHandler` pool.
- Exposes `IHttpClientFactory` via `QuantumSolverSettingsGlobal.HttpClientFactory` (the same static-global pattern already used for `QuantumSolverSettings`) so the 14 `Activator.CreateInstance` call sites require no changes.
- `BaseAddress` and `Timeout` are now configured once in the factory registration; the `QuantumSolver__BaseURL` environment variable correctly drives the full request path (it already drove error messages before).

## What's not addressed

`.Result` blocking on async `PostAsync` calls remains — fixing it requires making `ISolver.solve` async, which touches interfaces and controllers and belongs in a separate PR.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 552/552 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)