### PR TITLE
Reduction/visualization endpoints: structured 400 on unparsable input (closes #355)

### DIFF
--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -118,6 +118,29 @@ public class ProblemProvider : ControllerBase
         };
     }
 
+    // --- Parse-error handling shared across endpoints -----------------------
+    // Reflective construction (Activator.CreateInstance) wraps constructor
+    // exceptions in TargetInvocationException; direct calls (e.g. mapSolutions,
+    // verify) throw the parse exception unwrapped. Unwrap normalizes both so
+    // callers can pattern-match on the real exception type.
+    private static Exception Unwrap(Exception ex) =>
+        ex is System.Reflection.TargetInvocationException { InnerException: { } inner } ? inner : ex;
+
+    /// <summary>True when <paramref name="ex"/> (once unwrapped) is a parse error we translate to HTTP 400.</summary>
+    private static bool IsParseError(Exception ex) =>
+        Unwrap(ex) is ProblemParseException or ReductionInputException or CertificateParseException;
+
+    /// <summary>Maps a parse exception to a 400 BadRequest with the matching structured body.</summary>
+    private IActionResult ParseError(Exception ex) => Unwrap(ex) switch {
+        ProblemParseException p     => BadRequest(ParseErrorBody("instance_parse_error", p.ProblemName,
+                                           LookupInstanceFormat(p.ProblemName), p.Received, p.Message)),
+        ReductionInputException r   => BadRequest(ReductionParseErrorBody("reduction_input_parse_error",
+                                           r.Reduction, r.ExpectedFormat, r.Received, r.Message)),
+        CertificateParseException c => BadRequest(ParseErrorBody("certificate_parse_error",
+                                           c.Problem.problemName, c.Problem.certificateFormat, c.Received, c.Message)),
+        _ => throw ex,
+    };
+
     private static string LookupInstanceFormat(string problemName) {
         // problemName may be either the class name (Problems key) or the
         // friendly problemName property — scan both. Error path: O(N) is fine.
@@ -256,7 +279,11 @@ public class ProblemProvider : ControllerBase
         if (!Visualizers.TryGetValue(visualization.ToLower(), out _))
             return BadRequest(new { error = "unknown_visualization", received = visualization });
         var vis = Visualization(visualization);
-        return Content(getVisualize(vis, vis.solver.GetSteps(instance), vis.solver.solve(instance), instance), "application/json");
+        try {
+            return Content(getVisualize(vis, vis.solver.GetSteps(instance), vis.solver.solve(instance), instance), "application/json");
+        } catch (Exception ex) when (IsParseError(ex)) {
+            return ParseError(ex);
+        }
     }
 
     /// <summary>
@@ -276,11 +303,15 @@ public class ProblemProvider : ControllerBase
                 return BadRequest(new { error = "unknown_reduction", received = r });
 
         IReduction? red = null;
-        foreach (string reductionname in reds)
-        {
-            red = Reduction(reductionname, instance);
-            solution = red.mapSolutions(solution);
-            instance = red.reductionTo.instance;
+        try {
+            foreach (string reductionname in reds)
+            {
+                red = Reduction(reductionname, instance);
+                solution = red.mapSolutions(solution);
+                instance = red.reductionTo.instance;
+            }
+        } catch (Exception ex) when (IsParseError(ex)) {
+            return ParseError(ex);
         }
 
         if (red is null)
@@ -301,7 +332,11 @@ public class ProblemProvider : ControllerBase
     {
         if (!Reductions.TryGetValue(reduction.ToLower(), out _))
             return BadRequest(new { error = "unknown_reduction", received = reduction });
-        return Content(JsonSerializer.Serialize(Reduction(reduction, instance), new JsonSerializerOptions() { WriteIndented = true }), "application/json");
+        try {
+            return Content(JsonSerializer.Serialize(Reduction(reduction, instance), new JsonSerializerOptions() { WriteIndented = true }), "application/json");
+        } catch (Exception ex) when (IsParseError(ex)) {
+            return ParseError(ex);
+        }
     }
 
     /// <summary>
@@ -363,7 +398,11 @@ public class ProblemProvider : ControllerBase
     {
         if (!Reductions.TryGetValue(reduction.ToLower(), out _))
             return BadRequest(new { error = "unknown_reduction", received = reduction });
-        IReduction red = Reduction(reduction, instance);
-        return Content(JsonSerializer.Serialize(red.gadgets, new JsonSerializerOptions() { WriteIndented = true }), "application/json");
+        try {
+            IReduction red = Reduction(reduction, instance);
+            return Content(JsonSerializer.Serialize(red.gadgets, new JsonSerializerOptions() { WriteIndented = true }), "application/json");
+        } catch (Exception ex) when (IsParseError(ex)) {
+            return ParseError(ex);
+        }
     }
 }

