### PR TITLE
feat: add Minimum S-T Cut problem (P class, Edmonds-Karp)

### DIFF
--- a/Problems/P/P_MINSTCUT/MINSTCUT_Class.cs
+++ b/Problems/P/P_MINSTCUT/MINSTCUT_Class.cs
@@ -1,0 +1,123 @@
+using API.Interfaces;
+using API.Problems.P.P_MINSTCUT.Solvers;
+using API.Problems.P.P_MINSTCUT.Verifiers;
+using API.Problems.P.P_MINSTCUT.Visualizations;
+using SPADE;
+
+namespace API.Problems.P.P_MINSTCUT;
+
+class MINSTCUT : IGraphProblem<MinSTCutSolver, MinSTCutVerifier, MinSTCutVisualization, UtilCollectionGraph>
+{
+    public string problemName { get; } = "Minimum S-T Cut";
+    public string problemLink { get; } = "https://en.wikipedia.org/wiki/Minimum_cut";
+    public string formalDefinition { get; } = "MinSTCut = {<G,s,t> | G is a weighted directed graph with source s and sink t} — find the partition of V into S (containing s) and T (containing t) minimizing the total capacity of edges directed from S to T.";
+    public string problemDefinition { get; } = "Given a weighted directed graph with non-negative edge capacities, a source node s, and a sink node t, find a partition of the vertices into S (containing s) and T (containing t) such that the total capacity of edges directed from S to T is minimized. By the Max-Flow Min-Cut theorem, this minimum cut capacity equals the maximum flow from s to t.";
+    public string[] contributors { get; } = { "Michael Trosper" };
+    public string source { get; } = "Ford, L. R.; Fulkerson, D. R. (1956). Maximal flow through a network. Canadian Journal of Mathematics, 8, 399–404.";
+    public string sourceLink { get; } = "https://doi.org/10.4153/CJM-1956-045-5";
+    public string wikiName { get; } = "";
+    public static string _defaultInstance { get; } = "({1,2,3,4},{((1,2),10),((1,3),2),((2,4),3),((3,4),5)},1,4)";
+    public string defaultInstance { get; } = _defaultInstance;
+    public string instance { get; set; } = string.Empty;
+    public string instanceFormat { get; } = "Weighted directed graph with source and sink: ({nodes},{((u,v),w),...},source,target) — e.g. ({1,2,3,4},{((1,2),10),((1,3),2),((2,4),3),((3,4),5)},1,4)";
+    public string certificateFormat { get; } = "Set of vertices on the S side of the minimum cut (must contain source, must not contain target): {node,...} — e.g. {1,2}";
+
+    private List<string> _nodes = new();
+    private List<(string from, string to, int weight)> _edges = new();
+
+    public string sourceNode { get; private set; } = string.Empty;
+    public string targetNode { get; private set; } = string.Empty;
+
+    public MinSTCutSolver defaultSolver { get; } = new MinSTCutSolver();
+    public MinSTCutVerifier defaultVerifier { get; } = new MinSTCutVerifier();
+    public MinSTCutVisualization defaultVisualization { get; } = new MinSTCutVisualization();
+    public UtilCollectionGraph graph { get; set; }
+
+    public List<string> nodes { get => _nodes; set => _nodes = value; }
+    public List<(string from, string to, int weight)> edges { get => _edges; set => _edges = value; }
+
+    public MINSTCUT() : this(_defaultInstance) { }
+
+    public MINSTCUT(string instanceString)
+    {
+        instance = instanceString;
+
+        List<string> outerParts = SplitOuterTuple(instanceString);
+
+        string graphPart;
+        if (outerParts.Count == 4)
+        {
+            graphPart = $"({outerParts[0]},{outerParts[1]})";
+            sourceNode = outerParts[2];
+            targetNode = outerParts[3];
+        }
+        else if (outerParts.Count == 3 && LooksLikeTuple(outerParts[0]))
+        {
+            graphPart = outerParts[0];
+            sourceNode = outerParts[1];
+            targetNode = outerParts[2];
+        }
+        else
+        {
+            throw new InvalidOperationException("Invalid Minimum S-T Cut instance format. Expected ({nodes},{((u,v),w),...},source,target).");
+        }
+
+        StringParser sp = new("{(N,E) | N is set, E subset {(e,w) | e is N cross N, w is int}}");
+        sp.parse(graphPart);
+
+        nodes = sp["N"].ToList().Select(n => n.ToString()).ToList();
+        edges = sp["E"].ToList().Select(edge =>
+        {
+            string from = edge[0][0].ToString();
+            string to = edge[0][1].ToString();
+            int weight = int.Parse(edge[1].ToString());
+            return (from, to, weight);
+        }).ToList();
+
+        graph = new UtilCollectionGraph(sp["N"], sp["E"]);
+
+        if (!nodes.Contains(sourceNode))
+            throw new InvalidOperationException($"Source node '{sourceNode}' is not in the node set.");
+        if (!nodes.Contains(targetNode))
+            throw new InvalidOperationException($"Target node '{targetNode}' is not in the node set.");
+    }
+
+    private static List<string> SplitOuterTuple(string input)
+    {
+        string trimmed = input.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '(' || trimmed[^1] != ')')
+            return new List<string>();
+
+        string inner = trimmed[1..^1];
+        var parts = new List<string>();
+        var current = new System.Text.StringBuilder();
+        int parenDepth = 0;
+        int braceDepth = 0;
+
+        foreach (char ch in inner)
+        {
+            if (ch == ',' && parenDepth == 0 && braceDepth == 0)
+            {
+                parts.Add(current.ToString().Trim());
+                current.Clear();
+                continue;
+            }
+
+            current.Append(ch);
+            switch (ch)
+            {
+                case '(': parenDepth++; break;
+                case ')': parenDepth--; break;
+                case '{': braceDepth++; break;
+                case '}': braceDepth--; break;
+            }
+        }
+
+        if (current.Length > 0)
+            parts.Add(current.ToString().Trim());
+
+        return parts;
+    }
+
+    private static bool LooksLikeTuple(string value) => value.TrimStart().StartsWith("(");
+}

