### PR TITLE
Added SSSP problem under P category

### DIFF
--- a/Problems/P/P_SSSP/P_SSSP.cs
+++ b/Problems/P/P_SSSP/P_SSSP.cs
@@ -1,0 +1,295 @@
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using API.Problems.NPComplete.NPC_TSP.Verifiers;
+using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
+using API.Problems.P.P_SSSP.Visualizations;
+using SPADE;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace API.Problems.P.P_SSSP;
+
+class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilCollectionGraph>
+{
+
+    // --- Fields ---
+    public string problemName { get; } = "Single Source Shortest Path Problem";
+    public string problemLink { get; } = "https://en.wikipedia.org/wiki/Shortest_path_problem";
+    public string formalDefinition { get; } = "For a weighted graph G= (V,E) with non-negative edge weights and source vertex s \u2208 V, find the shortest path distance from s to every other vertex v \u2208 V, where path length is defined as the sum of edge weights along the path.";
+    public string problemDefinition { get; } = "Single Source Shortest Path (SSSP) in a weighted graph is the problem of finding the shortest path from a given source vertex s in the graph, such that the sum of edge weights along each path is minimized.";
+    public string source { get; } = "N/A";
+    public string sourceLink { get; } = "N/A";
+    private static string _defaultInstance =
+    "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)";
+    public string defaultInstance { get; } = _defaultInstance;
+    public string instance { get; set; } = string.Empty;
+
+    public string wikiName { get; } = "";
+    public string sourceNode { get; private set; } = string.Empty;
+    public string targetNode { get; private set; } = string.Empty;
+    public bool isDirected { get; private set; }
+    public bool isWeighted { get; private set; }
+    private List<string> _nodes = new List<string>();
+    private List<KeyValuePair<string, string>> _edges = new List<KeyValuePair<string, string>>();
+    public SSSPSolver defaultSolver { get; } = new SSSPSolver();
+    public SSSPVerifier defaultVerifier { get; } = new SSSPVerifier();
+    public SSSPVisualization defaultVisualization { get; } = new SSSPVisualization();
+    public UtilCollectionGraph graph { get; set; }
+    public string[] contributors { get; } = { "Rajit Nilkar", "Scott Barfuss" };
+
+    // --- Properties ---
+    public List<string> nodes
+    {
+        get => _nodes;
+        set => _nodes = value;
+    }
+    public List<KeyValuePair<string, string>> edges
+    {
+        get => _edges;
+        set => _edges = value;
+    }
+
+    // --- Methods Including Constructors ---
+    public SSSP() : this(_defaultInstance) { }
+
+    public SSSP(string GInput)
+    {
+        instance = GInput;
+
+        ParsedShortestPathInstance parsed = ParseInstance(GInput);
+        nodes = parsed.Nodes;
+        edges = parsed.Edges;
+        sourceNode = parsed.SourceNode;
+        targetNode = parsed.TargetNode;
+        isDirected = parsed.IsDirected;
+        isWeighted = parsed.IsWeighted;
+        graph = new UtilCollectionGraph(parsed.NodeCollection, parsed.EdgeCollection);
+    }
+
+    private static ParsedShortestPathInstance ParseInstance(string rawInstance)
+    {
+        string graphInput = rawInstance;
+        string? explicitSource = null;
+        string? explicitTarget = null;
+
+        List<string> outerTerms = SplitOuterTuple(rawInstance);
+        if (outerTerms.Count == 4)
+        {
+            graphInput = $"({outerTerms[0]},{outerTerms[1]})";
+            explicitSource = outerTerms[2];
+            explicitTarget = outerTerms[3];
+        }
+        else if (outerTerms.Count == 3 && LooksLikeTuple(outerTerms[0]))
+        {
+            graphInput = outerTerms[0];
+            explicitSource = outerTerms[1];
+            explicitTarget = outerTerms[2];
+        }
+
+        GraphParseResult graphParse = ParseGraph(graphInput);
+        UtilCollection nodeCollection = graphParse.Parser["N"] ?? throw new InvalidOperationException("Failed to parse N (nodes).");
+        UtilCollection edgeCollection = graphParse.Parser["E"] ?? throw new InvalidOperationException("Failed to parse E (edges).");
+
+        List<string> parsedNodes = nodeCollection.ToList().Select(node => node.ToString()).ToList();
+        List<KeyValuePair<string, string>> parsedEdges = ToEdgePairs(edgeCollection);
+
+        ValidateInstance(parsedNodes, edgeCollection, explicitSource, explicitTarget);
+
+        string resolvedSource = explicitSource ?? (parsedNodes.Count > 0 ? parsedNodes[0] : string.Empty);
+        string resolvedTarget = explicitTarget ?? (parsedNodes.Count > 0 ? parsedNodes[^1] : string.Empty);
+
+        return new ParsedShortestPathInstance(
+            nodeCollection,
+            edgeCollection,
+            parsedNodes,
+            parsedEdges,
+            resolvedSource,
+            resolvedTarget,
+            graphParse.IsDirected,
+            graphParse.IsWeighted);
+    }
+
+    private static GraphParseResult ParseGraph(string graphInput)
+    {
+        (string Pattern, bool IsDirected, bool IsWeighted)[] parseAttempts =
+        {
+            ("{(N,E) | N is set, E subset {(e,w) | e is N cross N, w is int}}", true, true),
+            ("{(N,E) | N is set, E subset {(e,w) | e is N unorderedcross N, w is int}}", false, true),
+            ("{(N,E) | N is set, E subset N cross N}", true, false),
+            ("{(N,E) | N is set, E subset N unorderedcross N}", false, false)
+        };
+
+        Exception? lastError = null;
+        foreach (var attempt in parseAttempts)
+        {
+            try
+            {
+                StringParser parser = new(attempt.Pattern);
+                parser.parse(graphInput);
+                return new GraphParseResult(parser, attempt.IsDirected, attempt.IsWeighted);
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+        }
+
+        throw new InvalidOperationException("Failed to parse SSSP instance.", lastError);
+    }
+
+    private static void ValidateInstance(
+        List<string> parsedNodes,
+        UtilCollection edgeCollection,
+        string? explicitSource,
+        string? explicitTarget)
+    {
+        HashSet<string> nodeSet = parsedNodes.ToHashSet();
+
+        if (explicitSource != null && !nodeSet.Contains(explicitSource))
+            throw new InvalidOperationException($"Source node '{explicitSource}' is not in N.");
+
+        if (explicitTarget != null && !nodeSet.Contains(explicitTarget))
+            throw new InvalidOperationException($"Target node '{explicitTarget}' is not in N.");
+
+        foreach (UtilCollection rawEdge in edgeCollection.ToList())
+        {
+            ParsedEdge edge = ParseEdge(rawEdge);
+
+            if (!nodeSet.Contains(edge.From))
+                throw new InvalidOperationException($"Edge source '{edge.From}' is not in N.");
+
+            if (!nodeSet.Contains(edge.To))
+                throw new InvalidOperationException($"Edge target '{edge.To}' is not in N.");
+
+            if (edge.Weight < 0)
+                throw new InvalidOperationException("SSSP using Dijkstra's algorithm does not allow negative edge weights.");
+        }
+    }
+
+    private static List<KeyValuePair<string, string>> ToEdgePairs(UtilCollection edgeCollection)
+    {
+        return edgeCollection.ToList().Select(rawEdge =>
+        {
+            ParsedEdge edge = ParseEdge(rawEdge);
+            return new KeyValuePair<string, string>(edge.From, edge.To);
+        }).ToList();
+    }
+
+    private static ParsedEdge ParseEdge(UtilCollection rawEdge)
+    {
+        bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+        bool secondLooksLikeCollection = rawEdge.Count() > 1 && LooksLikeCollection(rawEdge[1]);
+        bool isWeighted = rawEdge.Count() == 2 && firstLooksLikeCollection && !secondLooksLikeCollection;
+
+        if (isWeighted)
+        {
+            UtilCollection endpoints = rawEdge[0];
+            int weight = int.Parse(rawEdge[1].ToString());
+
+            if (weight < 0)
+                throw new InvalidOperationException($"SSSP using Dijkstra's algorithm does not allow negative edge weights. Found edge weight: {weight}");
+
+            return new ParsedEdge(GetFrom(endpoints), GetTo(endpoints), weight);
+        }
+
+        return new ParsedEdge(GetFrom(rawEdge), GetTo(rawEdge), 1);
+    }
+
+    private static string GetFrom(UtilCollection endpoints)
+    {
+        if (endpoints.IsOrdered())
+            return endpoints[0].ToString();
+
+        List<UtilCollection> cast = endpoints.ToList();
+        return cast[0].ToString();
+    }
+
+    private static string GetTo(UtilCollection endpoints)
+    {
+        if (endpoints.IsOrdered())
+            return endpoints[1].ToString();
+
+        List<UtilCollection> cast = endpoints.ToList();
+        if (cast.Count == 1)
+            return cast[0].ToString();
+
+        return cast[1].ToString();
+    }
+
+    private static bool LooksLikeCollection(UtilCollection value)
+    {
+        string text = value.ToString().TrimStart();
+        return text.StartsWith("{") || text.StartsWith("(");
+    }
+
+    private static bool LooksLikeTuple(string value)
+    {
+        return value.TrimStart().StartsWith("(");
+    }
+
+    private static List<string> SplitOuterTuple(string input)
+    {
+        string trimmed = input.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '(' || trimmed[^1] != ')')
+            return new List<string>();
+
+        string inner = trimmed[1..^1];
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        int parenDepth = 0;
+        int braceDepth = 0;
+        int bracketDepth = 0;
+
+        foreach (char ch in inner)
+        {
+            if (ch == ',' && parenDepth == 0 && braceDepth == 0 && bracketDepth == 0)
+            {
+                parts.Add(current.ToString().Trim());
+                current.Clear();
+                continue;
+            }
+
+            current.Append(ch);
+            switch (ch)
+            {
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    parenDepth--;
+                    break;
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    braceDepth--;
+                    break;
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    bracketDepth--;
+                    break;
+            }
+        }
+
+        if (current.Length > 0)
+            parts.Add(current.ToString().Trim());
+
+        return parts;
+    }
+
+    private sealed record GraphParseResult(StringParser Parser, bool IsDirected, bool IsWeighted);
+    private sealed record ParsedShortestPathInstance(
+        UtilCollection NodeCollection,
+        UtilCollection EdgeCollection,
+        List<string> Nodes,
+        List<KeyValuePair<string, string>> Edges,
+        string SourceNode,
+        string TargetNode,
+        bool IsDirected,
+        bool IsWeighted);
+    private sealed record ParsedEdge(string From, string To, int Weight);
+}

