### PR TITLE
Batch navigation endpoints + problem listing via reflection

### DIFF
--- a/AdditionalControllers/Navigation/Nav_Batch.cs
+++ b/AdditionalControllers/Navigation/Nav_Batch.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+// Batch navigation endpoints: return metadata for ALL problems in a single
+// call so the GUI can prime its state with one request instead of N per-problem
+// round-trips.
+//
+// Everything here is projected from the same reflected data the singular
+// Navigation controllers already use — ProblemProvider.* and the *NavigationData
+// caches built once at startup (see Nav_Solvers/Nav_Verifiers/Nav_Visualizations).
+// Because the source of truth is shared, a batch response can never drift from its
+// per-problem counterpart.
+//
+// This deliberately does NOT scan the on-disk Problems/ layout, take a problemType
+// argument, or register an IMemoryCache the way the original proposal (upstream
+// PR #168) did: the reflected dictionaries are already a process-lifetime in-memory
+// cache, so each payload is serialized exactly once via Lazy<string>. Problem names
+// are unique across complexity classes, so no class filter is required.
+[ApiController]
+[Route("Navigation/[controller]")]
+[Tags("- Navigation (Batch)")]
+#pragma warning disable CS1591
+public class BatchController : ControllerBase
+{
+#pragma warning restore CS1591
+
+    private static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+
+    // All top-level problem names, from the same reflected source as the singular
+    // Navigation/*Problems* endpoints (see ProblemNavigationData in Nav_Problems.cs).
+    private static readonly Lazy<string> ProblemsJson = new(() =>
+        JsonSerializer.Serialize(ProblemNavigationData.All(), Indented));
+
+    private static readonly Lazy<string> SolversJson = new(() =>
+        GroupedJson(SolverNavigationData.Entries.Select(e => (e.problemName, e.className))));
+
+    private static readonly Lazy<string> VerifiersJson = new(() =>
+        GroupedJson(VerifierNavigationData.Entries.Select(e => (e.problemName, e.className))));
+
+    private static readonly Lazy<string> VisualizationsJson = new(() =>
+        GroupedJson(VisualizationNavigationData.Entries.Select(e => (e.problemName, e.className))));
+
+    // Instances of every reflected interface type, mirroring ProblemProvider.info
+    // (Newtonsoft + reference-loop ignore) but for all interfaces at once. Types that
+    // cannot be default-constructed are skipped rather than failing the whole payload.
+    private static readonly Lazy<string> InfoJson = new(() =>
+    {
+        var result = new Dictionary<string, object>();
+        foreach (var (_, type) in ProblemProvider.Interfaces)
+        {
+            try
+            {
+                if (Activator.CreateInstance(type) is object instance)
+                    result[type.Name] = instance;
+            }
+            catch
+            {
+                // Skip an interface that has no parameterless constructor instead of
+                // failing the whole response.
+            }
+        }
+        return Newtonsoft.Json.JsonConvert.SerializeObject(
+            result,
+            Newtonsoft.Json.Formatting.Indented,
+            new Newtonsoft.Json.JsonSerializerSettings
+            {
+                ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore
+            });
+    });
+
+    // Group (problemName -> className) pairs into a sorted map of sorted class names.
+    private static string GroupedJson(IEnumerable<(string problemName, string className)> entries) =>
+        JsonSerializer.Serialize(
+            entries
+                .GroupBy(e => e.problemName, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Select(e => e.className)
+                          .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
+                          .ToList(),
+                    StringComparer.OrdinalIgnoreCase),
+            Indented);
+
+    /// <summary>Returns every problem name in a single call.</summary>
+    /// <response code="200">String array of all problem names.</response>
+    [ProducesResponseType(typeof(List<string>), 200)]
+    [HttpGet("allProblems")]
+    public IActionResult AllProblems() => Content(ProblemsJson.Value, "application/json");
+
+    /// <summary>Returns the solvers for every problem, keyed by problem name.</summary>
+    /// <response code="200">Map of problem name to its solver class names.</response>
+    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 200)]
+    [HttpGet("allSolvers")]
+    public IActionResult AllSolvers() => Content(SolversJson.Value, "application/json");
+
+    /// <summary>Returns the verifiers for every problem, keyed by problem name.</summary>
+    /// <response code="200">Map of problem name to its verifier class names.</response>
+    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 200)]
+    [HttpGet("allVerifiers")]
+    public IActionResult AllVerifiers() => Content(VerifiersJson.Value, "application/json");
+
+    /// <summary>Returns the visualizations for every problem, keyed by problem name.</summary>
+    /// <response code="200">Map of problem name to its visualization class names.</response>
+    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 200)]
+    [HttpGet("allVisualizations")]
+    public IActionResult AllVisualizations() => Content(VisualizationsJson.Value, "application/json");
+
+    /// <summary>Returns info objects for every reflected interface, keyed by class name.</summary>
+    /// <response code="200">Map of interface class name to its instance info.</response>
+    [ProducesResponseType(typeof(Dictionary<string, object>), 200)]
+    [HttpGet("allInfo")]
+    public IActionResult AllInfo() => Content(InfoJson.Value, "application/json");
+}

