### PR TITLE
Add Minimum Cut problem (P) with Stoer-Wagner solver

### DIFF
--- a/Problems/P/P_MINCUT/MINCUT_Class.cs
+++ b/Problems/P/P_MINCUT/MINCUT_Class.cs
@@ -1,0 +1,51 @@
+using API.Interfaces;
+using API.Problems.P.P_MINCUT.Solvers;
+using API.Problems.P.P_MINCUT.Verifiers;
+using API.Problems.P.P_MINCUT.Visualizations;
+using SPADE;
+
+namespace API.Problems.P.P_MINCUT;
+
+class MINCUT : IGraphProblem<MinCutStoerWagner, MinCutVerifier, MinCutVisualization, UtilCollectionGraph>
+{
+    public string problemName { get; } = "Minimum Cut";
+    public string problemLink { get; } = "https://en.wikipedia.org/wiki/Minimum_cut";
+    public string formalDefinition { get; } = "MinCut = {<G> | G is a weighted undirected graph} — find the partition of V into non-empty S and T minimizing the total weight of edges between S and T.";
+    public string problemDefinition { get; } = "Given a weighted undirected graph, find a partition of the vertices into two non-empty sets S and T such that the total weight of edges crossing the partition is minimized.";
+    public string[] contributors { get; } = { "Michael Trosper" };
+    public string source { get; } = "Stoer, Mechthild, and Frank Wagner. \"A simple min-cut algorithm.\" Journal of the ACM 44, no. 4 (1997): 585-591.";
+    public string sourceLink { get; } = "https://dl.acm.org/doi/10.1145/263867.263872";
+    public static string _defaultInstance { get; } = "({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})";
+    public string defaultInstance { get; } = _defaultInstance;
+    public string instance { get; set; } = string.Empty;
+    public string wikiName { get; } = "";
+    public string instanceFormat { get; } = "Weighted undirected graph: ({nodes},{({u,v},w),...}) — e.g. ({1,2,3},{({1,2},4),({2,3},2),({1,3},3)})";
+    public string certificateFormat { get; } = "Set of cut edges with weights: {({u,v},w),...} — e.g. {({1,2},4),({1,3},3)}";
+
+    private List<string> _nodes = new();
+    private List<(string source, string destination, int weight)> _edges = new();
+
+    public MinCutStoerWagner defaultSolver { get; } = new MinCutStoerWagner();
+    public MinCutVerifier defaultVerifier { get; } = new MinCutVerifier();
+    public MinCutVisualization defaultVisualization { get; } = new MinCutVisualization();
+    public UtilCollectionGraph graph { get; set; }
+
+    public List<string> nodes { get => _nodes; set => _nodes = value; }
+    public List<(string source, string destination, int weight)> edges { get => _edges; set => _edges = value; }
+
+    public MINCUT() : this(_defaultInstance) { }
+
+    public MINCUT(string instanceString)
+    {
+        instance = instanceString;
+        StringParser parser = new("{(N,E) | N is set, E subset {(e, w) | e is N unorderedcross N, w is int}}");
+        parser.parse(instanceString);
+        nodes = parser["N"].ToList().Select(n => n.ToString()).ToList();
+        edges = parser["E"].ToList().Select(edge =>
+        {
+            List<UtilCollection> endpoints = edge[0].ToList();
+            return (endpoints[0].ToString(), endpoints[1].ToString(), int.Parse(edge[1].ToString()));
+        }).ToList();
+        graph = new UtilCollectionGraph(parser["N"], parser["E"]);
+    }
+}