--- a/Problems/P/P_MINSTCUT/Solvers/MinSTCutSolver.cs
+++ b/Problems/P/P_MINSTCUT/Solvers/MinSTCutSolver.cs
@@ -1,0 +1,165 @@
+using API.Interfaces;
+
+namespace API.Problems.P.P_MINSTCUT.Solvers;
+
+class MinSTCutSolver : ISolver<MINSTCUT>
+{
+    public string solverName { get; } = "Minimum S-T Cut Solver (Edmonds-Karp)";
+    public string solverDefinition { get; } = "Uses the Edmonds-Karp algorithm (BFS-based Ford-Fulkerson max-flow) to find the maximum s-t flow, then identifies the minimum cut S side via BFS on the residual graph from the source. Certificate format: {node1,node2,...} representing the S side of the minimum cut.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Michael Trosper" };
+    public bool timerHasExpired { get; set; }
+
+    public MinSTCutSolver() { }
+
+    public string solve(MINSTCUT problem)
+    {
+        if (problem.nodes.Count == 0) return "{}";
+
+        var residual = BuildResidual(problem.nodes, problem.edges);
+
+        while (true)
+        {
+            if (timerHasExpired) return "{}";
+
+            var parent = BfsAugmentingPath(residual, problem.sourceNode, problem.targetNode);
+            if (parent == null) break;
+
+            int bottleneck = FindBottleneck(residual, parent, problem.sourceNode, problem.targetNode);
+            Augment(residual, parent, problem.sourceNode, problem.targetNode, bottleneck);
+        }
+
+        HashSet<string> sSide = BfsReachable(residual, problem.sourceNode);
+        return "{" + string.Join(",", sSide) + "}";
+    }
+
+    internal static int GetMinCutCapacity(MINSTCUT problem)
+    {
+        var residual = BuildResidual(problem.nodes, problem.edges);
+
+        while (true)
+        {
+            var parent = BfsAugmentingPath(residual, problem.sourceNode, problem.targetNode);
+            if (parent == null) break;
+            int bottleneck = FindBottleneck(residual, parent, problem.sourceNode, problem.targetNode);
+            Augment(residual, parent, problem.sourceNode, problem.targetNode, bottleneck);
+        }
+
+        HashSet<string> sSide = BfsReachable(residual, problem.sourceNode);
+        return CutCapacity(problem.edges, sSide);
+    }
+
+    internal static int CutCapacity(List<(string from, string to, int weight)> edges, HashSet<string> S)
+    {
+        int total = 0;
+        foreach (var (from, to, weight) in edges)
+        {
+            if (S.Contains(from) && !S.Contains(to))
+                total += weight;
+        }
+        return total;
+    }
+
+    private static Dictionary<string, Dictionary<string, int>> BuildResidual(
+        List<string> nodes, List<(string from, string to, int weight)> edges)
+    {
+        var residual = new Dictionary<string, Dictionary<string, int>>();
+        foreach (string node in nodes)
+            residual[node] = new Dictionary<string, int>();
+
+        foreach (var (from, to, weight) in edges)
+        {
+            if (!residual[from].ContainsKey(to))
+                residual[from][to] = 0;
+            residual[from][to] += weight;
+
+            if (!residual[to].ContainsKey(from))
+                residual[to][from] = 0;
+        }
+
+        return residual;
+    }
+
+    private static Dictionary<string, string>? BfsAugmentingPath(
+        Dictionary<string, Dictionary<string, int>> residual,
+        string source, string target)
+    {
+        var parent = new Dictionary<string, string>();
+        parent[source] = source;
+        var queue = new Queue<string>();
+        queue.Enqueue(source);
+
+        while (queue.Count > 0)
+        {
+            string current = queue.Dequeue();
+            if (current == target) return parent;
+
+            foreach (var (next, cap) in residual[current])
+            {
+                if (cap > 0 && !parent.ContainsKey(next))
+                {
+                    parent[next] = current;
+                    queue.Enqueue(next);
+                }
+            }
+        }
+
+        return parent.ContainsKey(target) ? parent : null;
+    }
+
+    private static int FindBottleneck(
+        Dictionary<string, Dictionary<string, int>> residual,
+        Dictionary<string, string> parent,
+        string source, string target)
+    {
+        int bottleneck = int.MaxValue;
+        string node = target;
+        while (node != source)
+        {
+            string prev = parent[node];
+            bottleneck = Math.Min(bottleneck, residual[prev][node]);
+            node = prev;
+        }
+        return bottleneck;
+    }
+
+    private static void Augment(
+        Dictionary<string, Dictionary<string, int>> residual,
+        Dictionary<string, string> parent,
+        string source, string target, int bottleneck)
+    {
+        string node = target;
+        while (node != source)
+        {
+            string prev = parent[node];
+            residual[prev][node] -= bottleneck;
+            residual[node][prev] += bottleneck;
+            node = prev;
+        }
+    }
+
+    private static HashSet<string> BfsReachable(
+        Dictionary<string, Dictionary<string, int>> residual,
+        string source)
+    {
+        var reachable = new HashSet<string>();
+        var queue = new Queue<string>();
+        reachable.Add(source);
+        queue.Enqueue(source);
+
+        while (queue.Count > 0)
+        {
+            string current = queue.Dequeue();
+            foreach (var (next, cap) in residual[current])
+            {
+                if (cap > 0 && !reachable.Contains(next))
+                {
+                    reachable.Add(next);
+                    queue.Enqueue(next);
+                }
+            }
+        }
+
+        return reachable;
+    }
+}

