### PR TITLE
Fix SAT/SAT3 verifiers: || operator and CertificateParseException

### DIFF
--- a/Problems/NPComplete/NPC_SAT/SAT_Class.cs
+++ b/Problems/NPComplete/NPC_SAT/SAT_Class.cs
@@ -73,15 +73,32 @@ namespace API.Problems.NPComplete.NPC_SAT;
     // --- Methods Including Constructors ---
     public SAT() {
         instance = defaultInstance;
-         clauses = getClauses(instance);
+        clauses = getClauses(instance);
         literals = getLiterals(instance);
-      
     }
     public SAT(string phiInput) {
+        validateInstance(phiInput);
         instance = phiInput;
-         clauses = getClauses(phiInput);
+        clauses = getClauses(phiInput);
         literals = getLiterals(phiInput);
-     
+    }
+
+    private static void validateInstance(string phiInput) {
+        if (string.IsNullOrWhiteSpace(phiInput)) {
+            throw new ProblemParseException("SAT", phiInput, "instance is empty");
+        }
+        string stripped = phiInput.Replace(" ", "").Replace("(", "").Replace(")", "");
+        string[] rawClauses = stripped.Split('&');
+        foreach (string clause in rawClauses) {
+            string[] rawLiterals = clause.Split('|');
+            foreach (string literal in rawLiterals) {
+                string name = literal.StartsWith("!") ? literal.Substring(1) : literal;
+                if (string.IsNullOrEmpty(name) || !char.IsLetter(name[0])) {
+                    throw new ProblemParseException("SAT", phiInput,
+                        $"literal '{literal}' is not a valid identifier (optionally prefixed with '!')");
+                }
+            }
+        }
     }
 
     #endregion

--- a/Problems/NPComplete/NPC_SAT/Verifiers/SATVerifier.cs
+++ b/Problems/NPComplete/NPC_SAT/Verifiers/SATVerifier.cs
@@ -14,7 +14,7 @@ namespace API.Problems.NPComplete.NPC_SAT.Verifiers;
     private string _complexity = " ";
 
     private string _certificate = "(x1:True)";
-    
+
     #endregion
 
     #region Properties
@@ -34,22 +34,24 @@ namespace API.Problems.NPComplete.NPC_SAT.Verifiers;
             return _certificate;
         }
     }
-    
 
 
-    #endregion 
+
+    #endregion
 
     #region Constructors
 
     // --- Methods Including Constructors ---
     public SATVerifier() {
-        
+
     }
 
-    // Identical verifier for the 3SAT for KadensSimpleVerifier. Works for any SAT instance not just 3SAT.
     public bool verify(SAT problem, string certificate){
+        if (string.IsNullOrWhiteSpace(certificate)) {
+            throw new CertificateParseException(problem, certificate, "certificate is empty");
+        }
+
         List<List<string>> clauses = problem.clauses;
-        
         string strippedInput = certificate.Replace(" ", "").Replace("(", "").Replace(")","");
 
         string[] assignments = strippedInput.Split(',');
@@ -57,18 +59,27 @@ namespace API.Problems.NPComplete.NPC_SAT.Verifiers;
 
         foreach (string assignment in assignments) {
             string[] assignmentParts = assignment.Split(':');
-            if (assignmentParts.Length <= 1){
+            if (assignmentParts.Length <= 1)
                 assignmentParts = assignment.Split('=');
+
+            if (assignmentParts.Length < 2) {
+                throw new CertificateParseException(problem, certificate,
+                    $"assignment '{assignment}' is missing a ':' or '=' separator");
             }
+
             string literalName = assignmentParts[0];
             string TF = assignmentParts[1];
 
-            if (TF == "True" | TF == "T") {
+            if (TF == "True" || TF == "T") {
                 trueLiterals.Add(literalName);
             }
-            else if (TF == "False" | TF == "F") {
-                string inverseLiteralName = "!" + literalName; 
+            else if (TF == "False" || TF == "F") {
+                string inverseLiteralName = "!" + literalName;
                 trueLiterals.Add(inverseLiteralName);
+            }
+            else {
+                throw new CertificateParseException(problem, certificate,
+                    $"assignment '{assignment}' has value '{TF}'; expected True/False (capitalized) or T/F");
             }
         }
 
@@ -84,7 +95,7 @@ namespace API.Problems.NPComplete.NPC_SAT.Verifiers;
             if (containedInClause == false) {
                 return false;
             }
-            
+
         }
 
         return true;

--- a/Problems/NPComplete/NPC_SAT3/Verifiers/SAT3Verifier.cs
+++ b/Problems/NPComplete/NPC_SAT3/Verifiers/SAT3Verifier.cs
@@ -60,10 +60,10 @@ class SAT3Verifier : IVerifier<SAT3> {
             string literalName = assignmentParts[0];
             string TF = assignmentParts[1];
 
-            if (TF == "True" | TF == "T") {
+            if (TF == "True" || TF == "T") {
                 trueLiterals.Add(literalName);
             }
-            else if (TF == "False" | TF == "F") {
+            else if (TF == "False" || TF == "F") {
                 string inverseLiteralName = "!" + literalName;
                 trueLiterals.Add(inverseLiteralName);
             }


### PR DESCRIPTION
Both verifiers used bitwise | instead of logical || when comparing string values for True/False assignments. While functionally equivalent today (no side effects), it signals a misunderstanding and is corrected to ||.

SATVerifier additionally had no error handling: malformed assignments (missing separator, unknown boolean value, empty certificate) were silently ignored. It now throws CertificateParseException on any parse failure, matching SAT3Verifier's existing behavior.

SAT_Class gains a validateInstance() guard in its non-default constructor, mirroring the same guard already in SAT3_Class.