### PR TITLE
Verifier nav: match on problem name, ignore problemType prefix

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Verifiers.cs
+++ b/AdditionalControllers/Navigation/Nav_Verifiers.cs
@@ -9,7 +9,6 @@ internal static class VerifierNavigationData
         public string className { get; set; } = "";
         public string classNameWithExtension { get; set; } = "";
         public string problemName { get; set; } = "";
-        public string problemTypePrefix { get; set; } = "";
     }
 
     // Build once from reflected verifier types so navigation doesn't depend on
@@ -65,7 +64,6 @@ internal static class VerifierNavigationData
                 className = className,
                 classNameWithExtension = className + ".cs",
                 problemName = problemType.Name,
-                problemTypePrefix = InferProblemTypePrefix(problemType),
             });
         }
 
@@ -75,15 +73,9 @@ internal static class VerifierNavigationData
             .ToList();
     }
 
-    private static string InferProblemTypePrefix(Type problemType)
-    {
-        string ns = problemType.Namespace ?? "";
-        if (ns.Contains(".Problems.NPComplete.", StringComparison.OrdinalIgnoreCase)) return "NPC";
-        if (ns.Contains(".Problems.P.", StringComparison.OrdinalIgnoreCase)) return "P";
-        if (ns.Contains(".Problems.NPHard.", StringComparison.OrdinalIgnoreCase)) return "NPH";
-        return "";
-    }
-
+    // problemTypePrefix is accepted for API compatibility but intentionally ignored:
+    // problem names are unique across complexity classes, so the name alone identifies
+    // the verifier set. (Solver/visualization nav still use the prefix; handled separately.)
     private static List<VerifierEntry> Find(string? problemName, string? problemTypePrefix)
     {
         IEnumerable<VerifierEntry> query = Entries;
@@ -91,11 +83,6 @@ internal static class VerifierNavigationData
         if (!string.IsNullOrWhiteSpace(problemName))
         {
             query = query.Where(e => string.Equals(e.problemName, problemName, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (!string.IsNullOrWhiteSpace(problemTypePrefix))
-        {
-            query = query.Where(e => string.Equals(e.problemTypePrefix, problemTypePrefix, StringComparison.OrdinalIgnoreCase));
         }
 
         return query

--- a/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
@@ -108,6 +108,48 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
         Assert.Empty(arr);
     }
 
+    // ── Problem_VerifiersRefactor: lookup must not depend on problemType ──────
+    // Regression for #317/#318: the GUI pins problemType to "NPC" and never updates
+    // it, so a P / NP-Hard problem arrives with the wrong prefix. The verifier lookup
+    // must still find the verifier by problem name regardless of the prefix sent.
+
+    [Fact]
+    public async Task ProblemVerifiersRefactor_PProblem_WithWrongNpcProblemType_FindsVerifier()
+    {
+        // DFA lives under Problems/P, but mirror the GUI sending problemType=NPC.
+        var response = await _client.GetAsync("/Navigation/Problem_VerifiersRefactor?chosenProblem=DFA&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("DFAVerifier", arr);
+    }
+
+    [Fact]
+    public async Task ProblemVerifiersRefactor_PProblem_WithCorrectProblemType_FindsVerifier()
+    {
+        var response = await _client.GetAsync("/Navigation/Problem_VerifiersRefactor?chosenProblem=DFA&problemType=P", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("DFAVerifier", arr);
+    }
+
+    [Fact]
+    public async Task ProblemVerifiersRefactor_UnknownProblem_ReturnsNotFoundString()
+    {
+        var response = await _client.GetAsync("/Navigation/Problem_VerifiersRefactor?chosenProblem=NoSuchProblem&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        // Ignoring problemType must not turn a genuinely missing problem into a match.
+        var message = JsonSerializer.Deserialize<string>(body);
+        Assert.Equal("entered a verifier that does not exist", message);
+    }
+
     // ── All_Visualizations (requires chosenProblem param) ────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes verifier-navigation lookup failing for every problem outside the `NPComplete` category (e.g. `P_DFA`, `P_NFA`, the NP-Hard Pump Scheduling problems). Selecting such a problem in the GUI returned **"entered a verifier that does not exist"** and listed no verifiers.

## Root cause

`VerifierNavigationData.Find()` strictly filtered entries by an inferred `problemTypePrefix` (`NPC` / `P` / `NPH`). The GUI sends a `problemType` query parameter to drive that filter — but the GUI never updates the value: `problemType` is initialised to `"NPC"` (`useState("NPC")` in `ProblemProvider/Problem.js`) and its setter is never called. So for every non-NPComplete problem the GUI sends `problemType=NPC`, the prefix filter matches nothing, and the endpoint returns the not-found error.

Solver and visualization navigation tolerate the same stale value because they fall back to a directory search across all complexity-class folders; the reflection-based verifier lookup had no equivalent fallback.

## Fix

Problem names are unique across complexity classes (verified against the full `Problems/` tree), so the problem name alone identifies the verifier set. This PR:

- Drops the `problemTypePrefix` filter from `Find()` and matches on `problemName` only.
- Removes the now-dead `InferProblemTypePrefix()` helper and the `VerifierEntry.problemTypePrefix` field.
- Retains the `problemTypePrefix` parameter on `Find` / `FindWith*` for API compatibility (the controllers still pass it); it is simply ignored.

This is the unconditional form of the prefix-fallback proposed in #317, and also covers the case where a correct prefix is supplied, with no behavioral downside given names are unique.

## Scope

Verifier navigation was used as the test case. Solver/visualization navigation still consult the prefix via their own directory-search fallback and are intentionally left unchanged here; aligning them will be handled separately.

The real GUI defect (the `problemType` setter never being called) is tracked on the frontend side; this backend change makes verifier lookup robust regardless of the `problemType` the client sends.

## Testing

- `dotnet build Redux.slnx` — clean, 0 warnings / 0 errors.
- `dotnet test Redux.slnx` — 577 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)