--- a/AdditionalControllers/Navigation/Nav_Problems.cs
+++ b/AdditionalControllers/Navigation/Nav_Problems.cs
@@ -1,16 +1,63 @@
 using Microsoft.AspNetCore.Mvc;
-using System.IO;
-using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Collections.Generic;
-using System.Collections;
 
-//NOTE - Corbin: In order to add a controller for another file within /Problems, simply copy a specified controller (such as 'NPC_ProblemsRefactorController')
-//               paste and rename, the only changes needed is the path which defines subdirs for both functions: getDefault and getProblemsJson and update comments
+// Problem navigation resolved via reflection over ProblemProvider.Problems, so it no
+// longer depends on the on-disk Problems/ folder layout. Mirrors the solver / verifier
+// / visualization navigation (#317/#318/#331); those endpoints were converted earlier,
+// this closes the gap for the problem-listing endpoints.
+//
+// A problem's complexity class is read from its namespace: every problem lives in
+// API.Problems.<ComplexityClass>.<ProblemFolder> (e.g. API.Problems.NPComplete.NPC_SAT3).
+// Only these top-level problems are listed; nested helper variants such as
+// API.Problems.NPComplete.NPC_CLIQUE.Inherited (SipserClique) are excluded, matching the
+// old top-level directory scan.
+internal static class ProblemNavigationData
+{
+    internal class ProblemEntry
+    {
+        public string className { get; set; } = "";
+        public string complexityClass { get; set; } = "";
+    }
 
-//NOTE - Corbin: All specific controllers should probably be removed with the addition of tags, instead of one function per folder it should probably query a tag (like the NagGraph does for chosenProblem)
-//               in order to have one generalized specified problem controller
+    // Built once from reflected problem types.
+    internal static readonly List<ProblemEntry> Entries = Build();
+
+    private static List<ProblemEntry> Build()
+    {
+        var entries = new List<ProblemEntry>();
+        foreach (var (_, type) in ProblemProvider.Problems)
+        {
+            // Namespace is API . Problems . <ComplexityClass> . <ProblemFolder>.
+            // Anything deeper (…<Folder>.Inherited, .ReduceTo.*, …) is a nested helper
+            // problem, not a top-level listable one, so require exactly that shape.
+            string[] ns = (type.Namespace ?? "").Split('.');
+            int i = Array.IndexOf(ns, "Problems");
+            if (i < 0 || ns.Length != i + 3) continue;
+
+            entries.Add(new ProblemEntry
+            {
+                className = type.Name,
+                complexityClass = ns[i + 1],
+            });
+        }
+
+        return entries
+            .GroupBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .OrderBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    // All problem names, sorted (Entries is already sorted).
+    internal static List<string> All() => Entries.Select(e => e.className).ToList();
+
+    // Problem names for one complexity class (namespace segment: NPComplete / P / NPHard).
+    internal static List<string> ByComplexity(string complexityClass) =>
+        Entries
+            .Where(e => string.Equals(e.complexityClass, complexityClass, StringComparison.OrdinalIgnoreCase))
+            .Select(e => e.className)
+            .ToList();
+}
 
 // Get all problems
 [ApiController]
@@ -24,38 +71,14 @@ public class ALL_ProblemsRefactorController : ControllerBase
 
 ///<summary>Returns all problems</summary>
 ///<response code = "200">Returns string array of all problems regardless of class</response>
-    
+
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
 
     public String getDefault()
     {
-        string projectSourcePath = ProjectSourcePath.Value;
-        var allProblemDirNames = new List<string>();
-
-        foreach (var classDir in Directory.GetDirectories(projectSourcePath + @"Problems"))
-        {
-            foreach (var problemDir in Directory.GetDirectories(classDir))
-            {
-                var name = Path.GetFileName(problemDir);
-                if (name != null)
-                    allProblemDirNames.Add(name);
-            }
-        }
-        string?[] subdirs = allProblemDirNames.ToArray();
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.All(), options);
     }
 }
 
