### PR TITLE
refactor(nav): resolve visualization navigation via reflection (#331)

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Visualizations.cs
+++ b/AdditionalControllers/Navigation/Nav_Visualizations.cs
@@ -1,7 +1,67 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Collections;
+using API.Interfaces;
+
+internal static class VisualizationNavigationData
+{
+    internal class VisualizationEntry
+    {
+        public string className { get; set; } = "";
+        public string problemName { get; set; } = "";
+    }
+
+    // Build once from reflected visualization types so navigation doesn't depend on
+    // on-disk source layout. Mirrors VerifierNavigationData (see Nav_Verifiers.cs).
+    internal static readonly List<VisualizationEntry> Entries = Build();
+
+    internal static List<string> FindWithoutExtension(string? problemName, string? problemTypePrefix)
+    {
+        return Find(problemName, problemTypePrefix)
+            .Select(x => x.className)
+            .ToList();
+    }
+
+    private static List<VisualizationEntry> Build()
+    {
+        var entries = new List<VisualizationEntry>();
+        foreach (var (_, visType) in ProblemProvider.Visualizers)
+        {
+            var generic = visType.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IVisualization<>));
+            if (generic == null) continue;
+
+            Type problemType = generic.GetGenericArguments()[0];
+            entries.Add(new VisualizationEntry
+            {
+                className = visType.Name,
+                problemName = problemType.Name,
+            });
+        }
+
+        return entries
+            .GroupBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
+    }
+
+    // problemTypePrefix is accepted for API compatibility but intentionally ignored:
+    // problem names are unique across complexity classes, so the name alone identifies
+    // the visualization set. Mirrors the verifier navigation (#317/#318): the GUI pins
+    // problemType to "NPC", so matching on the prefix would drop P / NP-Hard problems.
+    private static List<VisualizationEntry> Find(string? problemName, string? problemTypePrefix)
+    {
+        IEnumerable<VisualizationEntry> query = Entries;
+
+        if (!string.IsNullOrWhiteSpace(problemName))
+        {
+            query = query.Where(e => string.Equals(e.problemName, problemName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query
+            .OrderBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}
 
 // Get all Visualizations for a specific problem\
 [ApiController]
@@ -11,60 +71,20 @@ using System.Collections;
 
 public class Problem_VisualizationsRefactorController : ControllerBase {
 #pragma warning restore CS1591
-    
+
 ///<summary>Returns all Visualizations available for a given problem </summary>
 ///<param name="chosenProblem" example="SAT3">Problem name</param>
-///<param name="problemType" example="NPC">Problem type</param>
+///<param name="problemType" example="NPC">Problem type (optional; ignored — problem names are unique across complexity classes)</param>
 ///<response code="200">Returns string array of Visualizations</response>
 
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
-    public String getDefault([FromQuery]string chosenProblem,[FromQuery]string problemType) {
-        List<string> NOT_FOUND_ERR_Visualization = new();
+    public String getDefault([FromQuery]string chosenProblem, [FromQuery]string? problemType = null) {
         var options = new JsonSerializerOptions { WriteIndented = true };
 
-        try
-        {
-            string projectSourcePath = ProjectSourcePath.Value;
-            string problemsRoot = Path.Combine(projectSourcePath, "Problems");
-
-            // Search all complexity-class subdirectories for any folder ending with _<chosenProblem>
-            // so that NPH, NPC, P, and any future types are all found regardless of the
-            // problemType query parameter (which the Redux_GUI client hardcodes to "NPC").
-            string[]? visFiles = null;
-            foreach (string typeDir in Directory.GetDirectories(problemsRoot))
-            {
-                foreach (string probDir in Directory.GetDirectories(typeDir))
-                {
-                    string folderName = Path.GetFileName(probDir);
-                    if (!folderName.EndsWith("_" + chosenProblem, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    string visPath = Path.Combine(probDir, "Visualizations");
-                    if (!Directory.Exists(visPath))
-                        continue;
-
-                    visFiles = Directory.GetFiles(visPath)
-                                       .Select(Path.GetFileName)
-                                       .Where(f => f is not null)
-                                       .ToArray()!;
-                    break;
-                }
-                if (visFiles is not null) break;
-            }
-
-            if (visFiles is null)
-                return JsonSerializer.Serialize(NOT_FOUND_ERR_Visualization, options);
-
-            var subFilesList = new ArrayList();
-            foreach (var file in visFiles)
-                subFilesList.Add(file!.Split('.')[0]); // strip .cs extension
-
-            return JsonSerializer.Serialize(subFilesList, options);
-        }
-        catch (System.IO.DirectoryNotFoundException)
-        {
-            return JsonSerializer.Serialize(NOT_FOUND_ERR_Visualization, options);
-        }
+        // Returns an empty array when the problem has no visualizations (preserved
+        // not-found contract; this endpoint never returned an error string).
+        List<string> subFilesList = VisualizationNavigationData.FindWithoutExtension(chosenProblem, problemType);
+        return JsonSerializer.Serialize(subFilesList, options);
     }
 }

--- a/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/Navigation_Endpoint_Tests.cs
@@ -126,4 +126,58 @@ public class Navigation_Endpoint_Tests : IClassFixture<AppFactory>
         Assert.NotNull(graph);
         Assert.NotEmpty(graph);
     }
+
+    // ── Problem_VisualizationsRefactor: reflection-based, ignores problemType (#331) ──
+    // Lookup resolves by problem name; the GUI pins problemType to "NPC", so matching
+    // on the prefix would drop P / NP-Hard problems.
+
+    [Fact]
+    public async Task ProblemVisualizationsRefactor_NpcProblem_FindsVisualization()
+    {
+        var response = await _client.GetAsync("/Navigation/Problem_VisualizationsRefactor?chosenProblem=SAT3&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("Sat3DefaultVisualization", arr);
+    }
+
+    [Fact]
+    public async Task ProblemVisualizationsRefactor_PProblem_WithWrongNpcProblemType_FindsVisualization()
+    {
+        // DFA lives under Problems/P, but mirror the GUI sending problemType=NPC.
+        var response = await _client.GetAsync("/Navigation/Problem_VisualizationsRefactor?chosenProblem=DFA&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("DFAVisualization", arr);
+    }
+
+    [Fact]
+    public async Task ProblemVisualizationsRefactor_OmittedProblemType_FindsVisualization()
+    {
+        // problemType is optional (#331); omitting it entirely must still resolve by name.
+        var response = await _client.GetAsync("/Navigation/Problem_VisualizationsRefactor?chosenProblem=SAT3", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        Assert.Contains("Sat3DefaultVisualization", arr);
+    }
+
+    [Fact]
+    public async Task ProblemVisualizationsRefactor_UnknownProblem_ReturnsEmptyJsonArray()
+    {
+        var response = await _client.GetAsync("/Navigation/Problem_VisualizationsRefactor?chosenProblem=NoSuchProblem&problemType=NPC", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<JsonElement[]>(body);
+        Assert.NotNull(arr);
+        Assert.Empty(arr);
+    }
 }


### PR DESCRIPTION
Closes #331.

## Summary

`GET /Navigation/Problem_VisualizationsRefactor` computed its list by walking `Problems/.../Visualizations` on disk. This replaces that with reflection over `IVisualization<T>` types — the direct analog of the solver (#329) and verifier (#330) navigation refactors.

A new `VisualizationNavigationData` builds `(className, problemName)` entries once from `ProblemProvider.Visualizers`, reading each visualization's problem off its `IVisualization<T>` generic argument.

## Changes

- **Reflection lookup** instead of filesystem traversal in `Problem_VisualizationsRefactor`.
- **`problemType` is now optional** (`[FromQuery]string? = null`). It was required but unused — the GUI hardcodes `"NPC"`; lookup resolves by problem name alone (names are unique across complexity classes).
- The empty-array not-found contract is preserved (this endpoint never returned an error string).

All 44 visualizations implement the generic `IVisualization<T>`, so there's no non-generic edge case.

## Tests

Adds endpoint tests covering name-based lookup, a wrong-prefix P problem (`DFA`), the omitted `problemType`, and the unknown-problem (empty array) path.

- `dotnet build Redux.slnx` → 0 warnings, 0 errors
- `dotnet test Redux.slnx` → 671 passed, 0 failed

## Notes

- The issue's frontend follow-up (stop sending `problemType`) lives in the `Redux_GUI` repo and is out of scope here.
- Verified conflict-free against the open nav PRs **#329** (solvers) and **#333** (verifiers) — both pairwise (`git merge-tree`) and via a full three-way integration merge that builds clean and passes 678 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)