--- a/Problems/P/P_MINSTCUT/Verifiers/MinSTCutVerifier.cs
+++ b/Problems/P/P_MINSTCUT/Verifiers/MinSTCutVerifier.cs
@@ -1,0 +1,49 @@
+using API.Interfaces;
+using API.Problems.P.P_MINSTCUT.Solvers;
+
+namespace API.Problems.P.P_MINSTCUT.Verifiers;
+
+class MinSTCutVerifier : IVerifier<MINSTCUT>
+{
+    public string verifierName { get; } = "Minimum S-T Cut Verifier";
+    public string verifierDefinition { get; } = "Verifies that the certificate represents a valid S side of a minimum S-T cut: source is in S, target is not in S, all nodes exist, no duplicates, and the cut capacity equals the true minimum cut capacity computed by Edmonds-Karp.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Michael Trosper" };
+
+    private string _certificate = "";
+    public string certificate => _certificate;
+
+    public MinSTCutVerifier() { }
+
+    public bool verify(MINSTCUT problem, string certificate)
+    {
+        _certificate = certificate ?? "";
+
+        if (string.IsNullOrWhiteSpace(_certificate) || _certificate.Trim() == "{}")
+            return false;
+
+        List<string> S = _certificate.Trim()
+            .TrimStart('{').TrimEnd('}')
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToList();
+
+        if (S.Count == 0) return false;
+
+        if (S.Count != S.Distinct().Count()) return false;
+
+        foreach (string node in S)
+            if (!problem.nodes.Contains(node)) return false;
+
+        HashSet<string> sSet = new(S);
+
+        if (!sSet.Contains(problem.sourceNode)) return false;
+        if (sSet.Contains(problem.targetNode)) return false;
+
+        int cutCapacity = MinSTCutSolver.CutCapacity(problem.edges, sSet);
+        int minCutCapacity = MinSTCutSolver.GetMinCutCapacity(problem);
+
+        return cutCapacity == minCutCapacity;
+    }
+}

