### PR TITLE
extract LabeledEdge from WeightedEdge, fixing CS8618 warnings

### DIFF
--- a/Interfaces/JSON_Objects/Graphs/API_GraphJSON.cs
+++ b/Interfaces/JSON_Objects/Graphs/API_GraphJSON.cs
@@ -48,7 +48,7 @@ class API_GraphJSON : API_JSON
     }
 
     // Added an API Graph JSON Constructor For DFAs That Builds Links With Weights -- Michael Trosper -- 1/20/26 //
-    public API_GraphJSON(List<string> nodes, List<WeightedEdge> inputEdges, string startState, List<string> acceptStates)
+    public API_GraphJSON(List<string> nodes, List<LabeledEdge> inputEdges, string startState, List<string> acceptStates)
     {
         _nodes = new List<API_Node_Programmable_Small>();
         foreach (string n in nodes)
@@ -60,7 +60,7 @@ class API_GraphJSON : API_JSON
         }
 
         _links = new List<API_Link>();
-        foreach (WeightedEdge e in inputEdges)
+        foreach (LabeledEdge e in inputEdges)
         {
             API_Link newLink = new API_Link(e.from, e.to, weight: e.value);
             _links.Add(newLink);

--- a/Interfaces/graphs/LabeledEdge.cs
+++ b/Interfaces/graphs/LabeledEdge.cs
@@ -1,0 +1,40 @@
+// LabeledEdge.cs
+// A directed edge whose endpoints and label are plain strings.
+// Used by the DFA/NFA automaton model (WeightedDirectedGraph), where
+// "value" holds the transition symbol(s), e.g. "a,b".
+// Split out of WeightedEdge (Michael Trosper's 1/13/2026 DFA additions) so that
+// the node-based WeightedEdge and this string-based edge are no longer one fused type.
+
+namespace API.Interfaces.Graphs;
+
+class LabeledEdge
+{
+    private string _from;
+    private string _to;
+    private string _value;
+
+    public LabeledEdge(string from, string to, string value)
+    {
+        _from = from;
+        _to = to;
+        _value = value;
+    }
+
+    public string from
+    {
+        get => _from;
+        set => _from = value;
+    }
+
+    public string to
+    {
+        get => _to;
+        set => _to = value;
+    }
+
+    public string value
+    {
+        get => _value;
+        set => _value = value;
+    }
+}

--- a/Interfaces/graphs/WeightedDirectedGraph.cs
+++ b/Interfaces/graphs/WeightedDirectedGraph.cs
@@ -10,19 +10,19 @@ namespace API.Interfaces.Graphs;
 class WeightedDirectedGraph : Graph
 {
     private List<string> _nodeList;
-    private List<WeightedEdge> _edgeList;
+    private List<LabeledEdge> _edgeList;
     private List<string> _acceptStates;
     private string _startState;
 
     public WeightedDirectedGraph()
     {
         _nodeList = new List<string>();
-        _edgeList = new List<WeightedEdge>();
+        _edgeList = new List<LabeledEdge>();
         _acceptStates = new List<string>();
         _startState = string.Empty;
     }
 
-    public WeightedDirectedGraph(List<string> N, List<WeightedEdge> E, string S, List<string> F)
+    public WeightedDirectedGraph(List<string> N, List<LabeledEdge> E, string S, List<string> F)
     {
         _nodeList = N;
         _edgeList = E;
@@ -42,7 +42,7 @@ class WeightedDirectedGraph : Graph
             "WeightedDirectedGraph does not expose the base Node/Edge view; use Nodes/Edges instead.");
     
     public List<string> Nodes { get => _nodeList; }
-    public List<WeightedEdge> Edges { get => _edgeList; }
+    public List<LabeledEdge> Edges { get => _edgeList; }
     public string StartState { get => _startState; }
     public List<string> AcceptStates { get => _acceptStates; }
 

--- a/Interfaces/graphs/WeightedEdge.cs
+++ b/Interfaces/graphs/WeightedEdge.cs
@@ -12,23 +12,10 @@ class WeightedEdge : IComparable<WeightedEdge>{
     private Node _target;
     private int _weight;
 
-    // Added Fields For DFA Case -- Michael Trosper 1/13/2026 //
-    private string _from;
-    private string _to;
-    private string _value;
-
     public WeightedEdge()
     {
         _source = new Node();
         _target = new Node();
-    }
-
-    // Added Constructor Accepting String Weight -- Michael Trosper 1/13/2026 //
-    public WeightedEdge(string from, string to, string weight)
-    {
-        _from = from;
-        _to = to;
-        _value = weight;
     }
 
     public WeightedEdge(Node n1, Node n2, int weight) {
@@ -70,43 +57,6 @@ class WeightedEdge : IComparable<WeightedEdge>{
         set
         {
             _weight = value;
-        }
-    }
-
-    // Added DFA Field Getters and Setters -- Michael Trosper 1/13/2026 //
-    public string from
-    {
-        get
-        {
-            return _from;
-        }
-        set
-        {
-            _from = value;
-        }
-    }
-
-    public string to
-    {
-        get
-        {
-            return _to;
-        }
-        set
-        {
-            _to = value;
-        }
-    }
-
-    public string value
-    {
-        get
-        {
-            return _value;
-        }
-        set
-        {
-            _value = value;
         }
     }
 

--- a/Problems/P/P_DFA/DFA_Class.cs
+++ b/Problems/P/P_DFA/DFA_Class.cs
@@ -139,7 +139,7 @@ class DFA : IGraphProblem<DFASolver, DFAVerifier, DFAVisualization, WeightedDire
         // Join Multiple Edges To Same Output To Single Edge For Graph //
 
         // Save New Edges With Multiple Char Paths, Ex:(Node, "a,b", Node) //
-        List<WeightedEdge> joinedEdges = new List<WeightedEdge>();
+        List<LabeledEdge> joinedEdges = new List<LabeledEdge>();
         // Track What Nodes Are Connected To One Another //
         var connections = new Dictionary<(string From, string To), string>();
 
@@ -161,8 +161,8 @@ class DFA : IGraphProblem<DFASolver, DFAVerifier, DFAVisualization, WeightedDire
             }
         }
 
-        // Save New Edges As WeightedEdge Format For API Graph Conversion //
-        foreach (var connectionPair in connections) { joinedEdges.Add(new WeightedEdge(connectionPair.Key.Item1, connectionPair.Key.Item2, connectionPair.Value)); }
+        // Save New Edges As LabeledEdge Format For API Graph Conversion //
+        foreach (var connectionPair in connections) { joinedEdges.Add(new LabeledEdge(connectionPair.Key.Item1, connectionPair.Key.Item2, connectionPair.Value)); }
 
         // Build Graph //
         graph = new WeightedDirectedGraph(nodes, joinedEdges, startState, acceptStates);

--- a/Problems/P/P_NFA/NFA_Class.cs
+++ b/Problems/P/P_NFA/NFA_Class.cs
@@ -154,7 +154,7 @@ class NFA : IGraphProblem<NFASolver, NFAVerifier, NFAVisualization, WeightedDire
         // Join Multiple Edges To Same Output To Single Edge For Graph //
 
         // Save New Edges With Multiple Char Paths, Ex:(Node, "a,b", Node) //
-        List<WeightedEdge> joinedEdges = new List<WeightedEdge>();
+        List<LabeledEdge> joinedEdges = new List<LabeledEdge>();
         // Track What Nodes Are Connected To One Another //
         var connections = new Dictionary<(string From, string To), string>();
 
@@ -177,8 +177,8 @@ class NFA : IGraphProblem<NFASolver, NFAVerifier, NFAVisualization, WeightedDire
             }
         }
 
