### PR TITLE
fix: correct and complete Maximum Cut (NPC) implementation

### DIFF
--- a/Problems/NPComplete/NPC_MAXCUT/MAXCUT_Class.cs
+++ b/Problems/NPComplete/NPC_MAXCUT/MAXCUT_Class.cs
@@ -6,98 +6,46 @@ using SPADE;
 
 namespace API.Problems.NPComplete.NPC_MAXCUT;
 
-class MAXCUT : IGraphProblem<MaxCutSolver, MaxCutVerifier, MaxCutVisualization, UtilCollectionGraph> {
-
-    // --- Fields ---
-    public string problemName {get;} = "Max Cut";
+class MAXCUT : IGraphProblem<MaxCutSolver, MaxCutVerifier, MaxCutVisualization, UtilCollectionGraph>
+{
+    public string problemName { get; } = "Max Cut";
     public string problemLink { get; } = "https://en.wikipedia.org/wiki/Maximum_cut";
-    public string formalDefinition {get;} = "Max Cut = {<G> | G is a graph}";
-    public string problemDefinition {get;} = "A maximum cut in an undirected (possibly weighted) graph is a partition of the graphs vertices into two complementary sets S and T such that the total number (or total weight) of edges between S and T is maximized. The goal of the Max Cut problem is to find such a partition.";
-    public string[] contributors {get;} = {"Max Gruenwoldt", "Eric Hill"};
-    
-    public string source {get;} = "Karp, Richard M. Reducibility among combinatorial problems. Complexity of computer computations. Springer, Boston, MA, 1972. 85-103.";
+    public string formalDefinition { get; } = "MaxCut = {<G> | G is a weighted undirected graph} — find the partition of V into non-empty S and T maximizing the total weight of edges between S and T.";
+    public string problemDefinition { get; } = "Given a weighted undirected graph, find a partition of the vertices into two non-empty sets S and T such that the total weight of edges crossing the partition is maximized.";
+    public string[] contributors { get; } = { "Max Gruenwoldt", "Eric Hill", "Michael Trosper" };
+    public string source { get; } = "Karp, Richard M. Reducibility among combinatorial problems. Complexity of computer computations. Springer, Boston, MA, 1972. 85-103.";
     public string sourceLink { get; } = "https://cgi.di.uoa.gr/~sgk/teaching/grad/handouts/karp.pdf";
-    // private static string _defaultInstance = "({1,2,3,4,5},{{2,1},{1,3},{2,3},{3,5},{2,4},{4,5}})";
     public static string _defaultInstance { get; } = "({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})";
     public string defaultInstance { get; } = _defaultInstance;
-    public string instance {get;set;} = string.Empty;
-    
-    private List<string> _nodes = new List<string>();
-    // private List<KeyValuePair<string, string>> _edges = new List<KeyValuePair<string, string>>();
-    private List<(string source, string destination, int weight)> _edges = new List<(string source, string destination, int weight)>();
-    public MaxCutSolver defaultSolver {get;} = new MaxCutSolver();
-    public MaxCutVerifier defaultVerifier {get;} = new MaxCutVerifier();
+    public string instance { get; set; } = string.Empty;
+    public string wikiName { get; } = "";
+    public string instanceFormat { get; } = "Weighted undirected graph: ({nodes},{({u,v},w),...}) — e.g. ({1,2,3},{({1,2},4),({2,3},2),({1,3},3)})";
+    public string certificateFormat { get; } = "Set of vertices on the S side of the maximum cut: {node,...} — e.g. {1,3}";
+
+    private List<string> _nodes = new();
+    private List<(string source, string destination, int weight)> _edges = new();
+
+    public MaxCutSolver defaultSolver { get; } = new MaxCutSolver();
+    public MaxCutVerifier defaultVerifier { get; } = new MaxCutVerifier();
     public MaxCutVisualization defaultVisualization { get; } = new MaxCutVisualization();
     public UtilCollectionGraph graph { get; set; }
-    
-    public string wikiName {get;} = "";
-  
 
-    // --- Properties ---
-    public List<string> nodes {
-        get {
-            return _nodes;
-        }
-        set {
-            _nodes = value;
-        }
-    }
-    // public List<KeyValuePair<string, string>> edges {
-    //     get {
-    //         return _edges;
-    //     }
-    //     set {
-    //         _edges = value;
-    //     }
-    // }
+    public List<string> nodes { get => _nodes; set => _nodes = value; }
+    public List<(string source, string destination, int weight)> edges { get => _edges; set => _edges = value; }
 
-    public List<(string source, string destination, int weight)> edges
+    public MAXCUT() : this(_defaultInstance) { }
+
+    public MAXCUT(string instanceString)
     {
-        get
-        {
-            return _edges;
-        }
-        set
-        {
-            _edges = value;
-        }
-    }
-
-    // --- Methods Including Constructors ---
-    public MAXCUT() : this(_defaultInstance) {
-
-    }
-    public MAXCUT(string GInput) {
-        instance = GInput;
-
-        // StringParser maxcut = new("{(N,E) | N is set, E subset N unorderedcross N}");
-        // maxcut.parse(GInput);
-        // nodes = maxcut["N"].ToList().Select(node => node.ToString()).ToList();
-        // edges = maxcut["E"].ToList().Select(edge =>
-        // {
-        //     List<UtilCollection> cast = edge.ToList();
-        //     return new KeyValuePair<string, string>(cast[0].ToString(), cast[1].ToString());
-        // }).ToList();
-        // graph = new UtilCollectionGraph(maxcut["N"], maxcut["E"]);
-
-        // Alternative working (but with errors) parser
+        instance = instanceString;
         StringParser maxCut = new("{(N,E) | N is set, E subset {(e, w) | e is N unorderedcross N, w is int}}");
-
-        // Attempt to fix the parser to be more accurate (WIP)
-        // StringParser maxCut = new("{(N,E) | N is set, E subset {(e, w) | e is subset N cross N, w is int}}");
-        // StringParser maxCut = new("{(N,E) | N is set, E is set");
-        // StringParser EParse = new("E ");
-        // Instance (for help with fixing above) "({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})";
-       
         maxCut.parse(instance);
         nodes = maxCut["N"].ToList().Select(node => node.ToString()).ToList();
-
         edges = maxCut["E"].ToList().Select(edge =>
         {
             List<UtilCollection> cast = edge[0].ToList();
             return (cast[0].ToString(), cast[1].ToString(), int.Parse(edge[1].ToString()));
         }).ToList();
-        
         graph = new UtilCollectionGraph(maxCut["N"], maxCut["E"]);
     }
 }

--- a/Problems/NPComplete/NPC_MAXCUT/Solvers/MaxCutSolver.cs
+++ b/Problems/NPComplete/NPC_MAXCUT/Solvers/MaxCutSolver.cs
@@ -1,48 +1,38 @@
 using API.Interfaces;
-using API.Interfaces.Graphs.GraphParser;
-using API.Interfaces.Graphs;
 
 namespace API.Problems.NPComplete.NPC_MAXCUT.Solvers;
-class MaxCutSolver : ISolver<MAXCUT> {
 
-    // --- Fields ---
-    public string solverName {get;} = "Max Cut Brute Force Solver";
-    public string solverDefinition {get;} = "Enumerates all 2^n partitions of the vertex set and returns the side S of the partition whose crossing edges have maximum total weight. Certificate format: {node1,node2,...} representing the S side.";
-    public string source {get;} = "";
-    public string[] contributors {get;} = {"Max Gruenwoldt", "Eric Hill"};
+class MaxCutSolver : ISolver<MAXCUT>
+{
+    public string solverName { get; } = "Max Cut Brute Force Solver";
+    public string solverDefinition { get; } = "Enumerates all 2^n partitions of the vertex set and returns the S side of the partition whose crossing edges have maximum total weight. Certificate format: {node1,node2,...} representing the S side.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Max Gruenwoldt", "Eric Hill" };
     public bool timerHasExpired { get; set; }
 
     public MaxCutSolver() { }
 
-    private int cutWeight(MAXCUT maxcut, HashSet<string> S) {
-        int total = 0;
-        foreach (var edge in maxcut.edges) {
-            bool srcInS = S.Contains(edge.source);
-            bool dstInS = S.Contains(edge.destination);
-            if (srcInS != dstInS)
-                total += edge.weight;
-        }
-        return total;
-    }
-
-    public string solve(MAXCUT maxcut) {
-        List<string> nodes = maxcut.nodes;
+    public string solve(MAXCUT problem)
+    {
+        List<string> nodes = problem.nodes;
         int n = nodes.Count;
-        if (n == 0) return "{}";
+        if (n < 2) return "{}";
 
         int bestWeight = -1;
         HashSet<string> bestS = new();
 
-        // Each bitmask assigns each node to S (bit=1) or T (bit=0).
-        // Skip mask 0 (all in T) and (1<<n)-1 (all in S) — both give empty cuts.
         int limit = 1 << n;
-        for (int mask = 1; mask < limit - 1; mask++) {
+        for (int mask = 1; mask < limit - 1; mask++)
+        {
+            if (timerHasExpired) return "{}";
+
             HashSet<string> S = new();
             for (int i = 0; i < n; i++)
                 if ((mask >> i & 1) == 1) S.Add(nodes[i]);
 
-            int w = cutWeight(maxcut, S);
-            if (w > bestWeight) {
+            int w = CutWeight(problem.edges, S);
+            if (w > bestWeight)
+            {
                 bestWeight = w;
                 bestS = S;
             }
@@ -50,5 +40,39 @@ class MaxCutSolver : ISolver<MAXCUT> {
 
         if (bestS.Count == 0) return "{}";
         return "{" + string.Join(",", bestS) + "}";
+    }
+
+    internal static int GetMaxCutWeight(MAXCUT problem)
+    {
+        List<string> nodes = problem.nodes;
+        int n = nodes.Count;
+        if (n < 2) return 0;
+
+        int bestWeight = 0;
+        int limit = 1 << n;
+        for (int mask = 1; mask < limit - 1; mask++)
+        {
+            HashSet<string> S = new();
+            for (int i = 0; i < n; i++)
+                if ((mask >> i & 1) == 1) S.Add(nodes[i]);
+
+            int w = CutWeight(problem.edges, S);
+            if (w > bestWeight)
+                bestWeight = w;
+        }
+        return bestWeight;
+    }
+
+    internal static int CutWeight(List<(string source, string destination, int weight)> edges, HashSet<string> S)
+    {
+        int total = 0;
+        foreach (var edge in edges)
+        {
+            bool srcInS = S.Contains(edge.source);
+            bool dstInS = S.Contains(edge.destination);
+            if (srcInS != dstInS)
+                total += edge.weight;
+        }
+        return total;
     }
 }

--- a/Problems/NPComplete/NPC_MAXCUT/Verifiers/MaxCutVerifier.cs
+++ b/Problems/NPComplete/NPC_MAXCUT/Verifiers/MaxCutVerifier.cs
@@ -1,44 +1,51 @@
 using API.Interfaces;
-using API.Interfaces.Graphs.GraphParser;
+using API.Problems.NPComplete.NPC_MAXCUT.Solvers;
 
 namespace API.Problems.NPComplete.NPC_MAXCUT.Verifiers;
 
-class MaxCutVerifier : IVerifier<MAXCUT> {
-
-    // --- Fields ---
-    public string verifierName {get;} = "Max Cut Verifier";
-    public string verifierDefinition {get;} = "Verifies that the certificate is a valid non-trivial partition S of the graph's vertices (all nodes in S belong to the graph and appear exactly once, and S is neither empty nor the full node set).";
-    public string source {get;} = "";
-    public string[] contributors {get;} = {"Max Gruenwoldt", "Eric Hill"};
+class MaxCutVerifier : IVerifier<MAXCUT>
+{
+    public string verifierName { get; } = "Max Cut Verifier";
+    public string verifierDefinition { get; } = "Verifies that the certificate represents a valid non-trivial partition S whose crossing-edge weight equals the true maximum cut weight computed by brute force enumeration.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Max Gruenwoldt", "Eric Hill", "Michael Trosper" };
 
     private string _certificate = "";
-
-    public string certificate {
-        get { return _certificate; }
-    }
+    public string certificate => _certificate;
 
     public MaxCutVerifier() { }
 
-    public bool verify(MAXCUT problem, string certificate) {
-        if (string.IsNullOrWhiteSpace(certificate) || certificate == "{}")
+    public bool verify(MAXCUT problem, string certificate)
+    {
+        _certificate = certificate ?? "";
+
+        if (string.IsNullOrWhiteSpace(_certificate) || _certificate.Trim() == "{}")
             return false;
 
-        List<string> S = GraphParser.parseNodeListWithStringFunctions(certificate)
-                            .Where(s => !string.IsNullOrWhiteSpace(s))
-                            .ToList();
+        List<string> S = _certificate.Trim()
+            .TrimStart('{').TrimEnd('}')
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList();
 
         if (S.Count == 0) return false;
 
-        // Every node in S must exist in the graph.
+        // All nodes in S must exist in the graph.
         foreach (string node in S)
             if (!problem.nodes.Contains(node)) return false;
 
         // No duplicate nodes in S.
         if (S.Count != S.Distinct().Count()) return false;
 
-        // S must be a proper subset (not empty, not the entire vertex set).
+        // S must be a proper subset (not the entire vertex set).
         if (S.Count == problem.nodes.Count) return false;
 
-        return true;
+        // Cut weight for this S must equal the true maximum cut weight.
+        HashSet<string> sSet = new(S);
+        int cutWeight = MaxCutSolver.CutWeight(problem.edges, sSet);
+        int maxCutWeight = MaxCutSolver.GetMaxCutWeight(problem);
+
+        return cutWeight == maxCutWeight;
     }
 }

--- a/Problems/NPComplete/NPC_MAXCUT/Visualizations/MaxCutVisualization.cs
+++ b/Problems/NPComplete/NPC_MAXCUT/Visualizations/MaxCutVisualization.cs
@@ -1,69 +1,54 @@
 using API.Interfaces;
-using System.Text.Json;
-using API.Interfaces.Graphs.GraphParser;
-using API.Interfaces.JSON_Objects.Graphs;
 using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Graphs;
 using API.Problems.NPComplete.NPC_MAXCUT.Solvers;
 
 namespace API.Problems.NPComplete.NPC_MAXCUT.Visualizations;
 
 class MaxCutVisualization : IVisualization<MAXCUT>
 {
-
-    // --- Fields ---
-    public string visualizationName { get; } = " Max Cut Visualization";
-    public string visualizationDefinition { get; } = "TODO";
-    public string source { get; } = "TODO";
-    public string[] contributors { get; } = { "Max Gruenwoldt" };
-    public string visualizationType { get; } = "TODO";
+    public string visualizationName { get; } = "Max Cut Visualization";
+    public string visualizationDefinition { get; } = "Displays a weighted undirected graph and highlights the edges belonging to the maximum cut, coloring S-side nodes and crossing edges.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Max Gruenwoldt", "Michael Trosper" };
+    public string visualizationType { get; } = "Graph D3";
     public ISolver solver { get; } = new MaxCutSolver();
 
-    // --- Methods Including Constructors ---
-    public MaxCutVisualization()
+    public MaxCutVisualization() { }
+
+    public API_JSON visualize(MAXCUT problem) => problem.graph.ToAPIGraph();
+
+    public API_JSON SolvedVisualization(MAXCUT problem, string solution)
     {
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return visualize(problem);
 
-    }
-    public API_JSON visualize(MAXCUT maxcut)
-    {
-        return maxcut.graph.ToAPIGraph();
-    }
+        API_GraphJSON apiGraph = problem.graph.ToAPIGraph();
 
-    public API_JSON SolvedVisualization(MAXCUT maxcut, string solution)
-    {
-        List<KeyValuePair<string, string>> solutionEdges = GraphParser.parseUndirectedEdgeListWithStringFunctions(solution);
-        // removing duplicate edges since visualization cares about first edge only
-        for (int i = solutionEdges.Count - 1; i >= 0; i--)
-            if (i % 2 == 1) solutionEdges.RemoveAt(i);
+        // solution is the S-side node set: {node1,node2,...}
+        HashSet<string> sNodes = solution.Trim()
+            .TrimStart('{').TrimEnd('}')
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToHashSet();
 
-        API_GraphJSON apiGraph = maxcut.graph.ToAPIGraph();
-
-        foreach (var edge in solutionEdges)
+        // Color edges crossing the cut (one endpoint in S, one in T).
+        foreach (var link in apiGraph.links)
         {
-            var link = apiGraph.links.FirstOrDefault(l =>
-                (l.source == edge.Key && l.target == edge.Value) || (l.source == edge.Value && l.target == edge.Key)
-            );
-
-            var node = apiGraph.nodes.FirstOrDefault(n => n.name == edge.Key);
-
-            if (link != null)
+            bool srcInS = sNodes.Contains(link.source);
+            bool dstInS = sNodes.Contains(link.target);
+            if (srcInS != dstInS)
             {
                 link.color = "Solution";
                 link.dashed = "True";
             }
+        }
 
-            if (node != null)
-            {
+        // Color S-side nodes.
+        foreach (var node in apiGraph.nodes)
+            if (sNodes.Contains(node.name))
                 node.color = "Solution";
-            }
-        }
-
-        foreach (var link in apiGraph.links)
-        {
-            var node1 = apiGraph.nodes.FirstOrDefault(n => n.name == link.source);
-            var node2 = apiGraph.nodes.FirstOrDefault(n => n.name == link.target);
-            if (node1 != null && node2 != null && node1.color == "Solution" && node2.color == "Solution")
-                link.color = "Solution";
-        }
 
         return apiGraph;
     }

--- a/redux-tests/Problems/NPC_MAXCUT/MAXCUT_Tests.cs
+++ b/redux-tests/Problems/NPC_MAXCUT/MAXCUT_Tests.cs
@@ -1,0 +1,220 @@
+using Xunit;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.NPComplete.NPC_MAXCUT;
+using API.Problems.NPComplete.NPC_MAXCUT.Solvers;
+using API.Problems.NPComplete.NPC_MAXCUT.Verifiers;
+using API.Problems.NPComplete.NPC_MAXCUT.Visualizations;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class MAXCUT_Tests
+{
+    // ----- Instantiation ----- //
+
+    [Fact]
+    public void MAXCUT_Default_Instantiation()
+    {
+        MAXCUT problem = new MAXCUT();
+        Assert.Equal(MAXCUT._defaultInstance, problem.instance);
+        Assert.Equal(MAXCUT._defaultInstance, problem.defaultInstance);
+        Assert.Equal(5, problem.nodes.Count);
+        Assert.Equal(6, problem.edges.Count);
+    }
+
+    [Fact]
+    public void MAXCUT_Custom_Instantiation()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        MAXCUT problem = new MAXCUT(instance);
+        Assert.Equal(instance, problem.instance);
+        Assert.Equal(3, problem.nodes.Count);
+        Assert.Equal(3, problem.edges.Count);
+    }
+
+    [Fact]
+    public void MAXCUT_Two_Node_Graph()
+    {
+        string instance = "({1,2},{({1,2},7)})";
+        MAXCUT problem = new MAXCUT(instance);
+        Assert.Equal(2, problem.nodes.Count);
+        Assert.Single(problem.edges);
+    }
+
+    // ----- Solver ----- //
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})", 15)]
+    [InlineData("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})", 5)]
+    [InlineData("({1,2},{({1,2},7)})", 7)]
+    public void MAXCUT_Solver_Returns_Correct_Weight(string instance, int expectedWeight)
+    {
+        MAXCUT problem = new MAXCUT(instance);
+        MaxCutSolver solver = new MaxCutSolver();
+        string solution = solver.solve(problem);
+        int actualWeight = ComputeCutWeight(problem, solution);
+        Assert.Equal(expectedWeight, actualWeight);
+    }
+
+    [Fact]
+    public void MAXCUT_Solver_Default_Instance_Weight_Is_15()
+    {
+        MAXCUT problem = new MAXCUT();
+        string solution = new MaxCutSolver().solve(problem);
+        Assert.Equal(15, ComputeCutWeight(problem, solution));
+    }
+
+    [Fact]
+    public void MAXCUT_Solver_Single_Node_Returns_Empty()
+    {
+        string instance = "({1},{})";
+        MAXCUT problem = new MAXCUT(instance);
+        string solution = new MaxCutSolver().solve(problem);
+        Assert.Equal("{}", solution);
+    }
+
+    [Fact]
+    public void MAXCUT_Solver_Output_Passes_Verifier()
+    {
+        string[] instances = {
+            MAXCUT._defaultInstance,
+            "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})",
+            "({1,2},{({1,2},7)})",
+            "({A,B,C,D},{({A,B},4),({B,C},3),({C,D},4),({D,A},3)})"
+        };
+        foreach (string inst in instances)
+        {
+            MAXCUT problem = new MAXCUT(inst);
+            string solution = new MaxCutSolver().solve(problem);
+            Assert.True(new MaxCutVerifier().verify(problem, solution), $"Solver output failed verifier for: {inst}");
+        }
+    }
+
+    // ----- Verifier ----- //
+
+    [Theory]
+    // Default 5-node graph: S={1,4} gives cut weight 15 = max cut.
+    [InlineData("({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})", "{1,4}", true)]
+    // Complement S={2,3,5} also gives weight 15.
+    [InlineData("({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})", "{2,3,5}", true)]
+    // 3-node: max cut = 5, S={3} gives (1-3,3)+(2-3,2)=5.
+    [InlineData("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})", "{3}", true)]
+    // S={1,2} also gives weight 5 for 3-node graph.
+    [InlineData("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})", "{1,2}", true)]
+    // 2-node: max cut = 7.
+    [InlineData("({1,2},{({1,2},7)})", "{1}", true)]
+    public void MAXCUT_Verifier_Accepts_Valid_Maximum_Cut(string instance, string certificate, bool expected)
+    {
+        MAXCUT problem = new MAXCUT(instance);
+        MaxCutVerifier verifier = new MaxCutVerifier();
+        Assert.Equal(expected, verifier.verify(problem, certificate));
+    }
+
+    [Theory]
+    // S={1,2} gives cut weight 10, not max cut (15).
+    [InlineData("({1,2,3,4,5},{({2,1},5),({1,3},4),({2,3},2),({3,5},1),({2,4},4),({4,5},2)})", "{1,2}")]
+    // S={2} for 3-node graph gives weight 3, not max cut (5).
+    [InlineData("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})", "{2}")]
+    public void MAXCUT_Verifier_Rejects_Non_Maximum_Cut(string instance, string certificate)
+    {
+        MAXCUT problem = new MAXCUT(instance);
+        MaxCutVerifier verifier = new MaxCutVerifier();
+        Assert.False(verifier.verify(problem, certificate));
+    }
+
+    [Fact]
+    public void MAXCUT_Verifier_Rejects_Node_Not_In_Graph()
+    {
+        MAXCUT problem = new MAXCUT("({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})");
+        MaxCutVerifier verifier = new MaxCutVerifier();
+        Assert.False(verifier.verify(problem, "{99}"));
+    }
+
+    [Fact]
+    public void MAXCUT_Verifier_Rejects_Full_Node_Set()
+    {
+        MAXCUT problem = new MAXCUT("({1,2},{({1,2},7)})");
+        MaxCutVerifier verifier = new MaxCutVerifier();
+        Assert.False(verifier.verify(problem, "{1,2}"));
+    }
+
+    [Fact]
+    public void MAXCUT_Verifier_Rejects_Empty_Certificate()
+    {
+        MAXCUT problem = new MAXCUT();
+        MaxCutVerifier verifier = new MaxCutVerifier();
+        Assert.False(verifier.verify(problem, "{}"));
+    }
+
+    // ----- Visualization ----- //
+
+    [Fact]
+    public void MAXCUT_Visualization_Returns_Graph()
+    {
+        MAXCUT problem = new MAXCUT();
+        MaxCutVisualization viz = new MaxCutVisualization();
+        var graph = (API_GraphJSON)viz.visualize(problem);
+        Assert.Equal(5, graph.nodes.Count);
+        Assert.Equal(6, graph.links.Count);
+    }
+
+    [Fact]
+    public void MAXCUT_SolvedVisualization_Colors_Crossing_Edges()
+    {
+        // ({1,2,3},{({1,2},1),({2,3},2),({1,3},3)}), S={3}: crossing edges are (1-3) and (2-3).
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        MAXCUT problem = new MAXCUT(instance);
+        MaxCutVisualization viz = new MaxCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{3}");
+
+        var link23 = graph.links.FirstOrDefault(l =>
+            (l.source == "2" && l.target == "3") || (l.source == "3" && l.target == "2"));
+        Assert.NotNull(link23);
+        Assert.Equal("Solution", link23!.color);
+
+        // Edge (1-2) is within T and should not be colored.
+        var link12 = graph.links.FirstOrDefault(l =>
+            (l.source == "1" && l.target == "2") || (l.source == "2" && l.target == "1"));
+        Assert.NotNull(link12);
+        Assert.NotEqual("Solution", link12!.color);
+    }
+
+    [Fact]
+    public void MAXCUT_SolvedVisualization_Colors_S_Nodes()
+    {
+        string instance = "({1,2,3},{({1,2},1),({2,3},2),({1,3},3)})";
+        MAXCUT problem = new MAXCUT(instance);
+        MaxCutVisualization viz = new MaxCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{3}");
+
+        var node3 = graph.nodes.FirstOrDefault(n => n.name == "3");
+        Assert.NotNull(node3);
+        Assert.Equal("Solution", node3!.color);
+    }
+
+    [Fact]
+    public void MAXCUT_SolvedVisualization_Empty_Solution_Returns_Plain_Graph()
+    {
+        MAXCUT problem = new MAXCUT();
+        MaxCutVisualization viz = new MaxCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{}");
+        Assert.All(graph.nodes, n => Assert.NotEqual("Solution", n.color));
+        Assert.All(graph.links, l => Assert.NotEqual("Solution", l.color));
+    }
+
+    // ----- Helper ----- //
+
+    private static int ComputeCutWeight(MAXCUT problem, string certificate)
+    {
+        if (string.IsNullOrWhiteSpace(certificate) || certificate.Trim() == "{}") return 0;
+
+        HashSet<string> sNodes = certificate.Trim()
+            .TrimStart('{').TrimEnd('}')
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToHashSet();
+
+        return MaxCutSolver.CutWeight(problem.edges, sNodes);
+    }
+}


### PR DESCRIPTION
- MAXCUT_Class: remove dead commented-out code; add instanceFormat and certificateFormat descriptors; clean up field/property style to match the MinCut pattern.

- MaxCutSolver: remove dead GraphParser/Graphs imports; extract static CutWeight and GetMaxCutWeight helpers (used by verifier); add timerHasExpired guard inside the enumeration loop.

- MaxCutVerifier: rewrite verify() to actually confirm the proposed partition achieves the MAXIMUM cut weight (was only checking that S was a non-trivial subset). Now calls MaxCutSolver.GetMaxCutWeight and compares the certificate's cut weight against the true optimum.

- MaxCutVisualization: remove dead imports; fix SolvedVisualization to parse the {node,...} certificate as an S-side node set (was incorrectly calling parseUndirectedEdgeListWithStringFunctions on a node list); color crossing edges and S-side nodes; fill in TODO placeholders for visualizationType, visualizationName, and visualizationDefinition.

- MAXCUT_Tests: add 23 unit tests covering instantiation, solver weight correctness, solver→verifier round-trip, verifier accept/reject cases, and visualization edge/node coloring.

Closes #129 