### PR TITLE
docs(swagger): real example for /Navigation/Reductions

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Reductions.cs
+++ b/AdditionalControllers/Navigation/Nav_Reductions.cs
@@ -24,12 +24,16 @@ using API.Interfaces;
 public class ReductionEdge
 {
     /// <summary>The name of the class implementing the reduction.</summary>
+    /// <example>KarpVertexCoverToSetCover</example>
     public string className { get; set; } = "";
     /// <summary>The HTTP method and relative path that performs the reduction.</summary>
+    /// <example>POST /ProblemProvider/reduce?reduction=KarpVertexCoverToSetCover</example>
     public string endpoint { get; set; } = "";
     /// <summary>The input problem type for this reduction.</summary>
+    /// <example>VERTEXCOVER</example>
     public string inputType { get; set; } = "";
     /// <summary>The output problem type this reduction produces.</summary>
+    /// <example>SETCOVER</example>
     public string outputType { get; set; } = "";
 }
 

--- a/AdditionalControllers/Navigation/ReductionsResponseExampleFilter.cs
+++ b/AdditionalControllers/Navigation/ReductionsResponseExampleFilter.cs
@@ -1,0 +1,50 @@
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Text.Json.Nodes;
+
+/// <summary>
+/// Supplies a concrete example for the Reductions endpoint's 200 response so Swagger
+/// renders real problem-name keys (e.g. "VERTEXCOVER" → "SETCOVER") instead of the
+/// generic "additionalProp1" placeholders it auto-generates for Dictionary&lt;string, …&gt;.
+/// </summary>
+internal sealed class ReductionsResponseExampleFilter : IOperationFilter
+{
+    private const string ExampleJson = """
+    {
+      "VERTEXCOVER": {
+        "SETCOVER": [
+          {
+            "className": "KarpVertexCoverToSetCover",
+            "endpoint": "POST /ProblemProvider/reduce?reduction=KarpVertexCoverToSetCover",
+            "inputType": "VERTEXCOVER",
+            "outputType": "SETCOVER"
+          }
+        ],
+        "NODESET": [
+          {
+            "className": "KarpVertexCoverToNodeSet",
+            "endpoint": "POST /ProblemProvider/reduce?reduction=KarpVertexCoverToNodeSet",
+            "inputType": "VERTEXCOVER",
+            "outputType": "NODESET"
+          }
+        ]
+      }
+    }
+    """;
+
+    /// <inheritdoc/>
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (context.MethodInfo?.DeclaringType != typeof(ReductionsController))
+            return;
+        if (operation.Responses is null || !operation.Responses.TryGetValue("200", out var response))
+            return;
+        if (response is not OpenApiResponse concrete || concrete.Content is null)
+            return;
+
+        // Set on every media type Swashbuckle emits (the action returns string, so the
+        // response can carry application/json, text/json and text/plain).
+        foreach (var media in concrete.Content.Values)
+            media.Example = JsonNode.Parse(ExampleJson);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -41,6 +41,9 @@ builder.Services.AddSwaggerGen(options =>
 
     var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+
+    // Real-key example for /Navigation/Reductions (replaces additionalProp1 placeholders).
+    options.OperationFilter<ReductionsResponseExampleFilter>();
 });
 var app = builder.Build();
 


### PR DESCRIPTION
## Problem

`/Navigation/Reductions` returns `Dictionary<string, Dictionary<string, List<ReductionEdge>>>`. With no example supplied, Swagger renders it with `additionalProp1` key placeholders and `"string"` leaf values, which is hard to read:

```json
{ "additionalProp1": { "additionalProp1": [ { "className": "string", "endpoint": "string", "inputType": "string", "outputType": "string" } ] } }
```

## Fix

Two complementary, dependency-free improvements:

- **Schema panel** — added `<example>` tags to the `ReductionEdge` properties, so the leaves show real values instead of `"string"`.
- **Example Value panel** — added `ReductionsResponseExampleFilter` (`IOperationFilter`) that attaches a concrete example to the 200 response, replacing the `additionalProp1` skeleton with real problem-name keys:

```json
{
  "VERTEXCOVER": {
    "SETCOVER": [
      { "className": "KarpVertexCoverToSetCover", "endpoint": "POST /ProblemProvider/reduce?reduction=KarpVertexCoverToSetCover", "inputType": "VERTEXCOVER", "outputType": "SETCOVER" }
    ],
    "NODESET": [
      { "className": "KarpVertexCoverToNodeSet", "endpoint": "POST /ProblemProvider/reduce?reduction=KarpVertexCoverToNodeSet", "inputType": "VERTEXCOVER", "outputType": "NODESET" }
    ]
  }
}
```

The example uses real reduction classes/types (`VERTEXCOVER → SETCOVER` and `VERTEXCOVER → NODESET`) — it shows one source with two distinct targets. Every `from → to` pair in the actual graph currently holds exactly one reduction, so the example deliberately doesn't depict a multi-reduction inner list that doesn't exist.

## Notes

- No runtime behavior change — Swagger documentation only.
- The Schema panel still shows the `additionalProp1` structure; that's inherent to how Swagger models a `Dictionary<string, …>` with runtime keys, and is not overridable without misrepresenting the type. The filter governs the Example Value panel.
- Verified live against a running instance: the 200 example now renders the real-key payload above.

- `dotnet build Redux.slnx` → 0 warnings, 0 errors
- `dotnet test Redux.slnx` → 667 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)