### PR TITLE
fix(nav): make problemType optional on Problem_VerifiersRefactor (#330)

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Verifiers.cs
+++ b/AdditionalControllers/Navigation/Nav_Verifiers.cs
@@ -93,12 +93,12 @@ public class Problem_VerifiersRefactorController : ControllerBase {
     
 ///<summary>Returns all verifiers available for a given problem </summary>
 ///<param name="chosenProblem" example="SAT3">Problem name</param>
-///<param name="problemType" example="NPC">Problem type</param>
+///<param name="problemType" example="NPC">Problem type (optional; ignored — problem names are unique across complexity classes)</param>
 ///<response code="200">Returns string array of verifiers</response>
 
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
-    public String getDefault([FromQuery]string chosenProblem,[FromQuery]string problemType) {
+    public String getDefault([FromQuery]string chosenProblem,[FromQuery]string? problemType = null) {
         string NOT_FOUND_ERR_VERIFIER = "entered a verifier that does not exist";
         string jsonString = "";
         var options = new JsonSerializerOptions { WriteIndented = true };

--- a/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
@@ -96,6 +96,19 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
     }
 
     [Fact]
+    public async Task ProblemVerifiersRefactor_OmittedProblemType_FindsVerifier()
+    {
+        // problemType is optional (#330); omitting it entirely must still resolve by name.
+        var response = await _client.GetAsync("/Navigation/Problem_VerifiersRefactor?chosenProblem=DFA", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("DFAVerifier", arr);
+    }
+
+    [Fact]
     public async Task ProblemVerifiersRefactor_CaseInsensitiveInputs_ReturnsNonEmptyJsonArray()
     {
         var response = await _client.GetAsync("/Navigation/Problem_VerifiersRefactor?chosenProblem=sat3&problemType=npc", TestContext.Current.CancellationToken);


### PR DESCRIPTION
Closes #330.

## Problem

`GET /Navigation/Problem_VerifiersRefactor` requires the `problemType` query parameter but never uses it — lookup resolves by problem name alone (problem names are unique across complexity classes). The frontend hardcodes `problemType=NPC`.

## Fix

Make `problemType` optional:

```csharp
public String getDefault([FromQuery]string chosenProblem, [FromQuery]string? problemType = null)
```

Callers can now omit it entirely. This is the verifier analog of the same change already made for `Problem_SolversRefactor`.

## Tests

Adds `ProblemVerifiersRefactor_OmittedProblemType_FindsVerifier`, covering the omitted-prefix path.

- `dotnet build Redux.slnx` → 0 warnings, 0 errors
- `dotnet test Redux.slnx` → 668 passed, 0 failed

## Notes

- The issue's frontend follow-up ("remove its use from the frontend") lives in the `Redux_GUI` repo and is out of scope here.
- Verified conflict-free against the open solver-nav PR (#329) via `git merge-tree` — disjoint backend files, and the shared test file's additions land in separated regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)