-        // Save New Edges As WeightedEdge Format For API Graph Conversion //
-        foreach (var connectionPair in connections) { joinedEdges.Add(new WeightedEdge(connectionPair.Key.Item1, connectionPair.Key.Item2, connectionPair.Value)); }
+        // Save New Edges As LabeledEdge Format For API Graph Conversion //
+        foreach (var connectionPair in connections) { joinedEdges.Add(new LabeledEdge(connectionPair.Key.Item1, connectionPair.Key.Item2, connectionPair.Value)); }
 
         // Build Graph //
         graph = new WeightedDirectedGraph(nodes, joinedEdges, startState, acceptStates);


### PR DESCRIPTION
## Summary

`WeightedEdge` was two unrelated types fused into one class:

| World | Fields | Used by |
|-------|--------|---------|
| Node (kept) | `_source`, `_target` (`Node`), `_weight` (`int`) | All NPC graph problems |
| String (extracted) | `_from`, `_to`, `_value` (`string`) | DFA/NFA automaton model only |

Each constructor only initialized half the fields, producing CS8618 on all three constructors. There was also a latent `NullReferenceException`: `ToString`/`toKVP`/`directedString` unconditionally dereference `_source`, so any string-constructed edge calling those methods would crash at runtime.

**Fix:** extract the string-based fields into a new `LabeledEdge` type. Update the four consumers that used the string world (`WeightedDirectedGraph`, `API_GraphJSON`, `DFA_Class`, `NFA_Class`). `WeightedEdge` now has a single responsibility and both its constructors fully initialize the object.

## Files changed
- `Interfaces/graphs/LabeledEdge.cs` — new type (from/to/value, string-only)
- `Interfaces/graphs/WeightedEdge.cs` — string fields, constructor, and properties removed
- `Interfaces/graphs/WeightedDirectedGraph.cs` — edge list type: `WeightedEdge` → `LabeledEdge`
- `Interfaces/JSON_Objects/Graphs/API_GraphJSON.cs` — DFA constructor param: `WeightedEdge` → `LabeledEdge`
- `Problems/P/P_DFA/DFA_Class.cs` — `joinedEdges`: `WeightedEdge` → `LabeledEdge`
- `Problems/P/P_NFA/NFA_Class.cs` — `joinedEdges`: `WeightedEdge` → `LabeledEdge`

## Test plan
- [x] `dotnet build` — no errors; CS8618 warnings on `WeightedEdge.cs` lines 20/27/34 are gone
- [x] `dotnet test --filter "DFA|NFA"` — 65 passed
- [x] `dotnet test` — 555 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)