### PR TITLE
remove dead getNodeList/getEdgeList getters, fixing CS0108 warnings

### DIFF
--- a/Interfaces/graphs/Graph.cs
+++ b/Interfaces/graphs/Graph.cs
@@ -9,9 +9,6 @@ abstract class Graph
     public abstract List<Node> nodes { get; }
     public abstract List<Edge> edges { get; }
 
-    public List<Node> getNodeList { get => nodes; }
-    public List<Edge> getEdgeList { get => edges; }
-
     public virtual API_GraphJSON ToAPIGraph()
     {
         return new API_GraphJSON(nodes, edges);

--- a/Interfaces/graphs/WeightedUndirectedGraph.cs
+++ b/Interfaces/graphs/WeightedUndirectedGraph.cs
@@ -275,21 +275,6 @@ abstract class WeightedUndirectedGraph : WeightedGraph
 
 
     //Getters
-    public List<Node> getNodeList
-    {
-        get
-        {
-            return base._nodeList;
-        }
-    }
-    public List<WeightedEdge> getEdgeList
-    {
-        get
-        {
-            return base._edgeList;
-        }
-    }
-
     public List<string> nodesStringList
     {
         get


### PR DESCRIPTION
## Summary

Removes the dead `getNodeList`/`getEdgeList` getters across the graph base classes. Neither is called anywhere in the codebase (the one `getNodeList` grep hit is an unrelated `getNodeList(string)` method in `GraphParser`), and the frontend reads `/info` for metadata only and never references them.

Two places:

1. **`WeightedUndirectedGraph`** — its `getNodeList`/`getEdgeList` hid the inherited `Graph` members, producing two **CS0108** warnings. `getNodeList` was fully redundant with the inherited member; `getEdgeList` returned a weight-preserving `List<WeightedEdge>` vs. the inherited weight-stripped `List<Edge>`, but is also unused.
2. **`Graph` (base)** — the `getNodeList`/`getEdgeList` getters just forwarded to `nodes`/`edges` and have no remaining callers.

Both are dead code, so they are deleted rather than annotated with `new`. `nodes`/`edges` themselves are intentionally left in place.

## Test plan
- [x] `dotnet build` — both CS0108 warnings on `WeightedUndirectedGraph.cs` are gone; 0 errors
- [x] `dotnet test` — 555 passed