@@ -77,34 +100,8 @@ public class NPC_ProblemsRefactorController : ControllerBase
 
     public String getDefault()
     {
-        // File system patch that should work on both Window/Linux enviroments
-        string projectSourcePath = ProjectSourcePath.Value;
-        string?[] subdirs = Directory.GetDirectories(projectSourcePath + @"/Problems/NPComplete")
-                        .Select(Path.GetFileName)
-                        .ToArray();
-
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-
-        //NOTE - Corbin: below is someone elses commented out code, I am leaving it for now just in case it is needed.
-
-        // ProblemGraph graph = new ProblemGraph();
-        // graph.getConnectedNodes("SAT3");
-        // string ring = JsonSerializer.Serialize(graph.getConnectedNodes("SAT3"), options);
-        //  Console.WriteLine("\n"+ring );
-
-        //Response.Headers.Add("Access-Control-Allow-Origin", "http://127.0.0.1:5500");
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.ByComplexity("NPComplete"), options);
     }
 }
 
@@ -119,32 +116,15 @@ public class P_ProblemsRefactorController : ControllerBase
 #pragma warning restore CS1591
 
     ///<summary>Returns all P-Class problems </summary>
-    ///<response code="200">Returns string array of all NP-Complete problems</response>
+    ///<response code="200">Returns string array of all P-Class problems</response>
 
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
 
     public String getDefault()
     {
-        // File system patch that should work on both Window/Linux enviroments
-        string projectSourcePath = ProjectSourcePath.Value;
-        string?[] subdirs = Directory.GetDirectories(projectSourcePath + @"/Problems/P")
-                        .Select(Path.GetFileName)
-                        .ToArray();
-
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.ByComplexity("P"), options);
     }
 
 }
@@ -160,32 +140,15 @@ public class NPHard_ProblemsRefactorController : ControllerBase
 #pragma warning restore CS1591
 
     ///<summary>Returns all NPHard problems </summary>
-    ///<response code="200">Returns string array of all NP-Complete problems</response>
+    ///<response code="200">Returns string array of all NP-Hard problems</response>
 
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
 
     public String getDefault()
     {
-        // File system patch that should work on both Window/Linux enviroments
-        string projectSourcePath = ProjectSourcePath.Value;
-        string?[] subdirs = Directory.GetDirectories(projectSourcePath + @"/Problems/NPHard")
-                        .Select(Path.GetFileName)
-                        .ToArray();
-
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.ByComplexity("NPHard"), options);
     }
 
 }

