### PR TITLE
Fix Partition and SetCover solver loop bounds

### DIFF
--- a/Problems/NPComplete/NPC_PARTITION/Solvers/PartitionBruteForce.cs
+++ b/Problems/NPComplete/NPC_PARTITION/Solvers/PartitionBruteForce.cs
@@ -52,7 +52,7 @@ class PartitionBruteForce : ISolver<PARTITION> {
             binary.Add(0);
         }
         string certificate = BinaryToCertificate(binary, partition.S);
-        while(counter <= Math.Pow(2,partition.S.Count)){
+        while(counter < Math.Pow(2,partition.S.Count)){
             nextBinary(binary);
             certificate = BinaryToCertificate(binary, partition.S);
             if(partition.defaultVerifier.verify(partition, certificate)){

--- a/Problems/NPComplete/NPC_SETCOVER/Solvers/SetCoverBruteForce.cs
+++ b/Problems/NPComplete/NPC_SETCOVER/Solvers/SetCoverBruteForce.cs
@@ -69,7 +69,7 @@ class SetCoverBruteForce : ISolver<SETCOVER> {
                 combination.Add(i);
             }
             BigInteger reps = factorial(setCover.subsets.Count) / (factorial(j) * factorial(setCover.subsets.Count - j));
-            for (int i = 0; i < reps; i++)
+            for (BigInteger i = 0; i < reps; i++)
             {
                 string certificate = indexListToCertificate(combination, setCover.subsets);
                 if (setCover.defaultVerifier.verify(setCover, certificate))


### PR DESCRIPTION
Partition: while(counter <= 2^n) ran one extra iteration, re-checking an already-seen binary state. Changed to < so exactly 2^n distinct states are evaluated without the off-by-one duplicate.

SetCover: the combination-count loop used `int i` against a BigInteger upper bound. When the binomial coefficient exceeds int.MaxValue the int overflows to a negative value that stays < the BigInteger forever, creating an infinite loop. Changed the loop variable to BigInteger.