--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -352,25 +352,14 @@ public class ProblemProvider : ControllerBase
     {
         if (!Reductions.TryGetValue(reduction.ToLower(), out _))
             return BadRequest(new { error = "unknown_reduction", received = reduction });
-        IReduction red;
         try {
-            red = Reduction(reduction, instance);
-        } catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is ProblemParseException ex) {
-            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
-                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
-        } catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is ReductionInputException ex) {
-            return BadRequest(ReductionParseErrorBody("reduction_input_parse_error", ex.Reduction,
-                ex.ExpectedFormat, ex.Received, ex.Message));
-        }
-
-        try {
+            IReduction red = Reduction(reduction, instance);
             string mappedSolution = red.mapSolutions(solution);
             return Content(
                 JsonSerializer.Serialize(mappedSolution, new JsonSerializerOptions() { WriteIndented = true }),
                 "application/json");
-        } catch (ReductionInputException ex) {
-            return BadRequest(ReductionParseErrorBody("reduction_input_parse_error", ex.Reduction,
-                ex.ExpectedFormat, ex.Received, ex.Message));
+        } catch (Exception ex) when (IsParseError(ex)) {
+            return ParseError(ex);
         }
     }
 

--- a/AdditionalControllers/ProblemProvider.cs
+++ b/AdditionalControllers/ProblemProvider.cs
@@ -317,9 +317,37 @@ public class ProblemProvider : ControllerBase
     {
         if (!Reductions.TryGetValue(reduction.ToLower(), out _))
             return BadRequest(new { error = "unknown_reduction", received = reduction });
-        IReduction red = Reduction(reduction, instance);
-        string mappedSolution = red.mapSolutions(solution);
-        return Content(JsonSerializer.Serialize(mappedSolution, new JsonSerializerOptions() { WriteIndented = true }), "application/json");
+        IReduction red;
+        try {
+            red = Reduction(reduction, instance);
+        } catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is ProblemParseException ex) {
+            return BadRequest(ParseErrorBody("instance_parse_error", ex.ProblemName,
+                LookupInstanceFormat(ex.ProblemName), ex.Received, ex.Message));
+        } catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException is ReductionInputException ex) {
+            return BadRequest(ReductionParseErrorBody("reduction_input_parse_error", ex.Reduction,
+                ex.ExpectedFormat, ex.Received, ex.Message));
+        }
+
+        try {
+            string mappedSolution = red.mapSolutions(solution);
+            return Content(
+                JsonSerializer.Serialize(mappedSolution, new JsonSerializerOptions() { WriteIndented = true }),
+                "application/json");
+        } catch (ReductionInputException ex) {
+            return BadRequest(ReductionParseErrorBody("reduction_input_parse_error", ex.Reduction,
+                ex.ExpectedFormat, ex.Received, ex.Message));
+        }
+    }
+
+    private static object ReductionParseErrorBody(string error, IReduction reduction, string expected, string received, string detail) {
+        return new {
+            error,
+            reduction = reduction.reductionName,
+            problem = reduction.reductionFrom.problemName,
+            expected,
+            received,
+            detail
+        };
     }
 
 

