### PR TITLE
Gave Pump Scheduling problems more accuracy at the cost of more computation time

### DIFF
--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
@@ -26,7 +26,6 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
     public List<object> GetSteps(PUMPSCHEDULINGCM _) => [true];
 
     private const int Hours = 24;
-    private const int Buckets = 1000;
     private const double Inf = double.MaxValue / 2;
 
     public string solve(PUMPSCHEDULINGCM problem)
@@ -34,10 +33,11 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
         int n = problem.Pumps.Count;
         int nMasks = 1 << n;
         double cap = problem.TankCapacity;
-        double bucketSize = cap / Buckets;
+        int buckets = (int)Math.Ceiling(cap);
+        double bucketSize = 1.0;
 
         int ToBucket(double level) =>
-            Math.Clamp((int)Math.Round(level / bucketSize), 0, Buckets);
+            Math.Clamp((int)Math.Round(level / bucketSize), 0, buckets);
 
         double ToLevel(int b) => b * bucketSize;
 
@@ -69,7 +69,7 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
             return cost;
         }
 
-        int stateB = Buckets + 1;
+        int stateB = buckets + 1;
         double[,,] dp      = new double[Hours + 1, stateB, nMasks];
         int[,,]    parentB = new int   [Hours + 1, stateB, nMasks];
         int[,,]    parentM = new int   [Hours + 1, stateB, nMasks];

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGCM/Solvers/PumpSchedulingCMSolver.cs
@@ -26,7 +26,7 @@ class PumpSchedulingCMSolver : ISolver<PUMPSCHEDULINGCM>
     public List<object> GetSteps(PUMPSCHEDULINGCM _) => [true];
 
     private const int Hours = 24;
-    private const double Inf = double.MaxValue / 2;
+    private const double Inf = double.PositiveInfinity;
 
     public string solve(PUMPSCHEDULINGCM problem)
     {

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGEM/Solvers/PumpSchedulingEMSolver.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGEM/Solvers/PumpSchedulingEMSolver.cs
@@ -26,8 +26,8 @@ class PumpSchedulingEMSolver : ISolver<PUMPSCHEDULINGEM>
 
     private const int Hours     = 24;
     private const double BudgetSlack = 1.5;
-    private const double Inf    = double.MaxValue / 2;
-    private const double NegInf = double.MinValue / 2;
+    private const double Inf    = double.PositiveInfinity;
+    private const double NegInf = double.NegativeInfinity;
 
     public string solve(PUMPSCHEDULINGEM problem)
     {

--- a/Problems/NPHard/NPH_PUMPSCHEDULINGEM/Solvers/PumpSchedulingEMSolver.cs
+++ b/Problems/NPHard/NPH_PUMPSCHEDULINGEM/Solvers/PumpSchedulingEMSolver.cs
@@ -25,7 +25,6 @@ class PumpSchedulingEMSolver : ISolver<PUMPSCHEDULINGEM>
     public List<object> GetSteps(PUMPSCHEDULINGEM _) => [true];
 
     private const int Hours     = 24;
-    private const int Buckets   = 1000;
     private const double BudgetSlack = 1.5;
     private const double Inf    = double.MaxValue / 2;
     private const double NegInf = double.MinValue / 2;
@@ -64,12 +63,13 @@ class PumpSchedulingEMSolver : ISolver<PUMPSCHEDULINGEM>
     {
         int n = problem.Pumps.Count;
         int nMasks = 1 << n;
-        int stateB = Buckets + 1;
         double cap = problem.TankCapacity;
         double minLevel = problem.TankMinLevel;
-        double bucketSize = cap / Buckets;
+        int buckets = (int)Math.Ceiling(cap);
+        int stateB = buckets + 1;
+        double bucketSize = 1.0;
 
-        int ToBucket(double level) => Math.Clamp((int)Math.Round(level / bucketSize), 0, Buckets);
+        int ToBucket(double level) => Math.Clamp((int)Math.Round(level / bucketSize), 0, buckets);
         double ToLevel(int b) => b * bucketSize;
 
         double[] maskFlow = BuildMaskFlow(problem, n, nMasks);
@@ -133,12 +133,13 @@ class PumpSchedulingEMSolver : ISolver<PUMPSCHEDULINGEM>
     {
         int n = problem.Pumps.Count;
         int nMasks = 1 << n;
-        int stateB = Buckets + 1;
         double cap = problem.TankCapacity;
         double minLevel = problem.TankMinLevel;
-        double bucketSize = cap / Buckets;
+        int buckets = (int)Math.Ceiling(cap);
+        int stateB = buckets + 1;
+        double bucketSize = 1.0;
 
-        int ToBucket(double level) => Math.Clamp((int)Math.Round(level / bucketSize), 0, Buckets);
+        int ToBucket(double level) => Math.Clamp((int)Math.Round(level / bucketSize), 0, buckets);
         double ToLevel(int b) => b * bucketSize;
 
         double[] maskFlow = BuildMaskFlow(problem, n, nMasks);


### PR DESCRIPTION
Before:

const int Buckets = 1000 — always 1000 buckets regardless of tank size
bucketSize = cap / 1000 — each bucket represented a fraction of capacity

After:

buckets = (int)Math.Ceiling(cap) — number of buckets equals the tank capacity (in gallons)
bucketSize = 1.0 — each bucket represents exactly 1 gallon

The effect is that tank levels are now tracked at 1-gallon precision instead of cap/1000 precision. For the default 10,000-gallon tank this makes buckets 10× finer (10,000 vs 1,000), but the real benefit is correctness — the bucket count now scales with the actual tank size rather than being an arbitrary constant. The change appears in both the CM and EM solvers, and in two separate DP methods within the EM solver.