### PR TITLE
docs(swagger): example values for Verify and MapSolution parameters

### DIFF
--- a/Tools/ApiParameters.cs
+++ b/Tools/ApiParameters.cs
@@ -4,8 +4,10 @@ namespace API.Tools.ApiParameters;
 /// <summary>API parameters for the verify routes.</summary>
 public class Verify {
     /// <summary>The certificate solution to the problem.</summary>
+    /// <example>{1,2,3}</example>
     public string Certificate { get; set; } = "";
     /// <summary>The problem instance.</summary>
+    /// <example>(({1,2,3},{{1,2},{2,3},{1,3}}),3)</example>
     public string ProblemInstance { get; set; } = "";
 }
 

--- a/Tools/ApiParameters.cs
+++ b/Tools/ApiParameters.cs
@@ -13,10 +13,13 @@ public class Verify {
 
 /// <summary>API parameters for the map solution routes.</summary>
 public class MapSolution {
-    /// <summary>The problem instance.</summary>
+    /// <summary>The problem to reduce from.</summary>
+    /// <example>INDEPENDENTSET</example>
     public string ProblemFrom { get; set; } = "";
-    /// <summary>The reduced problem instance.</summary>
+    /// <summary>The problem to reduce to.</summary>
+    /// <example>CLIQUE</example>
     public string ProblemTo { get; set; } = "";
     /// <summary>The solution to the problem.</summary>
+    /// <example>{1,2,3}</example>
     public string ProblemFromSolution { get; set; } = "";
 }


### PR DESCRIPTION
## Summary
Adds `<example>` tags to the parameter classes in `Tools/ApiParameters.cs` so Swagger renders concrete sample values for the relevant routes.

### `Verify` (used as the `[FromBody]` model on the `verify` route)
The examples are CLIQUE-shaped to stay coherent with the verify action's `cliqueverifier` example, and they match CLIQUE's declared `instanceFormat`/`certificateFormat` (`Problems/NPComplete/NPC_CLIQUE/CLIQUE_Class.cs`):

- `Certificate` → `{1,2,3}` (brace-wrapped node list, a valid 3-clique)
- `ProblemInstance` → `(({1,2,3},{{1,2},{2,3},{1,3}}),3)` (`((nodes, edges), k)`)

### `MapSolution`
`ProblemFrom`/`ProblemTo` are problem **class names** (mirroring `ProblemTemplate`'s `problemFrom`/`problemTo` params, e.g. `SAT3`/`CLIQUE`), not instances — so the summaries are also reworded from "problem instance" to "problem to reduce from/to" to match. Values use the existing `INDEPENDENTSET → CLIQUE` reduction, with a node-set certificate coherent with the CLIQUE example above:

- `ProblemFrom` → `INDEPENDENTSET`
- `ProblemTo` → `CLIQUE`
- `ProblemFromSolution` → `{1,2,3}`

Note: `MapSolution` is not currently bound to any endpoint, so these examples don't surface in Swagger yet; they're in place for whenever the class gets wired up.

Documentation-only change; no behavioral impact.

## Testing
- `dotnet build API.csproj` — clean (0 warnings, 0 errors)
- `dotnet test` — 667 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