--- a/Interfaces/ParseExceptions.cs
+++ b/Interfaces/ParseExceptions.cs
@@ -27,3 +27,21 @@ internal class CertificateParseException : Exception {
         Received = received;
     }
 }
+
+// Thrown when a reduction cannot parse the supplied input (either the
+// source-problem instance during construction, or the source-problem
+// certificate during mapSolutions). Controllers translate this to HTTP
+// 400. The `ExpectedFormat` field is passed in at the throw site so the
+// caller can choose between `reductionFrom.instanceFormat` and
+// `reductionFrom.certificateFormat` depending on which input failed.
+internal class ReductionInputException : Exception {
+    public IReduction Reduction { get; }
+    public string Received { get; }
+    public string ExpectedFormat { get; }
+    public ReductionInputException(IReduction reduction, string received, string expectedFormat, string? detail = null)
+        : base(detail ?? $"could not parse input to {reduction.reductionName}") {
+        Reduction = reduction;
+        Received = received;
+        ExpectedFormat = expectedFormat;
+    }
+}

--- a/Problems/NPComplete/NPC_CLIQUE/ReduceTo/NPC_SAT3/SipserReduceToSAT3.cs
+++ b/Problems/NPComplete/NPC_CLIQUE/ReduceTo/NPC_SAT3/SipserReduceToSAT3.cs
@@ -39,7 +39,17 @@ class SipserReduceToSAT3 : IReduction<CLIQUE, API.Problems.NPComplete.NPC_SAT3.S
     {
         gadgets = new();
         _reductionFrom = from;
-        _reductionTo = reduce();
+        try {
+            _reductionTo = reduce();
+        } catch (ArgumentException ex) {
+            // ParseSipserNode rejected one of the instance's node names.
+            // The CLIQUE itself is well-formed; it's just not the
+            // Sipser-formatted variety this reduction needs as input.
+            throw new ReductionInputException(this, from.instance,
+                _reductionFrom.instanceFormat +
+                " | Additionally, this reduction requires Sipser-formatted node names of the form '<literal>_<clauseIdx>'.",
+                ex.Message);
+        }
     }
     public SipserReduceToSAT3(string instance) : this(new CLIQUE(instance)) { }
     public SipserReduceToSAT3() : this(new CLIQUE()) { }
