### PR TITLE
refactor: deduplicate Verify request-body class

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -319,15 +319,3 @@ public class ProblemProvider : ControllerBase
         return JsonSerializer.Serialize(red.gadgets, new JsonSerializerOptions() { WriteIndented = true });
     }
 }
-
-/// <summary>Request body for verify endpoint</summary>
-public class Verify
-{
-    /// <summary>
-    /// Proposed solution for this problem
-    /// </summary>
-    public string Certificate { get; set; } = "";
-
-    /// <summary>Instance of the problem</summary>
-    public string ProblemInstance { get; set; } = "";
-}


### PR DESCRIPTION
## Summary

Removes the duplicate `Verify` request-body class defined in `AdditionalControllers/ProblemProvider.cs`. An identical class already exists in `Tools/ApiParameters.cs` (namespace `API.Tools.ApiParameters`), which `ProblemProvider.cs` already imports via `using`.

This is item 6 ("Deduplicate `Verify` class") from the API critique.

## Details

- Both classes were byte-for-byte equivalent in shape: two `string` properties, `Certificate` and `ProblemInstance`.
- The only consumer is the `verify` endpoint (`ProblemProvider.cs:93`, `[FromBody] Verify verify`). With the in-file copy removed, the parameter transparently re-resolves to `API.Tools.ApiParameters.Verify` — no other edits needed since the `using` is already present.
- No behavior change; serialization shape is identical.

## Testing

- `dotnet build` — succeeded, 0 warnings, 0 errors
- `dotnet test` — 603 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)