--- a/Problems/P/P_MINCUT/Solvers/MinCutStoerWagner.cs
+++ b/Problems/P/P_MINCUT/Solvers/MinCutStoerWagner.cs
@@ -1,0 +1,132 @@
+using API.Interfaces;
+
+namespace API.Problems.P.P_MINCUT.Solvers;
+
+class MinCutStoerWagner : ISolver<MINCUT>
+{
+    public string solverName { get; } = "Stoer-Wagner Minimum Cut";
+    public string solverDefinition { get; } = "Finds the global minimum cut of a weighted undirected graph using the Stoer-Wagner algorithm in O(V³) time.";
+    public string source { get; } = "Stoer, Mechthild, and Frank Wagner. \"A simple min-cut algorithm.\" Journal of the ACM 44, no. 4 (1997): 585-591.";
+    public string[] contributors { get; } = { "Michael Trosper" };
+    public bool timerHasExpired { get; set; }
+
+    public MinCutStoerWagner() { }
+
+    public string solve(MINCUT problem)
+    {
+        int n = problem.nodes.Count;
+        if (n < 2) return "{}";
+
+        Dictionary<string, int> nodeIndex = BuildNodeIndex(problem.nodes);
+        int[,] w = BuildAdjacencyMatrix(n, nodeIndex, problem.edges);
+
+        if (timerHasExpired) return "{}";
+        var (_, minSide) = RunStoerWagner(n, w);
+
+        List<string> cutEdgeParts = new();
+        HashSet<string> seen = new();
+        foreach (var edge in problem.edges)
+        {
+            int u = nodeIndex[edge.source];
+            int v = nodeIndex[edge.destination];
+            if (minSide.Contains(u) == minSide.Contains(v)) continue;
+
+            string key = $"{Math.Min(u, v)}-{Math.Max(u, v)}";
+            if (!seen.Add(key)) continue;
+            cutEdgeParts.Add("({" + edge.source + "," + edge.destination + "}," + edge.weight + ")");
+        }
+
+        return "{" + string.Join(",", cutEdgeParts) + "}";
+    }
+
+    // Runs Stoer-Wagner and returns (minCutWeight, one side of the min cut as original node indices).
+    internal static (int weight, HashSet<int> side) RunStoerWagner(int n, int[,] wInput)
+    {
+        int[,] w = (int[,])wInput.Clone();
+        List<HashSet<int>> merged = Enumerable.Range(0, n).Select(i => new HashSet<int> { i }).ToList();
+        bool[] active = Enumerable.Repeat(true, n).ToArray();
+
+        int bestWeight = int.MaxValue;
+        HashSet<int> bestSide = new();
+
+        for (int phase = 0; phase < n - 1; phase++)
+        {
+            int[] key = new int[n];
+            bool[] inA = new bool[n];
+            int lastAdded = -1, secondLastAdded = -1;
+            int activeCount = active.Count(x => x);
+
+            for (int step = 0; step < activeCount; step++)
+            {
+                int z = -1;
+                for (int i = 0; i < n; i++)
+                {
+                    if (active[i] && !inA[i] && (z == -1 || key[i] > key[z]))
+                        z = i;
+                }
+                if (z == -1) break;
+
+                secondLastAdded = lastAdded;
+                lastAdded = z;
+                inA[z] = true;
+
+                for (int i = 0; i < n; i++)
+                    if (active[i] && !inA[i])
+                        key[i] += w[z, i];
+            }
+
+            if (lastAdded == -1 || secondLastAdded == -1) break;
+
+            // The cut-of-the-phase separates lastAdded from the rest.
+            // key[lastAdded] = sum of edges from lastAdded to all other active nodes.
+            int phaseWeight = key[lastAdded];
+            if (phaseWeight < bestWeight)
+            {
+                bestWeight = phaseWeight;
+                bestSide = new HashSet<int>(merged[lastAdded]);
+            }
+
+            // Merge lastAdded into secondLastAdded.
+            for (int i = 0; i < n; i++)
+            {
+                w[secondLastAdded, i] += w[lastAdded, i];
+                w[i, secondLastAdded] += w[i, lastAdded];
+            }
+            merged[secondLastAdded].UnionWith(merged[lastAdded]);
+            active[lastAdded] = false;
+        }
+
+        return (bestWeight == int.MaxValue ? 0 : bestWeight, bestSide);
+    }
+
+    internal static int GetMinCutWeight(MINCUT problem)
+    {
+        int n = problem.nodes.Count;
+        if (n < 2) return 0;
+        Dictionary<string, int> nodeIndex = BuildNodeIndex(problem.nodes);
+        int[,] w = BuildAdjacencyMatrix(n, nodeIndex, problem.edges);
+        var (weight, _) = RunStoerWagner(n, w);
+        return weight;
+    }
+
+    internal static Dictionary<string, int> BuildNodeIndex(List<string> nodes)
+    {
+        Dictionary<string, int> index = new();
+        for (int i = 0; i < nodes.Count; i++) index[nodes[i]] = i;
+        return index;
+    }
+
+    internal static int[,] BuildAdjacencyMatrix(int n, Dictionary<string, int> nodeIndex,
+        List<(string source, string destination, int weight)> edges)
+    {
+        int[,] w = new int[n, n];
+        foreach (var edge in edges)
+        {
+            int u = nodeIndex[edge.source];
+            int v = nodeIndex[edge.destination];
+            w[u, v] += edge.weight;
+            w[v, u] += edge.weight;
+        }
+        return w;
+    }
+}

