### PR TITLE
fix CS8618: initialize DFASolver.nodePath to empty list

### DIFF
--- a/Problems/P/P_DFA/Solvers/DFASolver.cs
+++ b/Problems/P/P_DFA/Solvers/DFASolver.cs
@@ -15,7 +15,7 @@ class DFASolver : ISolver<DFA>
 
     public bool timerHasExpired { get; set; }
 
-    private List<string> nodePath;
+    private List<string> nodePath = [];
 
     // Methods Including Constructors //
     public DFASolver() { }


### PR DESCRIPTION
## Summary
- `nodePath` was declared without an initializer, producing a CS8618 nullability warning
- Initialized to `[]` so the field is never null; callers that invoke `GetSteps` before `solve` receive an empty list rather than a `NullReferenceException`

## Test plan
- [ ] `dotnet build` — CS8618 warning for `DFASolver.cs` is gone
- [ ] `dotnet test` — all DFA tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)