### PR TITLE
Implement MaxCut brute-force solver and real verifier

### DIFF
--- a/Problems/NPComplete/NPC_MAXCUT/Solvers/MaxCutSolver.cs
+++ b/Problems/NPComplete/NPC_MAXCUT/Solvers/MaxCutSolver.cs
@@ -6,17 +6,49 @@ namespace API.Problems.NPComplete.NPC_MAXCUT.Solvers;
 class MaxCutSolver : ISolver<MAXCUT> {
 
     // --- Fields ---
-    public string solverName {get;} = "Max Cut Solver";
-    public string solverDefinition {get;} = "TODO";
-    public string source {get;} = "TODO";
+    public string solverName {get;} = "Max Cut Brute Force Solver";
+    public string solverDefinition {get;} = "Enumerates all 2^n partitions of the vertex set and returns the side S of the partition whose crossing edges have maximum total weight. Certificate format: {node1,node2,...} representing the S side.";
+    public string source {get;} = "";
     public string[] contributors {get;} = {"Max Gruenwoldt", "Eric Hill"};
     public bool timerHasExpired { get; set; }
 
     public MaxCutSolver() { }
 
-    public string solve(MAXCUT maxcut){
-        return "TODO";
+    private int cutWeight(MAXCUT maxcut, HashSet<string> S) {
+        int total = 0;
+        foreach (var edge in maxcut.edges) {
+            bool srcInS = S.Contains(edge.source);
+            bool dstInS = S.Contains(edge.destination);
+            if (srcInS != dstInS)
+                total += edge.weight;
+        }
+        return total;
+    }
+
+    public string solve(MAXCUT maxcut) {
+        List<string> nodes = maxcut.nodes;
+        int n = nodes.Count;
+        if (n == 0) return "{}";
+
+        int bestWeight = -1;
+        HashSet<string> bestS = new();
+
+        // Each bitmask assigns each node to S (bit=1) or T (bit=0).
+        // Skip mask 0 (all in T) and (1<<n)-1 (all in S) — both give empty cuts.
+        int limit = 1 << n;
+        for (int mask = 1; mask < limit - 1; mask++) {
+            HashSet<string> S = new();
+            for (int i = 0; i < n; i++)
+                if ((mask >> i & 1) == 1) S.Add(nodes[i]);
+
+            int w = cutWeight(maxcut, S);
+            if (w > bestWeight) {
+                bestWeight = w;
+                bestS = S;
+            }
+        }
+
+        if (bestS.Count == 0) return "{}";
+        return "{" + string.Join(",", bestS) + "}";
     }
 }
-
-   

--- a/Problems/NPComplete/NPC_MAXCUT/Verifiers/MaxCutVerifier.cs
+++ b/Problems/NPComplete/NPC_MAXCUT/Verifiers/MaxCutVerifier.cs
@@ -7,25 +7,38 @@ class MaxCutVerifier : IVerifier<MAXCUT> {
 
     // --- Fields ---
     public string verifierName {get;} = "Max Cut Verifier";
-    public string verifierDefinition {get;} = "TODO";
-    public string source {get;} = "TODO";
+    public string verifierDefinition {get;} = "Verifies that the certificate is a valid non-trivial partition S of the graph's vertices (all nodes in S belong to the graph and appear exactly once, and S is neither empty nor the full node set).";
+    public string source {get;} = "";
     public string[] contributors {get;} = {"Max Gruenwoldt", "Eric Hill"};
 
+    private string _certificate = "";
 
-    private string _certificate =  "";
-
-      public string certificate {
-        get {
-            return _certificate;
-        }
+    public string certificate {
+        get { return _certificate; }
     }
 
+    public MaxCutVerifier() { }
 
-    // --- Methods Including Constructors ---
-    public MaxCutVerifier() {
-    }
+    public bool verify(MAXCUT problem, string certificate) {
+        if (string.IsNullOrWhiteSpace(certificate) || certificate == "{}")
+            return false;
 
-    public bool verify(MAXCUT problem, string certificate){
+        List<string> S = GraphParser.parseNodeListWithStringFunctions(certificate)
+                            .Where(s => !string.IsNullOrWhiteSpace(s))
+                            .ToList();
+
+        if (S.Count == 0) return false;
+
+        // Every node in S must exist in the graph.
+        foreach (string node in S)
+            if (!problem.nodes.Contains(node)) return false;
+
+        // No duplicate nodes in S.
+        if (S.Count != S.Distinct().Count()) return false;
+
+        // S must be a proper subset (not empty, not the entire vertex set).
+        if (S.Count == problem.nodes.Count) return false;
+
         return true;
     }
 }


### PR DESCRIPTION
Solver: enumerates all 2^n vertex partitions, computes the total weight of crossing edges for each, and returns the S-side node set of the maximum cut as {node1,node2,...}.

Verifier: replaced the always-true stub with a check that the certificate is a valid proper non-trivial partition (all nodes exist in the graph, no duplicates, not empty, not the full vertex set).