### PR TITLE
Fix HittingSet solver IndexOutOfRange / missed-item loop bound

### DIFF
--- a/Problems/NPComplete/NPC_HITTINGSET/Solvers/HittingSetBruteForce.cs
+++ b/Problems/NPComplete/NPC_HITTINGSET/Solvers/HittingSetBruteForce.cs
@@ -40,7 +40,7 @@ class HittingSetBruteForce : ISolver<HITTINGSET> {
         foreach (List<int> possibleSolution in possibleSolutions(items.Count()))
         {
             UtilCollection certificate = new UtilCollection("{}");
-            for (int i = 0; i < hittingSet.subSets.Count() + 1; i++)
+            for (int i = 0; i < items.Count; i++)
             {
                 if (possibleSolution[i] == 1) certificate.Add(items[i]);
             }


### PR DESCRIPTION
The inner loop iterated hittingSet.subSets.Count() + 1 times while indexing into items (the universalSet). When the universal set size differs from subsets count the loop either crashes with IndexOutOfRangeException or stops before processing every candidate. The possibleSolution list is already sized by items.Count, so use that as the bound.