--- a/Problems/P/P_MINSTCUT/Visualizations/MinSTCutVisualization.cs
+++ b/Problems/P/P_MINSTCUT/Visualizations/MinSTCutVisualization.cs
@@ -1,0 +1,53 @@
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_MINSTCUT.Solvers;
+
+namespace API.Problems.P.P_MINSTCUT.Visualizations;
+
+class MinSTCutVisualization : IVisualization<MINSTCUT>
+{
+    public string visualizationName { get; } = "Minimum S-T Cut Visualization";
+    public string visualizationDefinition { get; } = "Displays a weighted directed graph and highlights the minimum S-T cut: S-side nodes are colored and cut edges (directed from S to T) are colored and dashed.";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Michael Trosper" };
+    public string visualizationType { get; } = "Graph D3";
+    public ISolver solver { get; } = new MinSTCutSolver();
+
+    public MinSTCutVisualization() { }
+
+    public API_JSON visualize(MINSTCUT problem) => problem.graph.ToAPIGraph();
+
+    public API_JSON SolvedVisualization(MINSTCUT problem, string solution)
+    {
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return visualize(problem);
+
+        API_GraphJSON apiGraph = problem.graph.ToAPIGraph();
+
+        HashSet<string> sNodes = solution.Trim()
+            .TrimStart('{').TrimEnd('}')
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToHashSet();
+
+        // Color cut edges directed from S to T.
+        foreach (var link in apiGraph.links)
+        {
+            bool srcInS = sNodes.Contains(link.source);
+            bool dstInS = sNodes.Contains(link.target);
+            if (srcInS && !dstInS)
+            {
+                link.color = "Solution";
+                link.dashed = "True";
+            }
+        }
+
+        // Color S-side nodes; T-side nodes become Background.
+        foreach (var node in apiGraph.nodes)
+            node.color = sNodes.Contains(node.name) ? "Solution" : "Background";
+
+        return apiGraph;
+    }
+}

