### PR TITLE
test(mincut): use Assert.Single for edge count (xUnit2013)

### DIFF
--- a/redux-tests/Problems/P_MINCUT/MINCUT_Tests.cs
+++ b/redux-tests/Problems/P_MINCUT/MINCUT_Tests.cs
@@ -36,7 +36,7 @@ public class MINCUT_Tests
         string instance = "({1,2},{({1,2},7)})";
         MINCUT problem = new MINCUT(instance);
         Assert.Equal(2, problem.nodes.Count);
-        Assert.Equal(1, problem.edges.Count);
+        Assert.Single(problem.edges);
     }
 
     // ----- Solver ----- //


### PR DESCRIPTION
## Problem

`MINCUT_Two_Node_Graph` asserts the edge count with:

```csharp
Assert.Equal(1, problem.edges.Count);
```

The xUnit2013 analyzer flags this ("Do not use Assert.Equal() to check for collection size. Use Assert.Single instead."), and under the repo's warnings-as-errors (`Directory.Build.props`) it becomes a **build error** — so a clean `CSharpAPI` checkout fails to build the test project on its own.

## Fix

```csharp
Assert.Single(problem.edges);
```

One-line change, extracted from #327 (which bundles it with unrelated endpoint removals). Isolated here so the baseline build break can be fixed independently.

## Verification

- `dotnet build Redux.slnx` → 0 warnings, 0 errors
- `dotnet test Redux.slnx` → 673 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)