--- a/redux-tests/Endpoints/Batch_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/Batch_Endpoint_Tests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+// Tests for the Navigation/Batch endpoints. The batch responses are projected
+// from the same reflected data the singular Navigation controllers use, so the
+// central guarantee under test is that a batch payload never drifts from its
+// per-problem counterpart.
+public class Batch_Endpoint_Tests : IClassFixture<AppFactory>
+{
+    private readonly HttpClient _client;
+
+    public Batch_Endpoint_Tests(AppFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private async Task<string[]> GetArray(string url)
+    {
+        var response = await _client.GetAsync(url, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        return arr!;
+    }
+
+    private async Task<Dictionary<string, List<string>>> GetMap(string url)
+    {
+        var response = await _client.GetAsync(url, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var map = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(body);
+        Assert.NotNull(map);
+        return map!;
+    }
+
+    // ── allProblems ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllProblems_Returns200AndNonEmpty()
+    {
+        var problems = await GetArray("/Navigation/Batch/allProblems");
+        Assert.NotEmpty(problems);
+        Assert.Contains("SAT3", problems);
+    }
+
+    [Fact]
+    public async Task AllProblems_MatchesSingularAllEndpoint()
+    {
+        // Batch must be exactly the reflected problem set the singular endpoint returns.
+        var batch = await GetArray("/Navigation/Batch/allProblems");
+        var singular = await GetArray("/Navigation/ALL_ProblemsRefactor");
+        Assert.Equal(
+            new SortedSet<string>(singular, StringComparer.Ordinal),
+            new SortedSet<string>(batch, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task AllProblems_ExcludesInheritedHelperProblems()
+    {
+        // SipserClique lives in NPC_CLIQUE.Inherited; it is a nested helper variant,
+        // not a top-level problem, so it must not appear in the listing.
+        var problems = await GetArray("/Navigation/Batch/allProblems");
+        Assert.DoesNotContain(problems, p => string.Equals(p, "SipserClique", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── allSolvers / allVerifiers / allVisualizations ─────────────────────────
+
+    [Fact]
+    public async Task AllSolvers_MapsSat3ToItsSolver()
+    {
+        var map = await GetMap("/Navigation/Batch/allSolvers");
+        Assert.True(map.ContainsKey("SAT3"));
+        Assert.Contains("Sat3BacktrackingSolver", map["SAT3"]);
+    }
+
+    [Fact]
+    public async Task AllSolvers_Sat3EntryMatchesSingularEndpoint()
+    {
+        // The whole point of the batch endpoint: no drift from the per-problem lookup.
+        var map = await GetMap("/Navigation/Batch/allSolvers");
+        var singular = await GetArray("/Navigation/Problem_SolversRefactor?chosenProblem=SAT3");
+        Assert.Equal(singular.OrderBy(x => x, StringComparer.Ordinal),
+                     map["SAT3"].OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task AllVerifiers_MapsSat3ToItsVerifier()
+    {
+        var map = await GetMap("/Navigation/Batch/allVerifiers");
+        Assert.True(map.ContainsKey("SAT3"));
+        Assert.Contains("SAT3Verifier", map["SAT3"]);
+    }
+
+    [Fact]
+    public async Task AllVerifiers_Sat3EntryMatchesSingularEndpoint()
+    {
+        var map = await GetMap("/Navigation/Batch/allVerifiers");
+        var singular = await GetArray("/Navigation/Problem_VerifiersRefactor?chosenProblem=SAT3");
+        Assert.Equal(singular.OrderBy(x => x, StringComparer.Ordinal),
+                     map["SAT3"].OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task AllVisualizations_MapsSat3ToDefaultVisualization()
+    {
+        var map = await GetMap("/Navigation/Batch/allVisualizations");
+        Assert.True(map.ContainsKey("SAT3"));
+        Assert.Contains("Sat3DefaultVisualization", map["SAT3"]);
+    }
+
+    // ── allInfo ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllInfo_Returns200AndContainsProblemObject()
+    {
+        var response = await _client.GetAsync("/Navigation/Batch/allInfo", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var map = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(body);
+        Assert.NotNull(map);
+        Assert.NotEmpty(map!);
+        Assert.True(map!.ContainsKey("SAT3"));
+        Assert.Equal(JsonValueKind.Object, map["SAT3"].ValueKind);
+    }
+
+    [Fact]
+    public async Task AllInfo_RepeatedCalls_ReturnIdenticalPayload()
+    {
+        // Cached via Lazy<string>: every call after the first returns the same bytes.
+        var first = await (await _client.GetAsync("/Navigation/Batch/allInfo", TestContext.Current.CancellationToken))
+            .Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var second = await (await _client.GetAsync("/Navigation/Batch/allInfo", TestContext.Current.CancellationToken))
+            .Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(first, second);
+    }
+
+    // ── method contract ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllProblems_RejectsPost()
+    {
+        // These are reads: GET only (PR #168 used POST; this reimplementation does not).
+        var response = await _client.PostAsync("/Navigation/Batch/allProblems", null, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary

Reworks the batch-metadata idea from #168 to sit on the reflection infrastructure this tree already has, and closes a gap the earlier navigation refactors left open. Three commits:

1. **refactor(nav): resolve problem listing via reflection** — the `ALL_/NPC_/P_/NPHard_ProblemsRefactor` endpoints still scanned the on-disk `Problems/` layout and split directory names on `_`, even though solver/verifier/visualization navigation had already moved to reflection (#317/#318/#331). Adds `ProblemNavigationData` (built once from `ProblemProvider.Problems`), reading the complexity class from each type's namespace and listing only top-level problems. Output is identical to the old scan (42 NPComplete + 5 P + 2 NPHard = 49), with no on-disk dependency and no name-truncation bug.

2. **feat(nav): add batch navigation endpoints** — `Navigation/Batch` with `GET allProblems, allSolvers, allVerifiers, allVisualizations, allInfo`, so the GUI can prime its state in one request instead of N per-problem round-trips. Every payload is projected from the same reflected data the singular controllers use, so a batch response can never drift from its per-problem counterpart.

3. **test(nav): cover Navigation/Batch endpoints** — 11 tests focused on the no-drift guarantee.

## How this differs from #168

| #168 | This PR |
|---|---|
| Scans `Problems/` on disk, splits folder names | Projects reflected `ProblemProvider.*` / `*NavigationData` (single source of truth) |
| `IMemoryCache` + 1h TTL + `AddMemoryCache()` + `clearCache` | No new services; data is already process-lifetime, serialized once via `Lazy<string>` |
| `POST` for reads, `problemType` required | `GET`, no `problemType` argument |
| Newtonsoft throughout | System.Text.Json (`allInfo` keeps Newtonsoft to match `ProblemProvider.info`) |

`allInfo` instantiates every interface (like `ProblemProvider.info`) but only on first call; instances are discarded after serialization and only the JSON string is retained.

## Testing

- `dotnet build` clean, `dotnet test` **689/689 pass** (+11).
- Verified live: batch output is element-for-element identical to the singular endpoints; `allInfo` byte-identical across calls.

## Frontend note

The companion frontend PR (ReduxISU/Redux_GUI#82) currently calls these endpoints via **POST** with a `?problemType=` query, matching #168. Against this backend those calls return **405** — the frontend needs to switch the five `requestAll*` helpers to `GET` (drop the unused `problemType`). Response shapes are otherwise compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)