--- a/redux-tests/Problems/P_MINSTCUT/MINSTCUT_Tests.cs
+++ b/redux-tests/Problems/P_MINSTCUT/MINSTCUT_Tests.cs
@@ -1,0 +1,268 @@
+using Xunit;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_MINSTCUT;
+using API.Problems.P.P_MINSTCUT.Solvers;
+using API.Problems.P.P_MINSTCUT.Verifiers;
+using API.Problems.P.P_MINSTCUT.Visualizations;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class MINSTCUT_Tests
+{
+    // ----- Instantiation ----- //
+
+    [Fact]
+    public void MINSTCUT_Default_Instantiation()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        Assert.Equal(MINSTCUT._defaultInstance, problem.instance);
+        Assert.Equal(MINSTCUT._defaultInstance, problem.defaultInstance);
+        Assert.Equal(4, problem.nodes.Count);
+        Assert.Equal(4, problem.edges.Count);
+        Assert.Equal("1", problem.sourceNode);
+        Assert.Equal("4", problem.targetNode);
+    }
+
+    [Fact]
+    public void MINSTCUT_Custom_Instantiation()
+    {
+        string instance = "({s,a,t},{((s,a),3),((a,t),5)},s,t)";
+        MINSTCUT problem = new MINSTCUT(instance);
+        Assert.Equal(instance, problem.instance);
+        Assert.Equal(3, problem.nodes.Count);
+        Assert.Equal(2, problem.edges.Count);
+        Assert.Equal("s", problem.sourceNode);
+        Assert.Equal("t", problem.targetNode);
+    }
+
+    [Fact]
+    public void MINSTCUT_Rejects_Source_Outside_Node_Set()
+    {
+        string instance = "({1,2,3},{((1,2),5),((2,3),3)},9,3)";
+        Assert.Throws<InvalidOperationException>(() => new MINSTCUT(instance));
+    }
+
+    [Fact]
+    public void MINSTCUT_Rejects_Target_Outside_Node_Set()
+    {
+        string instance = "({1,2,3},{((1,2),5),((2,3),3)},1,9)";
+        Assert.Throws<InvalidOperationException>(() => new MINSTCUT(instance));
+    }
+
+    // ----- Solver ----- //
+
+    [Theory]
+    // default: min cut = 5 (cut edges (1,3)=2 and (2,4)=3)
+    [InlineData("({1,2,3,4},{((1,2),10),((1,3),2),((2,4),3),((3,4),5)},1,4)", 5)]
+    // 2-node: min cut = 7
+    [InlineData("({1,2},{((1,2),7)},1,2)", 7)]
+    // chain: min cut = 2 (bottleneck is (2,3)=2)
+    [InlineData("({1,2,3},{((1,2),4),((2,3),2)},1,3)", 2)]
+    public void MINSTCUT_Solver_Returns_Correct_Min_Cut_Capacity(string instance, int expectedCapacity)
+    {
+        MINSTCUT problem = new MINSTCUT(instance);
+        MinSTCutSolver solver = new MinSTCutSolver();
+        string solution = solver.solve(problem);
+        int actualCapacity = ComputeCutCapacity(problem, solution);
+        Assert.Equal(expectedCapacity, actualCapacity);
+    }
+
+    [Fact]
+    public void MINSTCUT_Solver_Default_Instance_Min_Cut_Is_5()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        string solution = new MinSTCutSolver().solve(problem);
+        Assert.Equal(5, ComputeCutCapacity(problem, solution));
+    }
+
+    [Fact]
+    public void MINSTCUT_Solver_Source_In_Result()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        string solution = new MinSTCutSolver().solve(problem);
+        HashSet<string> sNodes = ParseNodeSet(solution);
+        Assert.Contains(problem.sourceNode, sNodes);
+    }
+
+    [Fact]
+    public void MINSTCUT_Solver_Target_Not_In_Result()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        string solution = new MinSTCutSolver().solve(problem);
+        HashSet<string> sNodes = ParseNodeSet(solution);
+        Assert.DoesNotContain(problem.targetNode, sNodes);
+    }
+
+    [Fact]
+    public void MINSTCUT_Solver_Output_Passes_Verifier()
+    {
+        string[] instances = {
+            MINSTCUT._defaultInstance,
+            "({1,2},{((1,2),7)},1,2)",
+            "({1,2,3},{((1,2),4),((2,3),2)},1,3)",
+            "({s,a,b,t},{((s,a),4),((s,b),3),((a,t),3),((b,t),4)},s,t)"
+        };
+        foreach (string inst in instances)
+        {
+            MINSTCUT problem = new MINSTCUT(inst);
+            string solution = new MinSTCutSolver().solve(problem);
+            Assert.True(new MinSTCutVerifier().verify(problem, solution), $"Solver output failed verifier for: {inst}");
+        }
+    }
+
+    // ----- Verifier ----- //
+
+    [Theory]
+    // default: min cut = 5, S={1,2} → cut edges (1,3)+(2,4)=2+3=5
+    [InlineData("({1,2,3,4},{((1,2),10),((1,3),2),((2,4),3),((3,4),5)},1,4)", "{1,2}", true)]
+    // 2-node: min cut = 7, S={1}
+    [InlineData("({1,2},{((1,2),7)},1,2)", "{1}", true)]
+    // chain: min cut = 2, S={1,2}
+    [InlineData("({1,2,3},{((1,2),4),((2,3),2)},1,3)", "{1,2}", true)]
+    public void MINSTCUT_Verifier_Accepts_Valid_Minimum_Cut(string instance, string certificate, bool expected)
+    {
+        MINSTCUT problem = new MINSTCUT(instance);
+        MinSTCutVerifier verifier = new MinSTCutVerifier();
+        Assert.Equal(expected, verifier.verify(problem, certificate));
+    }
+
+    [Theory]
+    // S={1}: (1,2)+(1,3)=10+2=12, not min cut (5)
+    [InlineData("({1,2,3,4},{((1,2),10),((1,3),2),((2,4),3),((3,4),5)},1,4)", "{1}")]
+    // S={1,2,3}: (2,4)+(3,4)=3+5=8, not min cut (5)
+    [InlineData("({1,2,3,4},{((1,2),10),((1,3),2),((2,4),3),((3,4),5)},1,4)", "{1,2,3}")]
+    public void MINSTCUT_Verifier_Rejects_Non_Minimum_Cut(string instance, string certificate)
+    {
+        MINSTCUT problem = new MINSTCUT(instance);
+        MinSTCutVerifier verifier = new MinSTCutVerifier();
+        Assert.False(verifier.verify(problem, certificate));
+    }
+
+    [Fact]
+    public void MINSTCUT_Verifier_Rejects_Missing_Source()
+    {
+        // S={2} does not contain source=1
+        MINSTCUT problem = new MINSTCUT("({1,2,3},{((1,2),4),((2,3),2)},1,3)");
+        MinSTCutVerifier verifier = new MinSTCutVerifier();
+        Assert.False(verifier.verify(problem, "{2}"));
+    }
+
+    [Fact]
+    public void MINSTCUT_Verifier_Rejects_Target_In_S()
+    {
+        // S={1,3} contains target=3
+        MINSTCUT problem = new MINSTCUT("({1,2,3},{((1,2),4),((2,3),2)},1,3)");
+        MinSTCutVerifier verifier = new MinSTCutVerifier();
+        Assert.False(verifier.verify(problem, "{1,3}"));
+    }
+
+    [Fact]
+    public void MINSTCUT_Verifier_Rejects_Node_Not_In_Graph()
+    {
+        MINSTCUT problem = new MINSTCUT("({1,2,3},{((1,2),4),((2,3),2)},1,3)");
+        MinSTCutVerifier verifier = new MinSTCutVerifier();
+        Assert.False(verifier.verify(problem, "{1,99}"));
+    }
+
+    [Fact]
+    public void MINSTCUT_Verifier_Rejects_Empty_Certificate()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        MinSTCutVerifier verifier = new MinSTCutVerifier();
+        Assert.False(verifier.verify(problem, "{}"));
+    }
+
+    // ----- Visualization ----- //
+
+    [Fact]
+    public void MINSTCUT_Visualization_Returns_Graph()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        MinSTCutVisualization viz = new MinSTCutVisualization();
+        var graph = (API_GraphJSON)viz.visualize(problem);
+        Assert.Equal(4, graph.nodes.Count);
+        Assert.Equal(4, graph.links.Count);
+    }
+
+    [Fact]
+    public void MINSTCUT_SolvedVisualization_Colors_Cut_Edges()
+    {
+        // S={1,2}: cut edges are (1,3) and (2,4)
+        MINSTCUT problem = new MINSTCUT();
+        MinSTCutVisualization viz = new MinSTCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{1,2}");
+
+        var link13 = graph.links.FirstOrDefault(l => l.source == "1" && l.target == "3");
+        Assert.NotNull(link13);
+        Assert.Equal("Solution", link13!.color);
+
+        var link24 = graph.links.FirstOrDefault(l => l.source == "2" && l.target == "4");
+        Assert.NotNull(link24);
+        Assert.Equal("Solution", link24!.color);
+    }
+
+    [Fact]
+    public void MINSTCUT_SolvedVisualization_Does_Not_Color_Internal_Edges()
+    {
+        // S={1,2}: (1,2) goes from S to S, not a cut edge
+        MINSTCUT problem = new MINSTCUT();
+        MinSTCutVisualization viz = new MinSTCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{1,2}");
+
+        var link12 = graph.links.FirstOrDefault(l => l.source == "1" && l.target == "2");
+        Assert.NotNull(link12);
+        Assert.NotEqual("Solution", link12!.color);
+    }
+
+    [Fact]
+    public void MINSTCUT_SolvedVisualization_Colors_S_Nodes()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        MinSTCutVisualization viz = new MinSTCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{1,2}");
+
+        Assert.Equal("Solution", graph.nodes.First(n => n.name == "1").color);
+        Assert.Equal("Solution", graph.nodes.First(n => n.name == "2").color);
+    }
+
+    [Fact]
+    public void MINSTCUT_SolvedVisualization_Colors_T_Nodes_As_Background()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        MinSTCutVisualization viz = new MinSTCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{1,2}");
+
+        Assert.Equal("Background", graph.nodes.First(n => n.name == "3").color);
+        Assert.Equal("Background", graph.nodes.First(n => n.name == "4").color);
+    }
+
+    [Fact]
+    public void MINSTCUT_SolvedVisualization_Empty_Solution_Returns_Plain_Graph()
+    {
+        MINSTCUT problem = new MINSTCUT();
+        MinSTCutVisualization viz = new MinSTCutVisualization();
+        var graph = (API_GraphJSON)viz.SolvedVisualization(problem, "{}");
+        Assert.All(graph.nodes, n => Assert.NotEqual("Solution", n.color));
+        Assert.All(graph.links, l => Assert.NotEqual("Solution", l.color));
+    }
+
+    // ----- Helpers ----- //
+
+    private static int ComputeCutCapacity(MINSTCUT problem, string certificate)
+    {
+        if (string.IsNullOrWhiteSpace(certificate) || certificate.Trim() == "{}") return 0;
+        HashSet<string> sNodes = ParseNodeSet(certificate);
+        return MinSTCutSolver.CutCapacity(problem.edges, sNodes);
+    }
+
+    private static HashSet<string> ParseNodeSet(string certificate)
+    {
+        return certificate.Trim()
+            .TrimStart('{').TrimEnd('}')
+            .Split(',')
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToHashSet();
+    }
+}


### PR DESCRIPTION
Implements the Minimum S-T Cut problem using the Edmonds-Karp algorithm (BFS-based Ford-Fulkerson max-flow). By the Max-Flow Min-Cut theorem the minimum cut capacity equals the maximum s-t flow, making this a polynomial- time problem placed in Problems/P/P_MINSTCUT/.

- MINSTCUT_Class: directed weighted graph with explicit source/target; instance format ({nodes},{((u,v),w),...},source,target)
- MinSTCutSolver: Edmonds-Karp to find max flow then BFS on residual graph to extract the S side; certificate {node1,node2,...}
- MinSTCutVerifier: checks source in S, target not in S, all nodes valid, and cut capacity equals true minimum via GetMinCutCapacity helper
- MinSTCutVisualization: colors S-side nodes and cut edges (S to T) as Solution/dashed; T-side nodes as Background
- 26 unit tests covering instantiation, solver, verifier, and visualization