--- a/Problems/P/P_MINCUT/Verifiers/MinCutVerifier.cs
+++ b/Problems/P/P_MINCUT/Verifiers/MinCutVerifier.cs
@@ -1,0 +1,52 @@
+using API.Interfaces;
+using API.Problems.P.P_MINCUT.Solvers;
+using SPADE;
+
+namespace API.Problems.P.P_MINCUT.Verifiers;
+
+class MinCutVerifier : IVerifier<MINCUT>
+{
+    public string verifierName { get; } = "Minimum Cut Verifier";
+    public string verifierDefinition { get; } = "Verifies that a proposed set of edges is a valid minimum cut of the graph by checking all edges exist, then comparing the total weight to the true minimum cut weight from Stoer-Wagner.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Michael Trosper" };
+    private string _certificate = "";
+    public string certificate => _certificate;
+
+    public MinCutVerifier() { }
+
+    public bool verify(MINCUT problem, string certificate)
+    {
+        _certificate = certificate ?? "";
+        int minCutWeight = MinCutStoerWagner.GetMinCutWeight(problem);
+
+        if (string.IsNullOrWhiteSpace(certificate) || certificate.Trim() == "{}")
+            return minCutWeight == 0;
+
+        UtilCollection edgeList;
+        try { edgeList = new UtilCollection(certificate); }
+        catch { return false; }
+
+        int totalWeight = 0;
+        foreach (UtilCollection item in edgeList)
+        {
+            try
+            {
+                List<UtilCollection> endpoints = item[0].ToList();
+                string src = endpoints[0].ToString();
+                string dst = endpoints[1].ToString();
+                int wt = int.Parse(item[1].ToString());
+
+                bool exists = problem.edges.Any(e =>
+                    (e.source == src && e.destination == dst && e.weight == wt) ||
+                    (e.source == dst && e.destination == src && e.weight == wt));
+                if (!exists) return false;
+
+                totalWeight += wt;
+            }
+            catch { return false; }
+        }
+
+        return totalWeight == minCutWeight;
+    }
+}

--- a/Problems/P/P_MINCUT/Visualizations/MinCutVisualization.cs
+++ b/Problems/P/P_MINCUT/Visualizations/MinCutVisualization.cs
@@ -1,0 +1,63 @@
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_MINCUT.Solvers;
+using SPADE;
+
+namespace API.Problems.P.P_MINCUT.Visualizations;
+
+class MinCutVisualization : IVisualization<MINCUT>
+{
+    public string visualizationName { get; } = "Minimum Cut Visualization";
+    public string visualizationDefinition { get; } = "Displays a weighted undirected graph and highlights the edges belonging to the minimum cut.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Michael Trosper" };
+    public string visualizationType { get; } = "Graph D3";
+    public ISolver solver { get; } = new MinCutStoerWagner();
+
+    public MinCutVisualization() { }
+
+    public API_JSON visualize(MINCUT problem) => problem.graph.ToAPIGraph();
+
+    public API_JSON SolvedVisualization(MINCUT problem, string solution)
+    {
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return visualize(problem);
+
+        API_GraphJSON apiGraph = problem.graph.ToAPIGraph();
+
+        UtilCollection edgeList;
+        try { edgeList = new UtilCollection(solution); }
+        catch { return apiGraph; }
+
+        HashSet<string> cutNodes = new();
+
+        foreach (UtilCollection item in edgeList)
+        {
+            try
+            {
+                List<UtilCollection> endpoints = item[0].ToList();
+                string src = endpoints[0].ToString();
+                string dst = endpoints[1].ToString();
+
+                var link = apiGraph.links.FirstOrDefault(l =>
+                    (l.source == src && l.target == dst) || (l.source == dst && l.target == src));
+                if (link != null)
+                {
+                    link.color = "Solution";
+                    link.dashed = "True";
+                }
+
+                cutNodes.Add(src);
+                cutNodes.Add(dst);
+            }
+            catch { }
+        }
+
+        foreach (var node in apiGraph.nodes)
+            if (cutNodes.Contains(node.name))
+                node.color = "Solution";
+
+        return apiGraph;
+    }
+}

