### PR TITLE
fix CS8600/CS8604 nullability warnings in VisualizationInterface.cs

### DIFF
--- a/Interfaces/VisualizationInterface.cs
+++ b/Interfaces/VisualizationInterface.cs
@@ -24,7 +24,7 @@ interface IVisualization<U> : IVisualization where U : IProblem
         // Should there be some sort of contraint that assures there is a constructor
         // that matches the signature of a single `string` argument?
         // Perhaps a static `FromInstance(string instance)` method for `IProblem` will work.
-        return visualize((U)Activator.CreateInstance(typeof(U), problem));
+        return visualize((U)Activator.CreateInstance(typeof(U), problem)!);
     }
     API_JSON visualize(U problem);
 
@@ -34,7 +34,7 @@ interface IVisualization<U> : IVisualization where U : IProblem
         // Should there be some sort of contraint that assures there is a constructor
         // that matches the signature of a single `string` argument?
         // Perhaps a static `FromInstance(string instance)` method for `IProblem` will work.
-        return SolvedVisualization((U)Activator.CreateInstance(typeof(U), problem), solution);
+        return SolvedVisualization((U)Activator.CreateInstance(typeof(U), problem)!, solution);
     }
     API_JSON SolvedVisualization(U problem, string solution)
     {
@@ -45,7 +45,7 @@ interface IVisualization<U> : IVisualization where U : IProblem
     {
         if (steps.Count == 0)
             return new List<API_JSON>();
-        return StepsVisualization((U)Activator.CreateInstance(typeof(U), problem), steps);
+        return StepsVisualization((U)Activator.CreateInstance(typeof(U), problem)!, steps);
     }
 
     List<API_JSON> StepsVisualization(U problem, List<Object> steps)


### PR DESCRIPTION
## Summary

- `Activator.CreateInstance` returns `object?`, causing CS8600 (null assigned to non-nullable) and CS8604 (null passed as non-nullable argument) on three call sites in `IVisualization<U>`
- Added the `!` null-forgiving operator after each cast — safe because `CreateInstance` never returns null when constructing a concrete type with a matching constructor
- Clears 6 warnings (3×CS8600 + 3×CS8604) and brings the repo from 19 → **13 warnings** remaining

## Test plan

- [x] `dotnet build` — 0 errors, VisualizationInterface.cs no longer appears in warning output
- [x] `dotnet test` — 555 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)