### PR TITLE
Fix CS8603 null-return warnings in UtilCollectionGraph

### DIFF
--- a/Interfaces/graphs/UtilCollectionGraph.cs
+++ b/Interfaces/graphs/UtilCollectionGraph.cs
@@ -48,9 +48,14 @@ class UtilCollectionGraph : Graph
         }
     }
 
-    public override List<Node> nodes => null;
+    // This transitional class represents its data as UtilCollections and overrides
+    // ToAPIGraph directly, so it never builds the Node/Edge view of the base class.
+    // These getters intentionally return null; null-forgiving (null!) keeps the
+    // non-nullable base contract while preserving the existing serialized output,
+    // which emits these as null (e.g. the /info endpoint reflects over them).
+    public override List<Node> nodes => null!;
 
-    public override List<Edge> edges => null;
+    public override List<Edge> edges => null!;
 
     public override API_GraphJSON ToAPIGraph()
     {


### PR DESCRIPTION
## Summary

`UtilCollectionGraph.nodes`/`edges` intentionally return `null` — this transitional graph type overrides `ToAPIGraph` directly and never materializes the `Node`/`Edge` view of the base class. The plain `=> null` returns violated the non-nullable base contract, producing two **CS8603** warnings.

Fixed with the null-forgiving operator (`=> null!`), which satisfies the contract while **preserving the existing serialized output** — these still emit as `null` (e.g. via the `/info` endpoint, which reflects over them). An earlier attempt to throw `NotSupportedException` was rejected because it broke 3 endpoint tests that serialize the default graph.

`nodes`/`edges` are intentionally left returning `null` for now.

## Test plan
- [x] `dotnet build` — the two CS8603 warnings on `UtilCollectionGraph.cs` are gone (remaining warnings are pre-existing CS8618, unrelated); 0 errors
- [x] `dotnet test` — 555 passed