--- a/redux-tests/Problems/P_MINCUT/MINCUT_Tests.cs
+++ b/redux-tests/Problems/P_MINCUT/MINCUT_Tests.cs
@@ -1,0 +1,193 @@
+using Xunit;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_MINCUT;
+using API.Problems.P.P_MINCUT.Solvers;
+using API.Problems.P.P_MINCUT.Verifiers;
+using API.Problems.P.P_MINCUT.Visualizations;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class MINCUT_Tests
+{
+    // ----- Instantiation ----- //
+
+    [Fact]
+    public void MINCUT_Default_Instantiation()
+    {
+        MINCUT problem = new MINCUT();
+        Assert.Equal(MINCUT._defaultInstance, problem.instance);
+        Assert.Equal(MINCUT._defaultInstance, problem.defaultInstance);
+    }
+
+    [Fact]
+    public void MINCUT_Custom_Instantiation()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        MINCUT problem = new MINCUT(instance);
+        Assert.Equal(instance, problem.instance);
+        Assert.Equal(3, problem.nodes.Count);
+        Assert.Equal(3, problem.edges.Count);
+    }
+
+    [Fact]
+    public void MINCUT_Two_Node_Graph()
+    {
+        string instance = "({1,2},{({1,2},7)})";
+        MINCUT problem = new MINCUT(instance);
+        Assert.Equal(2, problem.nodes.Count);
+        Assert.Equal(1, problem.edges.Count);
+    }
+
+    // ----- Solver ----- //
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})", 3)]
+    [InlineData("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})", 3)]
+    [InlineData("({1,2},{({1,2},7)})", 7)]
+    [InlineData("({1,2,3,4},{({1,2},3),({2,3},3),({3,4},3),({4,1},3)})", 6)]
+    public void MINCUT_Solver_Returns_Correct_Weight(string instance, int expectedWeight)
+    {
+        MINCUT problem = new MINCUT(instance);
+        MinCutStoerWagner solver = new MinCutStoerWagner();
+        string solution = solver.solve(problem);
+        int actualWeight = ParseTotalWeight(solution);
+        Assert.Equal(expectedWeight, actualWeight);
+    }
+
+    [Fact]
+    public void MINCUT_Solver_Default_Instance_Weight_Is_3()
+    {
+        MINCUT problem = new MINCUT();
+        string solution = new MinCutStoerWagner().solve(problem);
+        Assert.Equal(3, ParseTotalWeight(solution));
+    }
+
+    [Fact]
+    public void MINCUT_Solver_Single_Node_Returns_Empty()
+    {
+        // Single-node graph - no cut possible
+        string instance = "({1},{})";
+        MINCUT problem = new MINCUT(instance);
+        string solution = new MinCutStoerWagner().solve(problem);
+        Assert.Equal("{}", solution);
+    }
+
+    [Fact]
+    public void MINCUT_Solver_Certificate_Edges_All_Exist_In_Graph()
+    {
+        MINCUT problem = new MINCUT();
+        string solution = new MinCutStoerWagner().solve(problem);
+        Assert.NotEqual("{}", solution);
+
+        // Each edge in the certificate must exist in the problem
+        MinCutVerifier verifier = new MinCutVerifier();
+        Assert.True(verifier.verify(problem, solution));
+    }
+
+    // ----- Verifier ----- //
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})", "{({3,5},1),({4,5},2)}", true)]
+    [InlineData("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})", "{({1,2},1),({2,3},2)}", true)]
+    [InlineData("({1,2},{({1,2},7)})", "{({1,2},7)}", true)]
+    public void MINCUT_Verifier_Accepts_Valid_Minimum_Cut(string instance, string certificate, bool expected)
+    {
+        MINCUT problem = new MINCUT(instance);
+        MinCutVerifier verifier = new MinCutVerifier();
+        Assert.Equal(expected, verifier.verify(problem, certificate));
+    }
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})", "{({1,3},4),({2,3},2)}")]
+    [InlineData("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})", "{({1,2},1)}")]
+    public void MINCUT_Verifier_Rejects_Non_Minimum_Cut(string instance, string certificate)
+    {
+        MINCUT problem = new MINCUT(instance);
+        MinCutVerifier verifier = new MinCutVerifier();
+        Assert.False(verifier.verify(problem, certificate));
+    }
+
+    [Fact]
+    public void MINCUT_Verifier_Rejects_Nonexistent_Edge()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        MINCUT problem = new MINCUT(instance);
+        MinCutVerifier verifier = new MinCutVerifier();
+        Assert.False(verifier.verify(problem, "{({1,2},99)}"));
+    }
+
+    [Fact]
+    public void MINCUT_Verifier_Rejects_Empty_For_Connected_Graph()
+    {
+        MINCUT problem = new MINCUT();
+        MinCutVerifier verifier = new MinCutVerifier();
+        Assert.False(verifier.verify(problem, "{}"));
+    }
+
+    [Fact]
+    public void MINCUT_Solver_Output_Passes_Verifier()
+    {
+        string[] instances = {
+            MINCUT._defaultInstance,
+            "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})",
+            "({1,2},{({1,2},7)})",
+            "({A,B,C,D},{({A,B},4),({B,C},3),({C,D},4),({D,A},3),({A,C},1),({B,D},1)})"
+        };
+        foreach (string inst in instances)
+        {
+            MINCUT problem = new MINCUT(inst);
+            string solution = new MinCutStoerWagner().solve(problem);
+            Assert.True(new MinCutVerifier().verify(problem, solution), $"Solver output failed verifier for: {inst}");
+        }
+    }
+
+    // ----- Visualization ----- //
+
+    [Fact]
+    public void MINCUT_Visualization_Returns_Graph()
+    {
+        MINCUT problem = new MINCUT();
+        MinCutVisualization viz = new MinCutVisualization();
+        var graph = (API_GraphJSON)viz.visualize(problem);
+        Assert.Equal(5, graph.nodes.Count);
+    }
+
+    [Fact]
+    public void MINCUT_SolvedVisualization_Colors_Cut_Edges()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        MINCUT problem = new MINCUT(instance);
+        MinCutVisualization viz = new MinCutVisualization();
+
+        // Min cut for this graph: {2} vs {1,3}, edges ({1,2},1) and ({2,3},2), weight=3
+        string solution = "{({1,2},1),({2,3},2)}";
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, solution);
+
+        var link12 = graph.links.FirstOrDefault(l =>
+            (l.source == "1" && l.target == "2") || (l.source == "2" && l.target == "1"));
+        Assert.NotNull(link12);
+        Assert.Equal("Solution", link12!.color);
+    }
+
+    [Fact]
+    public void MINCUT_SolvedVisualization_Empty_Solution_Returns_Plain_Graph()
+    {
+        MINCUT problem = new MINCUT();
+        MinCutVisualization viz = new MinCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{}");
+        Assert.All(graph.nodes, n => Assert.NotEqual("Solution", n.color));
+    }
+
+    // ----- Helper ----- //
+
+    private static int ParseTotalWeight(string certificate)
+    {
+        if (string.IsNullOrWhiteSpace(certificate) || certificate.Trim() == "{}") return 0;
+        var edgeList = new SPADE.UtilCollection(certificate);
+        int total = 0;
+        foreach (SPADE.UtilCollection item in edgeList)
+            total += int.Parse(item[1].ToString());
+        return total;
+    }
+}


### PR DESCRIPTION
Implements the global minimum cut problem as a polynomial-time solvable problem under Problems/P/P_MINCUT. Uses the Stoer-Wagner algorithm (O(V³)) to find the minimum weight partition of graph vertices into two non-empty sets. Verifier confirms certificate edges exist and total weight equals the true minimum cut weight. Includes 21 unit tests covering solver, verifier, and visualization.