--- a/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
+++ b/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using SPADE;
+
+namespace API.Problems.P.P_SSSP.Solvers;
+
+class SSSPSolver : ISolver<SSSP>
+{
+    // ----- Fields ----- //
+    public string solverName { get; } = "Dijkstra's Algorithm";
+    public string solverDefinition { get; } = "";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar", "Scott Barfuss" };
+    public bool timerHasExpired { get; set; }
+    PriorityQueue<string, int>? pq;
+
+    public string solve(SSSP problem)
+    {
+        UtilCollectionGraph graph = problem.graph;
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+        {
+            return "{}"; // No nodes, return empty path
+        }
+
+        string sourceNode = problem.sourceNode;
+        string targetNode = problem.targetNode;
+
+        if (!nodes.Contains(sourceNode) || !nodes.Contains(targetNode))
+        {
+            return "{}";
+        }
+
+        var adjacency = BuildAdjacencyList(graph);
+
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        while (pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return "{}";
+
+            string current = pq.Dequeue();
+
+            if (visited.Contains(current))
+                continue; // Skip if we've already visited this node
+            visited.Add(current);
+
+            if (current == targetNode)
+                break; // Stop if we've reached the target node
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue; // No neighbors, so skip
+
+            foreach (var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue; // Skip visited neighbors
+
+                if (dist[current] == int.MaxValue)
+                    continue; // Skip if current node is unreachable
+
+                int candidate = dist[current] + weight;
+                if (candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+        }
+
+        if (dist[targetNode] == int.MaxValue)
+            return "{}"; // No path found
+        List<string> path = ReconstructPath(prev, sourceNode, targetNode);
+        return NodeListToCertificate(path);
+    }
+
+    //Helper method to build an adjacent list from the graph
+    internal static Dictionary<string, List<(string neighbor, int weight)>> BuildAdjacencyList(UtilCollectionGraph graph)
+    {
+        var adjacency = new Dictionary<string, List<(string neighbor, int weight)>>();
+
+        if (graph.Nodes.Count() == 0)
+            return adjacency; // No edges, so return empty adjacency list
+
+        foreach (UtilCollection rawEdge in graph.Edges.ToList())
+        {
+            // check if edge is weighted
+            bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+            bool secondLooksLikeCollection = LooksLikeCollection(rawEdge[1]);
+            bool isWeighted = rawEdge.Count() == 2 && firstLooksLikeCollection && !secondLooksLikeCollection;
+
+            if (isWeighted)
+            {
+                UtilCollection endpoints = rawEdge[0];
+                int w = int.Parse(rawEdge[1].ToString()); // Assuming the weight is an integer
+
+                if (endpoints.IsOrdered())
+                    AddDirected(adjacency, endpoints[0].ToString(), endpoints[1].ToString(), w);
+                else
+                {
+                    var cast = endpoints.ToList();
+                    if (cast.Count == 1) // Add directed edge from the node to itself
+                    {
+                        string v = cast[0].ToString();
+                        AddDirected(adjacency, v, v, w);
+                    }
+                    else // Undirected edge, add in both directions
+                    {
+                        string a = cast[0].ToString();
+                        string b = cast[1].ToString();
+                        AddDirected(adjacency, a, b, w);
+                        AddDirected(adjacency, b, a, w);
+                    }
+                }
+            }
+            else
+            {
+                int w = 1;
+
+                if (rawEdge.IsOrdered())
+                    AddDirected(adjacency, rawEdge[0].ToString(), rawEdge[1].ToString(), w);
+                else
+                {
+                    // If it's an unordered pair, treat it as an undirected edge
+                    var cast = rawEdge.ToList();
+                    if (cast.Count() == 1)
+                    {
+                        string v = cast[0].ToString();
+                        AddDirected(adjacency, v, v, w);
+                    }
+                    else
+                    {
+                        string a = cast[0].ToString();
+                        string b = cast[1].ToString();
+                        AddDirected(adjacency, a, b, w);
+                        AddDirected(adjacency, b, a, w);
+                    }
+                }
+            }
+        }
+        return adjacency;
+    }
+
+    // AddDirected: Adds a directed edge to the adjacency list
+    private static void AddDirected(Dictionary<string, List<(string neighbor, int weight)>> adjacency, string from, string to, int weight)
+    {
+        if (!adjacency.TryGetValue(from, out var list))
+        {
+            list = new List<(string neighbor, int weight)>();
+            adjacency[from] = list;
+        }
+        list.Add((to, weight));
+
+        if (!adjacency.ContainsKey(to))
+            adjacency[to] = new List<(string, int)>();
+    }
+
+    // ReconstructPath: Reconstructs the path from source to target using the previous dictionary
+    internal static List<string> ReconstructPath(Dictionary<string, string?> prev, string source, string target)
+    {
+        var path = new List<string>();
+        string? current = target;
+
+        while (current != null)
+        {
+            path.Add(current);
+            if (current == source)
+            {
+                break; // Stop if we've reached the source node
+            }
+            current = prev[current];
+        }
+
+        path.Reverse();
+
+        if (path.Count() == 0 || path[0] != source)
+        {
+            return new List<string>(); // No valid path
+        }
+        return path;
+    }
+
+    // NodeListCertificate: Converts a list of nodes into the certificate format
+    internal static string NodeListToCertificate(List<string> nodes)
+    {
+        if (nodes == null || nodes.Count() == 0)
+            return "{}"; // No path found, empty certificate
+        return "{" + string.Join(",", nodes) + "}";
+    }
+
+    // LooksLikeCollection: Helper method to determine if a UtilCollection looks like a collection
+    private static bool LooksLikeCollection(UtilCollection u)
+    {
+        string s = u.ToString().TrimStart();
+        return s.StartsWith("{") || s.StartsWith("(");
+    }
+
+    // GetSteps: The steps are returned as a list of strings, where each string representing a path in the certificate format
+    public List<Object> GetSteps(SSSP problem)
+    {
+        var steps = new List<Object>();
+        UtilCollectionGraph graph = problem.graph;
+
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+        if (nodes.Count == 0)
+            return steps; // return empty list of steps
+
+        string sourceNode = problem.sourceNode;
+        string targetNode = problem.targetNode;
+
+        var adjacency = BuildAdjacencyList(graph);
+
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        while (pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return steps;
+
+            string current = pq.Dequeue();
+            if (visited.Contains(current))
+                continue;
+
+            visited.Add(current);
+
+            var path = ReconstructPath(prev, sourceNode, current);
+            if (path.Count > 0)
+                steps.Add(NodeListToCertificate(path));
+
+            // if we have successfully reached the target node
+            if (current == targetNode)
+                break;
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach (var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue;
+
+                if (weight < 0)
+                    return steps;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if (candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+        }
+        return steps;
+    }
+}

--- a/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
+++ b/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Problems.P.P_SSSP.Solvers;
+
+namespace API.Problems.P.P_SSSP.Verifiers;
+
+class SSSPVerifier : IVerifier<SSSP>
+{
+    public string verifierName { get; } = "Single Source Shortest Path Verifier";
+    public string verifierDefinition { get; } = "Verifies the solution for the Single Source Shortest Path problem";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar", "Scott Barfuss" };
+    private string _certificate = "";
+    public string certificate => _certificate;
+
+    public SSSPVerifier() { }
+
+    // verify: takes a problem instance and a solution certificate,
+    // and returns true if the certificate is a valid solution to the problem instance,
+    // false otherwise
+    public bool verify(SSSP problem, string solution)
+    {
+        _certificate = solution ?? ""; // Reset certificate before verification
+
+        var nodes = problem.graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+        if (nodes.Count == 0)
+            // If there are no nodes, the only valid solution is an empty path
+            return solution == "{}" || string.IsNullOrWhiteSpace(solution);
+
+        string sourceNode = problem.sourceNode;
+        string targetNode = problem.targetNode;
+
+        var adjacency = SSSPSolver.BuildAdjacencyList(problem.graph);
+
+        // Compute true shortest distance using Dijkstra's algorithm
+        int? shortest = ShortestDistance(adjacency, nodes, sourceNode, targetNode);
+
+        // Allow {} as a certificate meaning "no path"
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return shortest is null; // Valid if and only if target is unreachable
+
+        List<string> path;
+        try
+        {
+            // Parse the certificate as a path
+            path = GraphParser.parseNodeListWithStringFunctions(solution);
+        }
+        catch
+        {
+            return false; // Invalid certificate format
+        }
+
+        if (path.Count == 0)
+            return shortest is null; // Empty path is only valid if target is unreachable
+
+        if (path[0] != sourceNode || path[^1] != targetNode)
+            return false; // Path must start at source and end at target
+
+        // Validate each hop is an edge, and compute total path length
+        int length = 0;
+        for (int i = 0; i < path.Count - 1; i++)
+        {
+            string u = path[i];
+            string v = path[i + 1];
+
+            if (!adjacency.TryGetValue(u, out var neighbors))
+                return false;
+
+            // Pick min weight among possible edges if any
+            var weights = neighbors.Where(e => e.neighbor == v).Select(e => e.weight).ToList();
+            if (weights.Count == 0)
+                return false; // No edges from u to v
+
+            int w = weights.Min();
+            if (w < 0)
+                return false; // No negative weights allowed
+
+            length += w;
+        }
+        return shortest is int s && length == s; // Valid if path is correct and matches true shortest distance
+    }
+
+    // ShortestDistance: helper method to compute shortest distance using Dijkstra's algorithm
+    private static int? ShortestDistance(
+        Dictionary<string, List<(string neighbor, int weight)>> adjacency,
+        List<string> allNodes,
+        string source,
+        string target)
+    {
+        var dist = allNodes.ToDictionary(n => n, _ => int.MaxValue);
+        var visited = new HashSet<string>();
+        PriorityQueue<string, int> pq = new PriorityQueue<string, int>();
+
+        dist[source] = 0;
+        pq.Enqueue(source, 0);
+
+        while (pq.Count > 0)
+        {
+            string current = pq.Dequeue();
+            if (visited.Contains(current))
+                continue;
+            visited.Add(current); // Mark as visited
+
+            if (current == target)
+                break; // Stop if we've reached the target node
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue; // No neighbors, skip
+
+            foreach (var (next, weight) in neighbors)
+            {
+                if (weight < 0)
+                    throw new InvalidOperationException("SSSP does not allow negative edge weights.");
+
+                if (visited.Contains(next))
+                    continue; // Skip visited neighbors
+
+                if (dist[current] == int.MaxValue)
+                    continue; // Skip if current node is unreachable
+
+                int candidate = dist[current] + weight;
+                if (candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    pq.Enqueue(next, candidate); // Update priority in the queue
+                }
+            }
+        }
+
+        if (dist[target] == int.MaxValue)
+            return null; // Target is unreachable
+
+        return dist[target]; // Return shortest distance to target
+    }
+}

--- a/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
+++ b/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
@@ -1,0 +1,136 @@
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_SSSP.Solvers;
+
+namespace API.Problems.P.P_SSSP.Visualizations;
+
+class SSSPVisualization : IVisualization<SSSP>
+{
+    public string visualizationName { get; } = "Single Source Shortest Path Visualization";
+    public string visualizationDefinition { get; } = "Visualizes the Single Source Shortest Path problem for non-negative weighted directed cyclic graphs using Dijkstra's algorithm";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar", "Scott Barfuss", "Tiger Sant", "Malaya Witt" };
+    public string visualizationType => "Graph D3";
+    public ISolver solver { get; } = new SSSPSolver();
+
+    public SSSPVisualization() { }
+
+    public API_JSON visualize(SSSP problem)
+    {
+        // For simplicity, we will just return a JSON representation of the graph
+        // In a real implementation, this would be more complex and would include visual elements
+        return problem.graph.ToAPIGraph();
+    }
+
+    // SolvedVisualization: takes a problem instance and a solution certificate,
+    // and returns a visualization of the problem instance with the solution highlighted
+    public API_JSON SolvedVisualization(SSSP problem, string solution)
+    {
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            // No path found, return graph with no highlights
+            return visualize(problem);
+
+        List<string> path;
+        try
+        {
+            // Parse the solution as a path
+            path = GraphParser.parseNodeListWithStringFunctions(solution);
+        }
+        catch
+        {
+            // Invalid solution format, return graph with no highlights
+            return visualize(problem);
+        }
+
+        API_GraphJSON graph = problem.graph.ToAPIGraph(); // Convert to API graph format
+
+        var pathNodes = new HashSet<string>(path);
+        for (int i = 0; i < graph.nodes.Count; i++)
+            graph.nodes[i].color = pathNodes.Contains(graph.nodes[i].name)
+            ? "Solution" : "Background";
+
+        var pathEdges = new HashSet<(string u, string v)>();
+        for (int i = 0; i < path.Count - 1; i++)
+            pathEdges.Add((path[i], path[i + 1]));
+
+        for (int i = 0; i < graph.links.Count; i++)
+        {
+            var link = graph.links[i];
+            bool isForwardPathEdge = pathEdges.Contains((link.source, link.target));
+            bool isReversePathEdge = !problem.isDirected && pathEdges.Contains((link.target, link.source));
+
+            if (isForwardPathEdge || isReversePathEdge)
+                link.color = "Solution";
+            else
+                link.color = "Background";
+        }
+        return graph;
+    }
+
+    public List<API_JSON> StepsVisualization(SSSP problem, List<Object> steps)
+    {
+        var result = new List<API_JSON>();
+
+        for (int s = 0; s < steps.Count; s++)
+        {
+            string? step = steps[s].ToString();
+
+            if (string.IsNullOrWhiteSpace(step) || step.Trim() == "{}")
+            {
+                result.Add(visualize(problem));
+                continue;
+            }
+
+            List<string> path;
+            try
+            {
+                path = GraphParser.parseNodeListWithStringFunctions(step);
+            }
+            catch
+            {
+                result.Add(visualize(problem));
+                continue;
+            }
+
+            API_GraphJSON graph = problem.graph.ToAPIGraph();
+
+            string? currentNode = path.Count > 0 ? path[path.Count - 1] : null;
+            var pathNodes = new HashSet<string>(path);
+
+            for (int i = 0; i < graph.nodes.Count; i++)
+            {
+                if (graph.nodes[i].name == currentNode)
+                {
+                    graph.nodes[i].color = "ElementHighlight";
+                    graph.nodes[i].outline = "Purple";
+                }
+                else if (pathNodes.Contains(graph.nodes[i].name))
+                {
+                    graph.nodes[i].color = "Solution";
+                }
+                else
+                {
+                    graph.nodes[i].color = "Background";
+                }
+            }
+
+            var pathEdges = new HashSet<(string u, string v)>();
+            for (int i = 0; i < path.Count - 1; i++)
+                pathEdges.Add((path[i], path[i + 1]));
+
+            for (int i = 0; i < graph.links.Count; i++)
+            {
+                var link = graph.links[i];
+                bool isForwardPathEdge = pathEdges.Contains((link.source, link.target));
+                bool isReversedPathEdge = !problem.isDirected && pathEdges.Contains((link.target, link.source));
+
+                link.color = (isForwardPathEdge || isReversedPathEdge) ? "Solution" : "Background";
+            }
+            result.Add(graph);
+        }
+
+        return result;
+    }
+}

--- a/redux-tests/Problems/P_SSSP/SSSPTests.cs
+++ b/redux-tests/Problems/P_SSSP/SSSPTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Linq;
+using Xunit;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_SSSP;
+using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
+using API.Problems.P.P_SSSP.Visualizations;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class SSSP_Tests
+{
+    [Fact]
+    public void SSSP_Default_Instantiation()
+    {
+        SSSP problem = new SSSP();
+        Assert.Equal("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)", problem.instance);
+        Assert.Equal(problem.defaultInstance, problem.instance);
+    }
+
+    [Fact]
+    public void SSSP_Custom_Instantiation()
+    {
+        string instance = "({1,2,3,4,5,6},{((1,2),8),((1,3),4),((2,3),6),((3,5),5),((2,4),3),((4,5),9),((3,6),1),((4,6),12),((5,6),5)},1,6)";
+        var problem = new SSSP(instance);
+        Assert.Equal(instance, problem.instance);
+    }
+
+    [Theory]
+    [InlineData("({1,2}, {((1,2),-1)}),1,2")]
+    [InlineData("(({1,2}, {((1,2),-1)}),1,2")]
+    public void SSSP_Rejects_Negative_Edge_Weights(string instance)
+    {
+        // Dijkstra's algorithm correctness depends on non-negative weights
+        // The SSSP problem must reject problem instances with negative-weights during parse time
+        Assert.Throws<InvalidOperationException>(() => new SSSP(instance));
+    }
+
+    [Fact]
+    public void SHORTESTPATH_Rejects_Source_Outside_Node_Set()
+    {
+        string instance = "(({1,2,3},{((1,2),1),((2,3),1)}),4,3)";
+        Assert.Throws<InvalidOperationException>(() => new SSSP(instance));
+    }
+
+    // ----- Solver ----- //
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)", "{1,3,5}")]
+    [InlineData("(({A,B,C,D},{((A,B),2),((B,D),2),((A,C),1),((C,D),1)}),A,D)", "{A,C,D}")]
+    [InlineData("(({1,2,3},((1,2))),1,3)", "{}")]
+    public void SSSP_Solver(string instance, string certificate)
+    {
+        SSSP problem = new SSSP(instance);
+        SSSPSolver solver = new SSSPSolver();
+        string solution = solver.solve(problem);
+        Assert.Equal(certificate, solution);
+    }
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)", 9)]
+    [InlineData("({1,2,3,4,5,6},{((1,2),8),((1,3),4),((2,3),6),((3,5),5),((2,4),3),((4,5),9),((3,6),1),((4,6),12),((5,6),5)},1,6)", 5)]
+    [InlineData("(({1,2,3,4},{((1,2),1),((2,3),1),((3,4),1),((1,4),10)}),2,4)", 2)]
+    [InlineData("(({A,B,C,D},{((A,B),2),((B,D),2),((A,C),1),((C,D),1)}),A,D)", 2)]
+    public void SSSP_Solver_Returns_Valid_Minimum_Cost_Path(string instance, int expectedMinCost)
+    {
+        SSSP problem = new SSSP(instance);
+        SSSPSolver solver = new SSSPSolver();
+        SSSPVerifier verifier = new SSSPVerifier();
+
+        string solution = solver.solve(problem);
+
+        Assert.True(verifier.verify(problem, solution), $"Solver returned an invalid certificate: {solution}");
+        Assert.Equal(expectedMinCost, TotalPathWeight(problem, solution));
+    }
+
+    [Fact]
+    public void SSSP_Solver_Handles_Equal_Weights()
+    {
+        string instance = "(({1,2,3},{((1,2),1),((2,3),1)}),1,1)";
+        SSSP problem = new SSSP(instance);
+        SSSPSolver solver = new SSSPSolver();
+
+        string solution = solver.solve(problem);
+
+        Assert.Equal("{1}", solution);
+    }
+
+    // ----- Verifier ----- //
+
+    [Theory] //Tests independent set verifier with a few certificates
+    [InlineData("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)", "{1,3,5}", true)]
+    [InlineData("({1,2,3,4,5},{(1,2),(1,3),(2,3),(3,5),(2,4),(4,5)},1,5)", "{1,3,5}", true)]
+    [InlineData("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)", "{1,2,3,5}", false)]
+    [InlineData("({1,2,3,4,5,6},{((1,2),8),((1,3),4),((2,3),6),((3,5),5),((2,4),3),((4,5),9),((3,6),1),((4,6),12),((5,6),5)},1,6)", "{1,3,6}", true)]
+    [InlineData("({1,2,3,4,5,6},{((1,2),8),((1,3),4),((2,3),6),((3,5),5),((2,4),3),((4,5),9),((3,6),1),((4,6),12),((5,6),5)},1,6)", "{1,2,4,5}", false)]
+    [InlineData("(({1,2,3,4},{((1,2),1),((2,3),1),((3,4),1),((1,4),10)}),2,4)", "{2,3,4}", true)]
+    [InlineData("(({1,2,3,4},{((1,2),1),((2,3),1),((3,4),1),((1,4),10)}),2,4)", "{1,2,3,4}", false)]
+    [InlineData("(({A,B,C,D},{((A,B),2),((B,D),2),((A,C),1),((C,D),1)}),A,D)", "{A,C,D}", true)]
+    public void SSSP_Verifier(string instance, string certificate, bool expected)
+    {
+        SSSP problem = new SSSP(instance);
+        SSSPVerifier verifier = new SSSPVerifier();
+        bool result = verifier.verify(problem, certificate);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void SSSP_Verifier_Rejects_Empty_Certificates_When_Path_Exists()
+    {
+        string instance = "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)";
+        SSSP problem = new SSSP(instance);
+        SSSPVerifier verifier = new SSSPVerifier();
+        Assert.False(verifier.verify(problem, "{}"));
+    }
+
+    // ----- Visualization ----- //
+    [Fact]
+    public void StepsVisualization_Highlights_Final_Path_Nodes_As_Solution()
+    {
+        string instance = "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1,5)";
+        SSSP problem = new SSSP(instance);
+        SSSPVisualization visualization = new SSSPVisualization();
+
+        var steps = new List<object> { "{1,3,5}" };
+        var frames = visualization.StepsVisualization(problem, steps);
+
+        var frame = Assert.IsType<API_GraphJSON>(frames[0]);
+        Assert.Contains(frame.nodes, n => n.name == "1" && (n.color == "Solution" || n.color == "ElementHighlight"));
+        Assert.Contains(frame.nodes, n => n.name == "5" && (n.color == "Solution" || n.color == "ElementHighlight"));
+    }
+
+    // ----- Helper ----- //
+    // The purpose of this helper function is to parse a certificate like "{1,3,5}" and sums the edge weights along the path
+    private static int TotalPathWeight(SSSP problem, string certificate)
+    {
+        var nodes = certificate.Trim('{', '}').Split(',').ToList();
+        var adjacency = SSSPSolver.BuildAdjacencyList(problem.graph);
+
+        int total = 0;
+        for (int i = 0; i < nodes.Count - 1; i++)
+        {
+            var edge = adjacency[nodes[i]].First(e => e.neighbor == nodes[i + 1]);
+            total += edge.weight;
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
## SSSP Problem Implementation
 
**Problem definition:** Given a weighted graph G = (V, E) with non-negative edge weights and a source vertex s, find the shortest path from s to every other vertex, where path length is the sum of edge weights along the path.
 
**What's included:**
- `SSSP_Class.cs` — problem definition, instance parsing/validation (rejects negative weights and out-of-range source vertices)
- `SSSPSolver.cs` — Dijkstra's algorithm implementation supporting both weighted and unweighted, directed and undirected graph instances
- `SSSPVerifier.cs` — validates submitted certificates against the problem instance
- `SSSPVisualization.cs` — graph visualization, solved-path highlighting, and step-by-step visualization of Dijkstra's execution
- Test suite (`SSSP_Tests.cs`) covering:
  - Default/custom instantiation and instance string round-tripping
  - Rejection of negative weights and invalid source vertices
  - Verifier accept/reject cases across directed/undirected and weighted/unweighted graphs
  - Solver correctness verified via the verifier (not exact-string matching, since Dijkstra may return any optimal path when ties exist)
  - Edge cases: unreachable target, source equal to target
  - Steps visualization rendering
**Category placement:** SSSP is correctly placed under `Problems/P/P_SSSP/` (polynomial-time), matching the platform's existing `P_DFA` / `P_NFA` convention
