### PR TITLE
refactor(nav): resolve solver navigation via reflection; remove All_Solvers

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Solvers.cs
+++ b/AdditionalControllers/Navigation/Nav_Solvers.cs
@@ -21,15 +21,6 @@ internal static class SolverNavigationData
             .ToList();
     }
 
-    // Every distinct solver class name, for the "all solvers" view.
-    internal static List<string> AllClassNames()
-    {
-        return Entries
-            .Select(e => e.className)
-            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
     private static List<SolverEntry> Build()
     {
         var entries = new List<SolverEntry>();
@@ -71,25 +62,6 @@ internal static class SolverNavigationData
             .ToList();
     }
 }
-
-// Get all Solvers regardless of complexity class
-[ApiController]
-[Route("Navigation/[controller]")]
-[Tags("- Navigation (Solvers)")]
-#pragma warning disable CS1591
-
-public class All_SolversController : ControllerBase {
-//Note: CALEB - should probably be removed with api refactor
-
-    [ApiExplorerSettings(IgnoreApi = true)]
-    [HttpGet]
-    public String getDefault() {
-        var options = new JsonSerializerOptions { WriteIndented = true };
-        return JsonSerializer.Serialize(SolverNavigationData.AllClassNames(), options);
-    }
-}
-#pragma warning restore CS1591
-
 
 // Get all Solvers for a specific problem (Refactored)
 [ApiController]