@@ -67,23 +77,30 @@ class SipserReduceToSAT3 : IReduction<CLIQUE, API.Problems.NPComplete.NPC_SAT3.S
     public string mapSolutions(string problemFromSolution)
     {
         // problemFromSolution is a clique certificate like "{x1_0,x2_1,x1_2}".
-        var assigned = new Dictionary<string, bool>();
-        var order = new List<string>();
-        foreach (string raw in problemFromSolution.Trim('{', '}', '(', ')', ' ').Split(','))
-        {
-            string node = raw.Trim();
-            if (node.Length == 0) continue;
-            (string literal, int _) = ParseSipserNode(node);
-            bool positive = !literal.StartsWith("!");
-            string varName = positive ? literal : literal.Substring(1);
-            if (!assigned.ContainsKey(varName))
+        try {
+            var assigned = new Dictionary<string, bool>();
+            var order = new List<string>();
+            foreach (string raw in problemFromSolution.Trim('{', '}', '(', ')', ' ').Split(','))
             {
-                assigned[varName] = positive;
-                order.Add(varName);
+                string node = raw.Trim();
+                if (node.Length == 0) continue;
+                (string literal, int _) = ParseSipserNode(node);
+                bool positive = !literal.StartsWith("!");
+                string varName = positive ? literal : literal.Substring(1);
+                if (!assigned.ContainsKey(varName))
+                {
+                    assigned[varName] = positive;
+                    order.Add(varName);
+                }
             }
+            var parts = order.Select(v => $"{v}:{(assigned[v] ? "True" : "False")}");
+            return "(" + string.Join(",", parts) + ")";
+        } catch (ArgumentException ex) {
+            throw new ReductionInputException(this, problemFromSolution,
+                _reductionFrom.certificateFormat +
+                " | Additionally, this reduction requires Sipser-formatted node names of the form '<literal>_<clauseIdx>'.",
+                ex.Message);
         }
-        var parts = order.Select(v => $"{v}:{(assigned[v] ? "True" : "False")}");
-        return "(" + string.Join(",", parts) + ")";
     }
 
     private static (string literal, int clauseIdx) ParseSipserNode(string node)

--- a/Problems/NPComplete/NPC_SAT3/ReduceTo/NPC_CLIQUE/SipserReduceToCliqueStandard.cs
+++ b/Problems/NPComplete/NPC_SAT3/ReduceTo/NPC_CLIQUE/SipserReduceToCliqueStandard.cs
@@ -365,6 +365,11 @@ class SipserReduceToCliqueStandard : IReduction<SAT3, CLIQUE>
         foreach (string item in items)
         {
             List<string> split = item.Split(":").ToList();
+            if (split.Count < 2) {
+                throw new ReductionInputException(this, solution,
+                    reductionFrom.certificateFormat,
+                    $"assignment '{item}' is missing a ':' separator");
+            }
             if (split[1] == "True")
                 trueLiterals.Add(split[0]);
             else

--- a/redux-tests/Endpoints/ProblemProvider_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/ProblemProvider_Endpoint_Tests.cs
@@ -159,4 +159,55 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
         var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains("reduction_input_parse_error", body);
     }
+
+    // ── unparsable-instance handling on the remaining reduction/visualization
+    //    endpoints (issue #355) ─────────────────────────────────────────────
+    // Each of these builds a SAT3 from the posted instance; a malformed SAT3
+    // formula ("1" is not a valid literal) used to escape as an unhandled
+    // exception → HTTP 500, and must now surface as a structured 400.
+
+    // A CLIQUE-shaped string posted to a SAT3-sourced reduction — the exact
+    // shape from the production stack trace that motivated issue #355.
+    private const string InvalidSat3Instance = "\"(1 | 2 | 3)\"";
+
+    [Fact]
+    public async Task Reduce_InvalidInstance_Returns400WithParseError()
+    {
+        var content = new StringContent(InvalidSat3Instance, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/ProblemProvider/reduce?reduction=sipserreducetocliquestandard", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("instance_parse_error", body);
+    }
+
+    [Fact]
+    public async Task Gadgets_InvalidInstance_Returns400WithParseError()
+    {
+        var content = new StringContent(InvalidSat3Instance, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/ProblemProvider/gadgets?reduction=sipserreducetocliquestandard", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("instance_parse_error", body);
+    }
+
+    [Fact]
+    public async Task VisualizeReduction_InvalidInstance_Returns400WithParseError()
+    {
+        var content = new StringContent(InvalidSat3Instance, Encoding.UTF8, "application/json");
+        var solution = Uri.EscapeDataString("(x1:True)");
+        var response = await _client.PostAsync($"/ProblemProvider/visualizeReduction?reduction=sipserreducetocliquestandard&solution={solution}", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("instance_parse_error", body);
+    }
+
+    [Fact]
+    public async Task Visualize_InvalidInstance_Returns400WithParseError()
+    {
+        var content = new StringContent(InvalidSat3Instance, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/ProblemProvider/visualize?visualization=sat3defaultvisualization", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("instance_parse_error", body);
+    }
 }

--- a/redux-tests/Endpoints/ProblemProvider_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/ProblemProvider_Endpoint_Tests.cs
@@ -103,4 +103,60 @@ public class ProblemProvider_Endpoint_Tests : IClassFixture<AppFactory>
         var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.False(string.IsNullOrWhiteSpace(body));
     }
+
+    // ── /ProblemProvider/mapSolution ──────────────────────────────────────────
+
+    [Fact]
+    public async Task MapSolution_ValidSAT3Solution_Returns200()
+    {
+        var instance = "\"(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)\"";
+        var content = new StringContent(instance, Encoding.UTF8, "application/json");
+        var solution = Uri.EscapeDataString("(x1:True,x2:False,x3:True)");
+        var response = await _client.PostAsync($"/ProblemProvider/mapSolution?reduction=sipserreducetocliquestandard&solution={solution}", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MapSolution_CliqueShapedCertificate_Returns400WithParseError()
+    {
+        // The original gut-check: a CLIQUE-shaped certificate fed to the SAT3→CLIQUE
+        // forward mapper used to throw IndexOutOfRangeException → HTTP 500. It must
+        // now surface as a structured 400.
+        var instance = "\"(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)\"";
+        var content = new StringContent(instance, Encoding.UTF8, "application/json");
+        var solution = Uri.EscapeDataString("{x1_0,x2_1,!x3_3}");
+        var response = await _client.PostAsync($"/ProblemProvider/mapSolution?reduction=sipserreducetocliquestandard&solution={solution}", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("reduction_input_parse_error", body);
+    }
+
+    [Fact]
+    public async Task MapSolution_NonSipserInstance_Returns400WithParseError()
+    {
+        // SipserReduceToSAT3 requires Sipser-formatted CLIQUE node names. A plain
+        // numeric-node CLIQUE instance is well-formed as a CLIQUE but invalid for
+        // this reduction, and must surface as a 400 rather than a 500.
+        var instance = "\"(({1,2,3,4,5,6},{{4,1},{1,2},{4,3},{3,2},{2,4},{5,2},{3,5},{5,4},{3,6},{6,4},{1,6}}),4)\"";
+        var content = new StringContent(instance, Encoding.UTF8, "application/json");
+        var solution = Uri.EscapeDataString("{x1_0}");
+        var response = await _client.PostAsync($"/ProblemProvider/mapSolution?reduction=sipserreducetosat3&solution={solution}", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("reduction_input_parse_error", body);
+    }
+
+    [Fact]
+    public async Task MapSolution_BadCertificate_Returns400WithParseError()
+    {
+        // Valid Sipser-formatted CLIQUE instance, but the certificate carries
+        // non-Sipser node names — the certificate-side throw site.
+        var instance = "\"(({x1_0,x2_1,x3_2},{{x1_0,x2_1},{x2_1,x3_2},{x1_0,x3_2}}),3)\"";
+        var content = new StringContent(instance, Encoding.UTF8, "application/json");
+        var solution = Uri.EscapeDataString("{a,b}");
+        var response = await _client.PostAsync($"/ProblemProvider/mapSolution?reduction=sipserreducetosat3&solution={solution}", content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("reduction_input_parse_error", body);
+    }
 }

--- a/redux-tests/Problems/NPC_SAT3/SAT3_Tests.cs
+++ b/redux-tests/Problems/NPC_SAT3/SAT3_Tests.cs
@@ -203,4 +203,17 @@ public class SAT3_Tests
         CliqueVerifier cliqueVerifier = new CliqueVerifier();
         Assert.True(cliqueVerifier.verify(clique, cliqueCertificate));
     }
+
+    [Fact]
+    public void SAT3_To_CLIQUE_Reduction_MalformedCertificate_Throws_ReductionInputException()
+    {
+        // Regression: a CLIQUE-shaped certificate (items missing the ':' separator)
+        // once threw IndexOutOfRangeException from Split(":"), surfacing as an
+        // opaque HTTP 500. It must now throw the typed ReductionInputException so
+        // the controller can return a 400 with a format hint.
+        SAT3 sat3 = new SAT3("(x1 | !x2 | x3) & (!x1 | x3 | x1) & (x2 | !x3 | x1)");
+        SipserReduceToCliqueStandard reduction = new SipserReduceToCliqueStandard(sat3);
+        Assert.Throws<API.Interfaces.ReductionInputException>(
+            () => reduction.mapSolutions("{x1_0,x2_1,!x3_3}"));
+    }
 }


### PR DESCRIPTION
Closes #355.

## Summary

Mis-shaped input on the reduction and visualization endpoints currently throws
into an HTTP 500 with a stack trace — any client (the GUI, curl, an LLM/MCP
client) gets opaque output with no actionable signal, and every bad request
writes a full stack trace to the server log.

This makes all five affected endpoints — `mapSolution`, `reduce`, `gadgets`,
`visualizeReduction`, `visualize` — surface parse failures as a structured
**HTTP 400**, matching the existing `instance_parse_error` /
`certificate_parse_error` pattern already used by `solve`/`verify`/`problemInstance`.

## Changes

### Reduction input exception + `/mapSolution` (original scope)

- Add `ReductionInputException` to `Interfaces/ParseExceptions.cs` (carries the
  `IReduction`, the received string, and the expected-format hint chosen at the
  throw site, so one type covers both instance-side and certificate-side parse
  failures).
- `SipserReduceToSAT3` validates its source instance and certificate, throwing
  `ReductionInputException` with the CLIQUE `instanceFormat`/`certificateFormat`
  plus a Sipser-node-format addendum.
- `SipserReduceToCliqueStandard.mapSolutions` validates the `:` separator before
  indexing, throwing `ReductionInputException` naming 3SAT's `certificateFormat`.
  This replaces the `IndexOutOfRangeException` at the original crash site.

### Extend to the remaining endpoints (#355)

- Add three shared helpers on `ProblemProvider`:
  - `Unwrap` — normalizes `TargetInvocationException` (from reflective
    `Activator.CreateInstance`) vs. bare parse exceptions (direct calls).
  - `IsParseError` — predicate used in the catch filter.
  - `ParseError` — maps a parse exception to the matching 400 body
    (`instance_parse_error` / `reduction_input_parse_error` /
    `certificate_parse_error`), reusing the existing body builders.
- `reduce`, `gadgets`, `visualizeReduction`, and `visualize` each gain a single
  `catch (Exception ex) when (IsParseError(ex)) => ParseError(ex)` arm. These
  previously let a `ProblemParseException`/`ReductionInputException` escape as an
  unhandled 500 (the `reduce` path was the endpoint in the reported #355 trace).
- `mapSolution` is refactored onto the same helper, collapsing its three inline
  catch blocks into one arm — all reduction/visualization endpoints now handle
  parse errors uniformly. `verify`/`solve`/`problemInstance` are left as-is.

## Scope note

This closes the **endpoint layer** of #355: all five endpoints now translate a
*typed* parse exception into a 400. Inputs whose underlying problem/reduction
still throws a *raw* (non-typed) exception will continue to 500 through these
endpoints; converting those constructors to throw typed parse exceptions is a
per-problem effort tracked separately.

## Verification

`dotnet build Redux.slnx` — 0 warnings, 0 errors.
`dotnet test Redux.slnx` — **687 passed, 0 failed**, including new endpoint
tests asserting `400` + `instance_parse_error` for `reduce`, `gadgets`,
`visualizeReduction`, and `visualize`, plus the existing `mapSolution`
parse-error tests.

Live against a running backend (`/ProblemProvider/mapSolution`):

| Input | Before | After |
|---|---|---|
| valid SAT3 solution → `SipserReduceToCliqueStandard` | 200 | **200** |
| clique-shaped cert → `SipserReduceToCliqueStandard` | 500 `IndexOutOfRange` | **400**, 3SAT cert format, `missing ':' separator` |
| non-Sipser CLIQUE instance → `SipserReduceToSAT3` | 500 | **400**, CLIQUE `instanceFormat` + Sipser addendum |
| bad certificate → `SipserReduceToSAT3` | 500 | **400**, CLIQUE `certificateFormat` + Sipser addendum |

No unhandled exceptions in the server log across all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
