### PR TITLE
Fix Knapsack and NQueens verifiers to throw CertificateParseException

### DIFF
--- a/Problems/NPComplete/NPC_KNAPSACK/Verifiers/KnapsackVerifier.cs
+++ b/Problems/NPComplete/NPC_KNAPSACK/Verifiers/KnapsackVerifier.cs
@@ -47,10 +47,14 @@ class KnapsackVerifier : IVerifier<KNAPSACK> {
         {
             solution = parseCertificate(problem, certificate);
         }
-        catch 
+        catch (CertificateParseException)
         {
-            return false;
-        } 
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new CertificateParseException(problem, certificate, ex.Message);
+        }
         int totalW = 0;
         int totalV = 0;
 
@@ -71,7 +75,9 @@ class KnapsackVerifier : IVerifier<KNAPSACK> {
         foreach (UtilCollection solItem in solution)
         {
             solItem.assertPair();
-            if (!problem.items.Contains(solItem)) throw new Exception();
+            if (!problem.items.Contains(solItem))
+                throw new CertificateParseException(problem, certificate,
+                    $"item '{solItem}' is not in the problem's item set");
         }
         return solution;
     }

--- a/Problems/NPComplete/NPC_NQUEENS/Verifiers/NQueensVerifier.cs
+++ b/Problems/NPComplete/NPC_NQUEENS/Verifiers/NQueensVerifier.cs
@@ -30,8 +30,11 @@ class NQueensVerifier : IVerifier<NQUEENS> {
         try {
             solution = parseCertificate(certificate);
         }
-        catch {
-            return false;
+        catch (CertificateParseException) {
+            throw;
+        }
+        catch (Exception ex) {
+            throw new CertificateParseException(problem, certificate, ex.Message);
         }
 
         int n = problem.n;


### PR DESCRIPTION
Both verifiers had bare `catch { return false; }` blocks that silently swallowed parse errors, giving callers no indication of why a certificate was rejected. They now re-throw CertificateParseException (passthrough if already that type, otherwise wrapping the underlying exception with the certificate string and a detail message), matching the codebase-wide convention established in other verifiers.

KnapsackVerifier.parseCertificate also updated to throw CertificateParseException with a descriptive message instead of a bare Exception when an item is not in the problem's item set.