### PR TITLE
refactor: remove dead toDotArrayList method (ArrayList)

### DIFF
--- a/Interfaces/graphs/DirectedGraph.cs
+++ b/Interfaces/graphs/DirectedGraph.cs
@@ -1,7 +1,6 @@
 //DirectedGraph.cs
 //Can take a string representation of a directed graph and turn it into a directed graph object.
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -342,39 +341,8 @@ abstract class DirectedGraph : Graph {
         return toString;
     }
 
-
-    ///<summary>
-    ///Returns an ArrayList of Strings that is essentially a dot representation of the graph.
-    ///</summary>
-    public ArrayList toDotArrayList(){
-
-        ArrayList dotList = new ArrayList();
-  
-        string preStr = @"digraph {";
-        dotList.Add(preStr);
-
-        //string preStr2 = @"node[style = ""filled""]";
-        dotList.Add(preStr);
-
-        
-        string dotNode = ""; 
-        //string colorRed = "#d62728";
-        foreach(Node n in _nodeList){
-        //dotNode=$"{n.name} [{colorRed}]";
-        dotList.Add(dotNode);
-        }
-        foreach(Edge e in _edgeList){ 
-            KeyValuePair<string,string> eKVP = e.toKVP();
-            string edgeStr = $"{eKVP.Key} -> {eKVP.Value}";
-            dotList.Add(edgeStr);
-        }
-        dotList.Add("}");
-        return dotList;
-       
-    }
-
     /// <summary>
-    /// Returns a Jsoned Dot representation (jsoned list of strings) that is compliant with the graphvis DOT format. 
+    /// Returns a Jsoned Dot representation (jsoned list of strings) that is compliant with the graphvis DOT format.
     /// </summary>
     /// <returns></returns>
     public abstract String toDotJson();


### PR DESCRIPTION
## Summary

Deletes `DirectedGraph.toDotArrayList()`. Part of item 10 ("Remove `ArrayList` and legacy patterns") from the API critique — this clears the last `ArrayList` usage in `DirectedGraph.cs`.

## Details

- **Unused:** `toDotArrayList()` had zero callers anywhere in the codebase or tests.
- **Incomplete:** the body added an always-empty `dotNode` string for each node and duplicated the `digraph {` header, so it never produced valid DOT output anyway.
- Removing it also lets the now-unused `using System.Collections;` be dropped.

The remaining `ArrayList` usages (item 10) live in the `Nav_*` navigation controllers, which are slated for removal under item 1 (controller consolidation) and are intentionally left untouched here.

## Testing

- `dotnet build` — succeeded, 0 warnings, 0 errors
- `dotnet test` — 603 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)