### PR TITLE
Add empty-solution guards to TSP and Hamiltonian visualizations

### DIFF
--- a/Problems/NPComplete/NPC_HAMILTONIAN/Visualizations/HamiltonianDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_HAMILTONIAN/Visualizations/HamiltonianDefaultVisualization.cs
@@ -30,7 +30,14 @@ class HamiltonianDefaultVisualization : IVisualization<HAMILTONIAN>
 
     public API_JSON SolvedVisualization(HAMILTONIAN hamiltonian, string solution)
     {
-        List<string> solutionNodes = GraphParser.parseNodeListWithStringFunctions(solution);
+        if (string.IsNullOrWhiteSpace(solution) || solution == "{}")
+            return hamiltonian.graph.ToAPIGraph();
+
+        List<string> solutionNodes = GraphParser.parseNodeListWithStringFunctions(solution)
+            .Where(n => !string.IsNullOrWhiteSpace(n)).ToList();
+
+        if (solutionNodes.Count == 0)
+            return hamiltonian.graph.ToAPIGraph();
 
         API_GraphJSON apiGraph = hamiltonian.graph.ToAPIGraph();
        

--- a/Problems/NPComplete/NPC_TSP/Visualizations/TSPDefaultVisualization.cs
+++ b/Problems/NPComplete/NPC_TSP/Visualizations/TSPDefaultVisualization.cs
@@ -30,7 +30,14 @@ class TSPDefaultVisualization : IVisualization<TSP>
 
     public API_JSON SolvedVisualization(TSP tsp, string solution)
     {
-        List<string> solutionNodes = GraphParser.parseNodeListWithStringFunctions(solution);
+        if (string.IsNullOrWhiteSpace(solution) || solution == "{}")
+            return tsp.graph.ToAPIGraph();
+
+        List<string> solutionNodes = GraphParser.parseNodeListWithStringFunctions(solution)
+            .Where(n => !string.IsNullOrWhiteSpace(n)).ToList();
+
+        if (solutionNodes.Count == 0)
+            return tsp.graph.ToAPIGraph();
 
         API_GraphJSON apiGraph = tsp.graph.ToAPIGraph();
         for (int i = 0; i < apiGraph.nodes.Count; i++)


### PR DESCRIPTION
SolvedVisualization() called parseNodeListWithStringFunctions without checking whether solve() returned an empty result. An empty or "{}" solution caused TSP to incorrectly color every graph node as Solution (the all-nodes loop ran unconditionally) and left both visualizations open to operating on a single-element list containing an empty string.

The guard returns the unsolved graph view immediately when the solution is empty, "{}", or produces no valid node names after parsing.