--- a/AdditionalControllers/Navigation/Nav_Solvers.cs
+++ b/AdditionalControllers/Navigation/Nav_Solvers.cs
@@ -1,7 +1,76 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Collections;
+using API.Interfaces;
+
+internal static class SolverNavigationData
+{
+    internal class SolverEntry
+    {
+        public string className { get; set; } = "";
+        public string problemName { get; set; } = "";
+    }
+
+    // Build once from reflected solver types so navigation doesn't depend on
+    // on-disk source layout. Mirrors VerifierNavigationData (see Nav_Verifiers.cs).
+    internal static readonly List<SolverEntry> Entries = Build();
+
+    internal static List<string> FindWithoutExtension(string? problemName, string? problemTypePrefix)
+    {
+        return Find(problemName, problemTypePrefix)
+            .Select(x => x.className)
+            .ToList();
+    }
+
+    // Every distinct solver class name, for the "all solvers" view.
+    internal static List<string> AllClassNames()
+    {
+        return Entries
+            .Select(e => e.className)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static List<SolverEntry> Build()
+    {
+        var entries = new List<SolverEntry>();
+        foreach (var (_, solverType) in ProblemProvider.Solvers)
+        {
+            var generic = solverType.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ISolver<>));
+            if (generic == null) continue;
+
+            Type problemType = generic.GetGenericArguments()[0];
+            entries.Add(new SolverEntry
+            {
+                className = solverType.Name,
+                problemName = problemType.Name,
+            });
+        }
+
+        return entries
+            .GroupBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
+    }
+
+    // problemTypePrefix is accepted for API compatibility but intentionally ignored:
+    // problem names are unique across complexity classes, so the name alone identifies
+    // the solver set. Mirrors the verifier navigation (#317/#318): the GUI pins
+    // problemType to "NPC", so matching on the prefix would drop P / NP-Hard solvers.
+    private static List<SolverEntry> Find(string? problemName, string? problemTypePrefix)
+    {
+        IEnumerable<SolverEntry> query = Entries;
+
+        if (!string.IsNullOrWhiteSpace(problemName))
+        {
+            query = query.Where(e => string.Equals(e.problemName, problemName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query
+            .OrderBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}
 
 // Get all Solvers regardless of complexity class
 [ApiController]
@@ -15,15 +84,8 @@ public class All_SolversController : ControllerBase {
     [ApiExplorerSettings(IgnoreApi = true)]
     [HttpGet]
     public String getDefault() {
-        string projectSourcePath = ProjectSourcePath.Value;
-        string?[] subdirs = Directory.GetDirectories(projectSourcePath+ @"/Solvers")
-                            .Select(Path.GetFileName)
-                            .ToArray();
-
-        // Not completed. Needs to loop through these directories to get the rest of the problems
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirs, options);
-        return jsonString;
+        return JsonSerializer.Serialize(SolverNavigationData.AllClassNames(), options);
     }
 }
 #pragma warning restore CS1591
@@ -38,83 +100,21 @@ public class All_SolversController : ControllerBase {
 public class Problem_SolversRefactorController : ControllerBase {
 #pragma warning restore CS1591
 
-            string NOT_FOUND_ERR_SOLVER = "entered a solver that does not exist";
+    string NOT_FOUND_ERR_SOLVER = "entered a solver that does not exist";
 
 ///<summary>Returns all solvers available for a given problem </summary>
 ///<param name="chosenProblem" example="SAT3">Problem name</param>
-///<param name="problemType" example="NPC">Problem type</param>
+///<param name="problemType" example="NPC">Problem type (optional; ignored — problem names are unique across complexity classes)</param>
 ///<response code="200">Returns string array of solvers</response>
 
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
-    public String getDefault([FromQuery]string chosenProblem, [FromQuery]string problemType) {
-
-        // Determine the directory to search based on prefix. chosenProblem expected to be a problemName like "NPC_PROBLEM"\
-        string problemTypeDirectory = "";
+    public String getDefault([FromQuery]string chosenProblem, [FromQuery]string? problemType = null) {
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = "";
 
-        if (problemType == "NPC") {
-            problemTypeDirectory = "NPComplete";
-        }
-        else if (problemType == "P") {
-            problemTypeDirectory = "Polynomial";
-        }
-
-
-        try
-        {
-            string projectSourcePath = ProjectSourcePath.Value;
-            string?[] subfiles = Directory.GetFiles(projectSourcePath+ @"Problems/" + problemTypeDirectory + "/" + problemType + "_" + chosenProblem + "/Solvers")
-                                .Select(Path.GetFileName)
-                                .ToArray();
-
-            ArrayList subFilesList = new ArrayList();
-
-            foreach (var file in subfiles)
-            {
-                if (file is null)
-                    continue;
-                string fileNoExt = file.Split('.')[0]; //gets the file without the file extension
-                subFilesList.Add(fileNoExt);
-            }
-
-             jsonString = JsonSerializer.Serialize(subFilesList, options);
-
-
-        }
-        catch(System.IO.DirectoryNotFoundException){
-            // Fallback: search every class directory under Problems/ for any folder
-            // whose name ends with _{chosenProblem}, regardless of prefix.
-            var fallback = FindSolversAcrossAllDirs(ProjectSourcePath.Value, chosenProblem);
-            jsonString = fallback.Count > 0
-                ? JsonSerializer.Serialize(fallback, options)
-                : JsonSerializer.Serialize(NOT_FOUND_ERR_SOLVER, options);
-        }
-        
-        // Not completed. Needs to loop through these directories to get the rest of the problems
-        return jsonString;
-    }
-
-    private static List<string> FindSolversAcrossAllDirs(string root, string chosenProblem) {
-        var result = new List<string>();
-        var problemsRoot = Path.Combine(root, "Problems");
-        if (!Directory.Exists(problemsRoot)) return result;
-        foreach (var classDir in Directory.GetDirectories(problemsRoot)) {
-            foreach (var problemDir in Directory.GetDirectories(classDir)) {
-                var dirName = Path.GetFileName(problemDir) ?? "";
-                var idx = dirName.IndexOf('_');
-                if (idx >= 0 && dirName[(idx + 1)..] == chosenProblem) {
-                    var solversPath = Path.Combine(problemDir, "Solvers");
-                    if (!Directory.Exists(solversPath)) continue;
-                    foreach (var file in Directory.GetFiles(solversPath)) {
-                        var name = Path.GetFileNameWithoutExtension(file);
-                        if (name != null) result.Add(name);
-                    }
-                    return result;
-                }
-            }
-        }
-        return result;
+        List<string> subFilesList = SolverNavigationData.FindWithoutExtension(chosenProblem, problemType);
+        return subFilesList.Count > 0
+            ? JsonSerializer.Serialize(subFilesList, options)
+            : JsonSerializer.Serialize(NOT_FOUND_ERR_SOLVER, options);
     }
 }

--- a/Problems/NPComplete/NPC_SAT/Solvers/SATGroverSolver.cs
+++ b/Problems/NPComplete/NPC_SAT/Solvers/SATGroverSolver.cs
@@ -10,7 +10,7 @@ namespace API.Problems.NPComplete.NPC_SAT.Solvers;
 /// solution to the instance.
 /// </summary>
 /// 
-class SATGroverSolver : ISolver
+class SATGroverSolver : ISolver<SAT>
 {
     // --- Fields ---
     public string solverName { get; } = "SAT Solver using Grover's Quantum computing algorithm.";
@@ -38,37 +38,6 @@ class SATGroverSolver : ISolver
     }
 
     // --- Methods ---
-
-    public string solve(string problemInstance)
-    {
-        try
-        {
-            var requestBody = new JSON_Sat_Problem(problemInstance);
-
-            // Create the API client
-            var client = new QuantumServerAPI();
-
-            // Make the API call to the quantum endpoint
-            string response = client.PostAsync("/sat-quantum", requestBody).Result;
-
-            // Parse the JSON response and extract just the answer
-            using JsonDocument doc = JsonDocument.Parse(response);
-            JsonElement root = doc.RootElement;
-
-            if (root.TryGetProperty("answer", out JsonElement answerElement))
-            {
-                return answerElement.GetString() ?? "No answer found";
-            }
-
-            // If no answer field, return the whole response
-            return response;
-        }
-        catch (Exception ex)
-        {
-            // Return error information in case of failure
-            return $"{{\"error\": \"{ex.Message}\"}}";
-        }
-    }
 
     public string solve(SAT problem)
     {

--- a/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
@@ -107,6 +107,85 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
         Assert.NotEmpty(arr);
     }
 
+    // ── Problem_SolversRefactor: reflection-based, lookup ignores problemType ──
+    // Mirrors the verifier navigation: the GUI pins problemType to "NPC", so the
+    // solver lookup must find solvers by problem name regardless of the prefix sent.
+
+    [Fact]
+    public async Task ProblemSolversRefactor_NpcProblem_FindsSolver()
+    {
+        var response = await _client.GetAsync("/Navigation/Problem_SolversRefactor?chosenProblem=SAT3&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.NotEmpty(arr);
+    }
+
+    [Fact]
+    public async Task ProblemSolversRefactor_SAT_ListsGroverSolver()
+    {
+        // SATGroverSolver declares ISolver<SAT>, so it resolves to SAT like any
+        // other solver — guards against it regressing out of the listing.
+        var response = await _client.GetAsync("/Navigation/Problem_SolversRefactor?chosenProblem=SAT&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("SATGroverSolver", arr);
+    }
+
+    [Fact]
+    public async Task ProblemSolversRefactor_PProblem_WithWrongNpcProblemType_FindsSolver()
+    {
+        // CLIQUE solver lookup must succeed even when the GUI sends a mismatched prefix.
+        var response = await _client.GetAsync("/Navigation/Problem_SolversRefactor?chosenProblem=Clique&problemType=P", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("CliqueBruteForce", arr);
+    }
+
+    [Fact]
+    public async Task ProblemSolversRefactor_OmittedProblemType_FindsSolver()
+    {
+        // problemType is optional; omitting it entirely must still resolve by name.
+        var response = await _client.GetAsync("/Navigation/Problem_SolversRefactor?chosenProblem=SAT3", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.NotEmpty(arr);
+    }
+
+    [Fact]
+    public async Task ProblemSolversRefactor_UnknownProblem_ReturnsNotFoundString()
+    {
+        var response = await _client.GetAsync("/Navigation/Problem_SolversRefactor?chosenProblem=NoSuchProblem&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var message = JsonSerializer.Deserialize<string>(body);
+        Assert.Equal("entered a solver that does not exist", message);
+    }
+
+    [Fact]
+    public async Task ProblemSolversRefactor_CaseInsensitiveInputs_ReturnsNonEmptyJsonArray()
+    {
+        var response = await _client.GetAsync("/Navigation/Problem_SolversRefactor?chosenProblem=sat3&problemType=npc", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<JsonElement[]>(body);
+        Assert.NotNull(arr);
+        Assert.NotEmpty(arr);
+    }
+
     // ── Reductions ────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Replaces the filesystem-traversal solver-navigation lookups with reflection over `ISolver<T>` types, mirroring the existing verifier navigation (`VerifierNavigationData`). Solver listings no longer depend on the on-disk `Problems/.../Solvers` layout.

A new `SolverNavigationData` builds `(className, problemName)` entries once from `ProblemProvider.Solvers`, reading each solver's problem off its `ISolver<T>` generic argument.

## Changes

- **`Problem_SolversRefactor`** now serves from reflected types instead of scanning the filesystem. Lookup matches on **problem name** and ignores the `problemType` prefix, which is now **optional**. This is consistent with the verifier fix for #317/#318, where the GUI pins `problemType` to `"NPC"` regardless of the actual complexity class.
- **`All_Solvers` is removed.** It returned a flat list of solver class names with no problem association — a solver is only meaningful relative to its problem, which `Problem_SolversRefactor` already answers. It was hidden from Swagger (`IgnoreApi = true`), had no callers, and was broken at runtime (it scanned a non-existent top-level `/Solvers` directory). The now-orphaned `AllClassNames` helper is dropped with it.
- **`SATGroverSolver`** now declares `ISolver<SAT>` instead of the non-generic `ISolver`, so it resolves like every other solver with no special-casing. Its hand-rolled `solve(string)` is dropped in favor of the generic interface default.

### Behavior notes (improvements vs. the old filesystem version)

- `DijkstraPriorityQueue` lived in a `Solvers/` folder but isn't an `ISolver`; the old endpoint wrongly listed it as a SHORTESTPATH solver. Reflection correctly excludes it.
- The SAT Grover `/solve` path now constructs `SAT(instance)`, which validates input — malformed SAT returns `400` (already handled by the endpoint) instead of being forwarded raw to the quantum API. The posted body and returned answer are otherwise unchanged because `SAT(string)` round-trips `instance`.

## Out of scope

The legacy `Problem_Solvers` (filesystem) endpoint is intentionally left untouched — its removal belongs to the #316/#327 nav-endpoint cleanup.

## Tests

Adds endpoint tests covering name-based lookup, the optional/ignored `problemType` prefix, `SATGroverSolver` generic resolution, case-insensitivity, and the unknown-problem path.

- `dotnet build redux-tests/redux-tests.csproj` → 0 warnings, 0 errors
- `dotnet test redux-tests/redux-tests.csproj` → 673 passed, 0 failed, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
