### PR TITLE
feat(devcont): #365 mise task runner for dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,16 @@
 {
   "name": "Redux .NET Dev Container",
   "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
-  "//appPort": "Publishes 27000 to the host via `docker -p`, so it works from a plain terminal (devcontainer CLI), not just VS Code forwarding. The API binds 0.0.0.0 (see the mise `run` task).",
   "appPort": [27000],
   "portsAttributes": {
     "27000": { "label": "Redux API", "onAutoForward": "notify" }
   },
-  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "containerEnv": { "ASPNETCORE_URLS": "http://0.0.0.0:27000" },
+  "containerUser": "vscode",
   "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "postStartCommand": "if [ \"$(stat -c %U /workspaces/Redux)\" != \"vscode\" ]; then sudo chown -R vscode:vscode /workspaces/Redux; fi",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {
       "extensions": ["ms-dotnettools.csharp"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,21 +1,16 @@
 {
   "name": "Redux .NET Dev Container",
-  "image": "mcr.microsoft.com/dotnet/sdk:10.0",
-  "features": {
-    "ghcr.io/devcontainers/features/common-utils:2": {
-      "username": "vscode",
-      "installZsh": false,
-      "upgradePackages": false
-    }
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
+  "//appPort": "Publishes 27000 to the host via `docker -p`, so it works from a plain terminal (devcontainer CLI), not just VS Code forwarding. The API binds 0.0.0.0 (see the mise `run` task).",
+  "appPort": [27000],
+  "portsAttributes": {
+    "27000": { "label": "Redux API", "onAutoForward": "notify" }
   },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "remoteUser": "vscode",
   "customizations": {
     "vscode": {
-      "extensions": [
-        "ms-dotnettools.csharp"
-      ]
+      "extensions": ["ms-dotnettools.csharp"]
     }
-  },
-  "postStartCommand": "if [ \"$(stat -c %U /workspaces/Redux)\" != \"vscode\" ]; then sudo chown -R vscode:vscode /workspaces/Redux; fi",
-  "postCreateCommand": "dotnet --list-sdks"
+  }
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Post-create for the Redux devcontainer.
+#
+# The .NET 10 runtime comes from the base image. This script only layers in mise
+# (the unified task runner) and restores NuGet packages so the container is ready
+# to `mise run build|test|run`. See CLAUDE.md "Toolchain layering (DECIDED)".
+set -euo pipefail
+
+# 1. Install mise if the base image doesn't already provide it.
+if ! command -v mise >/dev/null 2>&1; then
+  curl -fsSL https://mise.run | sh
+fi
+MISE="${HOME}/.local/bin/mise"
+
+# 2. Activate mise for future interactive shells.
+ACTIVATE="eval \"\$(${MISE} activate bash)\""
+grep -qF "${ACTIVATE}" "${HOME}/.bashrc" 2>/dev/null || echo "${ACTIVATE}" >> "${HOME}/.bashrc"
+
+# 3. Trust this repo's mise.toml, then warm the NuGet cache via the shared task.
+"${MISE}" trust
+"${MISE}" run restore

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
-# Post-create for the Redux devcontainer.
-#
-# The .NET 10 runtime comes from the base image. This script only layers in mise
-# (the unified task runner) and restores NuGet packages so the container is ready
-# to `mise run build|test|run`. See CLAUDE.md "Toolchain layering (DECIDED)".
 set -euo pipefail
 
-# 1. Install mise if the base image doesn't already provide it.
+# Install mise if missing, then restore packages.
 if ! command -v mise >/dev/null 2>&1; then
   curl -fsSL https://mise.run | sh
 fi
 MISE="${HOME}/.local/bin/mise"
-
-# 2. Activate mise for future interactive shells.
-ACTIVATE="eval \"\$(${MISE} activate bash)\""
-grep -qF "${ACTIVATE}" "${HOME}/.bashrc" 2>/dev/null || echo "${ACTIVATE}" >> "${HOME}/.bashrc"
-
-# 3. Trust this repo's mise.toml, then warm the NuGet cache via the shared task.
+grep -qF 'mise activate bash' "${HOME}/.bashrc" 2>/dev/null || echo "eval \"\$(${MISE} activate bash)\"" >> "${HOME}/.bashrc"
 "${MISE}" trust
 "${MISE}" run restore

--- a/AdditionalControllers/Navigation/Nav_Batch.cs
+++ b/AdditionalControllers/Navigation/Nav_Batch.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+// Batch navigation endpoints: return metadata for ALL problems in a single
+// call so the GUI can prime its state with one request instead of N per-problem
+// round-trips.
+//
+// Everything here is projected from the same reflected data the singular
+// Navigation controllers already use — ProblemProvider.* and the *NavigationData
+// caches built once at startup (see Nav_Solvers/Nav_Verifiers/Nav_Visualizations).
+// Because the source of truth is shared, a batch response can never drift from its
+// per-problem counterpart.
+//
+// This deliberately does NOT scan the on-disk Problems/ layout, take a problemType
+// argument, or register an IMemoryCache the way the original proposal (upstream
+// PR #168) did: the reflected dictionaries are already a process-lifetime in-memory
+// cache, so each payload is serialized exactly once via Lazy<string>. Problem names
+// are unique across complexity classes, so no class filter is required.
+[ApiController]
+[Route("Navigation/[controller]")]
+[Tags("- Navigation (Batch)")]
+#pragma warning disable CS1591
+public class BatchController : ControllerBase
+{
+#pragma warning restore CS1591
+
+    private static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+
+    // All top-level problem names, from the same reflected source as the singular
+    // Navigation/*Problems* endpoints (see ProblemNavigationData in Nav_Problems.cs).
+    private static readonly Lazy<string> ProblemsJson = new(() =>
+        JsonSerializer.Serialize(ProblemNavigationData.All(), Indented));
+
+    private static readonly Lazy<string> SolversJson = new(() =>
+        GroupedJson(SolverNavigationData.Entries.Select(e => (e.problemName, e.className))));
+
+    private static readonly Lazy<string> VerifiersJson = new(() =>
+        GroupedJson(VerifierNavigationData.Entries.Select(e => (e.problemName, e.className))));
+
+    private static readonly Lazy<string> VisualizationsJson = new(() =>
+        GroupedJson(VisualizationNavigationData.Entries.Select(e => (e.problemName, e.className))));
+
+    // Instances of every reflected interface type, mirroring ProblemProvider.info
+    // (Newtonsoft + reference-loop ignore) but for all interfaces at once. Types that
+    // cannot be default-constructed are skipped rather than failing the whole payload.
+    private static readonly Lazy<string> InfoJson = new(() =>
+    {
+        var result = new Dictionary<string, object>();
+        foreach (var (_, type) in ProblemProvider.Interfaces)
+        {
+            try
+            {
+                if (Activator.CreateInstance(type) is object instance)
+                    result[type.Name] = instance;
+            }
+            catch
+            {
+                // Skip an interface that has no parameterless constructor instead of
+                // failing the whole response.
+            }
+        }
+        return Newtonsoft.Json.JsonConvert.SerializeObject(
+            result,
+            Newtonsoft.Json.Formatting.Indented,
+            new Newtonsoft.Json.JsonSerializerSettings
+            {
+                ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore
+            });
+    });
+
+    // Group (problemName -> className) pairs into a sorted map of sorted class names.
+    private static string GroupedJson(IEnumerable<(string problemName, string className)> entries) =>
+        JsonSerializer.Serialize(
+            entries
+                .GroupBy(e => e.problemName, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Select(e => e.className)
+                          .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
+                          .ToList(),
+                    StringComparer.OrdinalIgnoreCase),
+            Indented);
+
+    /// <summary>Returns every problem name in a single call.</summary>
+    /// <response code="200">String array of all problem names.</response>
+    [ProducesResponseType(typeof(List<string>), 200)]
+    [HttpGet("allProblems")]
+    public IActionResult AllProblems() => Content(ProblemsJson.Value, "application/json");
+
+    /// <summary>Returns the solvers for every problem, keyed by problem name.</summary>
+    /// <response code="200">Map of problem name to its solver class names.</response>
+    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 200)]
+    [HttpGet("allSolvers")]
+    public IActionResult AllSolvers() => Content(SolversJson.Value, "application/json");
+
+    /// <summary>Returns the verifiers for every problem, keyed by problem name.</summary>
+    /// <response code="200">Map of problem name to its verifier class names.</response>
+    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 200)]
+    [HttpGet("allVerifiers")]
+    public IActionResult AllVerifiers() => Content(VerifiersJson.Value, "application/json");
+
+    /// <summary>Returns the visualizations for every problem, keyed by problem name.</summary>
+    /// <response code="200">Map of problem name to its visualization class names.</response>
+    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 200)]
+    [HttpGet("allVisualizations")]
+    public IActionResult AllVisualizations() => Content(VisualizationsJson.Value, "application/json");
+
+    /// <summary>Returns info objects for every reflected interface, keyed by class name.</summary>
+    /// <response code="200">Map of interface class name to its instance info.</response>
+    [ProducesResponseType(typeof(Dictionary<string, object>), 200)]
+    [HttpGet("allInfo")]
+    public IActionResult AllInfo() => Content(InfoJson.Value, "application/json");
+}

--- a/AdditionalControllers/Navigation/Nav_Problems.cs
+++ b/AdditionalControllers/Navigation/Nav_Problems.cs
@@ -1,16 +1,63 @@
 using Microsoft.AspNetCore.Mvc;
-using System.IO;
-using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Collections.Generic;
-using System.Collections;
 
-//NOTE - Corbin: In order to add a controller for another file within /Problems, simply copy a specified controller (such as 'NPC_ProblemsRefactorController')
-//               paste and rename, the only changes needed is the path which defines subdirs for both functions: getDefault and getProblemsJson and update comments
+// Problem navigation resolved via reflection over ProblemProvider.Problems, so it no
+// longer depends on the on-disk Problems/ folder layout. Mirrors the solver / verifier
+// / visualization navigation (#317/#318/#331); those endpoints were converted earlier,
+// this closes the gap for the problem-listing endpoints.
+//
+// A problem's complexity class is read from its namespace: every problem lives in
+// API.Problems.<ComplexityClass>.<ProblemFolder> (e.g. API.Problems.NPComplete.NPC_SAT3).
+// Only these top-level problems are listed; nested helper variants such as
+// API.Problems.NPComplete.NPC_CLIQUE.Inherited (SipserClique) are excluded, matching the
+// old top-level directory scan.
+internal static class ProblemNavigationData
+{
+    internal class ProblemEntry
+    {
+        public string className { get; set; } = "";
+        public string complexityClass { get; set; } = "";
+    }
 
-//NOTE - Corbin: All specific controllers should probably be removed with the addition of tags, instead of one function per folder it should probably query a tag (like the NagGraph does for chosenProblem)
-//               in order to have one generalized specified problem controller
+    // Built once from reflected problem types.
+    internal static readonly List<ProblemEntry> Entries = Build();
+
+    private static List<ProblemEntry> Build()
+    {
+        var entries = new List<ProblemEntry>();
+        foreach (var (_, type) in ProblemProvider.Problems)
+        {
+            // Namespace is API . Problems . <ComplexityClass> . <ProblemFolder>.
+            // Anything deeper (…<Folder>.Inherited, .ReduceTo.*, …) is a nested helper
+            // problem, not a top-level listable one, so require exactly that shape.
+            string[] ns = (type.Namespace ?? "").Split('.');
+            int i = Array.IndexOf(ns, "Problems");
+            if (i < 0 || ns.Length != i + 3) continue;
+
+            entries.Add(new ProblemEntry
+            {
+                className = type.Name,
+                complexityClass = ns[i + 1],
+            });
+        }
+
+        return entries
+            .GroupBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .OrderBy(e => e.className, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    // All problem names, sorted (Entries is already sorted).
+    internal static List<string> All() => Entries.Select(e => e.className).ToList();
+
+    // Problem names for one complexity class (namespace segment: NPComplete / P / NPHard).
+    internal static List<string> ByComplexity(string complexityClass) =>
+        Entries
+            .Where(e => string.Equals(e.complexityClass, complexityClass, StringComparison.OrdinalIgnoreCase))
+            .Select(e => e.className)
+            .ToList();
+}
 
 // Get all problems
 [ApiController]
@@ -24,38 +71,14 @@ public class ALL_ProblemsRefactorController : ControllerBase
 
 ///<summary>Returns all problems</summary>
 ///<response code = "200">Returns string array of all problems regardless of class</response>
-    
+
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
 
     public String getDefault()
     {
-        string projectSourcePath = ProjectSourcePath.Value;
-        var allProblemDirNames = new List<string>();
-
-        foreach (var classDir in Directory.GetDirectories(projectSourcePath + @"Problems"))
-        {
-            foreach (var problemDir in Directory.GetDirectories(classDir))
-            {
-                var name = Path.GetFileName(problemDir);
-                if (name != null)
-                    allProblemDirNames.Add(name);
-            }
-        }
-        string?[] subdirs = allProblemDirNames.ToArray();
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.All(), options);
     }
 }
 
@@ -77,34 +100,8 @@ public class NPC_ProblemsRefactorController : ControllerBase
 
     public String getDefault()
     {
-        // File system patch that should work on both Window/Linux enviroments
-        string projectSourcePath = ProjectSourcePath.Value;
-        string?[] subdirs = Directory.GetDirectories(projectSourcePath + @"/Problems/NPComplete")
-                        .Select(Path.GetFileName)
-                        .ToArray();
-
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-
-        //NOTE - Corbin: below is someone elses commented out code, I am leaving it for now just in case it is needed.
-
-        // ProblemGraph graph = new ProblemGraph();
-        // graph.getConnectedNodes("SAT3");
-        // string ring = JsonSerializer.Serialize(graph.getConnectedNodes("SAT3"), options);
-        //  Console.WriteLine("\n"+ring );
-
-        //Response.Headers.Add("Access-Control-Allow-Origin", "http://127.0.0.1:5500");
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.ByComplexity("NPComplete"), options);
     }
 }
 
@@ -119,32 +116,15 @@ public class P_ProblemsRefactorController : ControllerBase
 #pragma warning restore CS1591
 
     ///<summary>Returns all P-Class problems </summary>
-    ///<response code="200">Returns string array of all NP-Complete problems</response>
+    ///<response code="200">Returns string array of all P-Class problems</response>
 
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
 
     public String getDefault()
     {
-        // File system patch that should work on both Window/Linux enviroments
-        string projectSourcePath = ProjectSourcePath.Value;
-        string?[] subdirs = Directory.GetDirectories(projectSourcePath + @"/Problems/P")
-                        .Select(Path.GetFileName)
-                        .ToArray();
-
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.ByComplexity("P"), options);
     }
 
 }
@@ -160,32 +140,15 @@ public class NPHard_ProblemsRefactorController : ControllerBase
 #pragma warning restore CS1591
 
     ///<summary>Returns all NPHard problems </summary>
-    ///<response code="200">Returns string array of all NP-Complete problems</response>
+    ///<response code="200">Returns string array of all NP-Hard problems</response>
 
     [ProducesResponseType(typeof(string[]), 200)]
     [HttpGet]
 
     public String getDefault()
     {
-        // File system patch that should work on both Window/Linux enviroments
-        string projectSourcePath = ProjectSourcePath.Value;
-        string?[] subdirs = Directory.GetDirectories(projectSourcePath + @"/Problems/NPHard")
-                        .Select(Path.GetFileName)
-                        .ToArray();
-
-        ArrayList subdirsNoPrefix = new ArrayList();
-        foreach (var problemDirName in subdirs)
-        {
-            if (problemDirName is null)
-                continue;
-            string[] splitStr = problemDirName.Split('_');
-            string newName = splitStr[1];
-            subdirsNoPrefix.Add(newName);
-        }
-
         var options = new JsonSerializerOptions { WriteIndented = true };
-        string jsonString = JsonSerializer.Serialize(subdirsNoPrefix, options);
-        return jsonString;
+        return JsonSerializer.Serialize(ProblemNavigationData.ByComplexity("NPHard"), options);
     }
 
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,17 @@ By submitting a contribution (pull request, patch, or code submission), you conf
 
 ## How to Contribute
 
+### Development environment
+
+The easiest way to develop is the **dev container**: it provides the correct .NET 10 toolchain
+and a shared `mise run <task>` command set, so you install nothing on your host and your
+environment matches CI. Open the repo in VS Code (**Reopen in Container**) or run
+`devcontainer up` from a terminal. See **Quick Start → Recommended: Dev Container** in the
+[README](./Readme.md) for full setup.
+
+Inside the container: `mise run run` starts the API on `http://localhost:27000`, and
+`mise run test` runs the full test suite.
+
 ### 1. Fork the repository
 Create your own fork of the project.
 
@@ -40,7 +51,7 @@ Use a descriptive branch name:
 
 ### 4. Test your changes
 - Ensure the project builds successfully
-- Run any existing tests
+- Run any existing tests (`mise run test` in the dev container)
 - Add tests if applicable
 
 ### 5. Submit a Pull Request (PR)

--- a/Interfaces/JSON_Objects/Tables/API_TableJSON.cs
+++ b/Interfaces/JSON_Objects/Tables/API_TableJSON.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace API.Interfaces.JSON_Objects.Tables;
+
+class API_TableJSON : API_JSON
+{
+    public List<TableColumn> columns { get; set; } = new();
+    public List<TableRow> rows { get; set; } = new();
+
+}

--- a/Interfaces/JSON_Objects/Tables/TableColumn.cs
+++ b/Interfaces/JSON_Objects/Tables/TableColumn.cs
@@ -1,0 +1,7 @@
+namespace API.Interfaces.JSON_Objects.Tables;
+
+class TableColumn
+{
+    public string key { get; set; } = "";
+    public string label { get; set; } = "";
+}

--- a/Interfaces/JSON_Objects/Tables/TableRow.cs
+++ b/Interfaces/JSON_Objects/Tables/TableRow.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace API.Interfaces.JSON_Objects.Tables;
+
+class TableRow
+{
+    public string id { get; set; } = "";
+    public string? color { get; set; }
+    public Dictionary<string, string> cells = new();
+    public Dictionary<string, string>? cellColors;
+}

--- a/Interfaces/JSON_Objects/Tables/TableRow.cs
+++ b/Interfaces/JSON_Objects/Tables/TableRow.cs
@@ -6,6 +6,6 @@ class TableRow
 {
     public string id { get; set; } = "";
     public string? color { get; set; }
-    public Dictionary<string, string> cells = new();
-    public Dictionary<string, string>? cellColors;
+    public Dictionary<string, string> cells { get; set; } = new();
+    public Dictionary<string, string>? cellColors { get; set; }
 }

--- a/Problems/P/P_SSSP/P_SSSP.cs
+++ b/Problems/P/P_SSSP/P_SSSP.cs
@@ -53,6 +53,227 @@ class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilColl
 
     public SSSP(string GInput)
     {
-        throw new NotImplementedException("SSSP constructor to be implemented");
+        ParsedShortestPathInstance parsed = ParseInstance(GInput);
+        nodes = parsed.Nodes;
+        edges = parsed.Edges;
+        sourceNode = parsed.SourceNode;
+        isDirected = parsed.IsDirected;
+        isWeighted = parsed.IsWeighted;
+        graph = new UtilCollectionGraph(parsed.NodeCollection, parsed.EdgeCollection);
     }
+
+    private static ParsedShortestPathInstance ParseInstance(string rawInstance)
+    {
+        string graphInput = rawInstance;
+        string? explicitSource = null;
+
+        List<string> outerTerms = SplitOuterTuple(rawInstance);
+        if (outerTerms.Count == 3)
+        {
+            graphInput = $"({outerTerms[0]},{outerTerms[1]})";
+            explicitSource = outerTerms[2];
+        }
+        else if (outerTerms.Count == 2 && LooksLikeTuple(outerTerms[0]))
+        {
+            graphInput = outerTerms[0];
+            explicitSource = outerTerms[1];
+        }
+
+        GraphParseResult graphParse = ParseGraph(graphInput);
+        UtilCollection nodeCollection = graphParse.Parser["N"] ?? throw new InvalidOperationException("Failed to parse N (nodes)");
+        UtilCollection edgeCollection = graphParse.Parser["E"] ?? throw new InvalidOperationException("Failed to parse E (edges)");
+
+        List<string> parsedNodes = nodeCollection.ToList().Select(node => node.ToString()).ToList();
+        List<KeyValuePair<string, string>> parsedEdges = ToEdgePairs(edgeCollection);
+
+        ValidateInstance(parsedNodes, edgeCollection, explicitSource);
+
+        string resolvedSource = explicitSource ?? (parsedNodes.Count > 0 ? parsedNodes[0] : string.Empty);
+
+        return new ParsedShortestPathInstance(
+            nodeCollection,
+            edgeCollection,
+            parsedNodes,
+            parsedEdges,
+            resolvedSource,
+            graphParse.IsDirected,
+            graphParse.IsWeighted);
+    }
+
+    private static GraphParseResult ParseGraph(string graphInput)
+    {
+        (string Pattern, bool IsDirected, bool IsWeighted)[] parseAttempts =
+        {
+            ("{(N,E) | N is set, E subset {(e,w) | e is N cross N, w is int}}", true, true),
+            ("{(N,E) | N is set, E subset {(e,w) | e is unorderedcross N, w is int}}", false, true),
+            ("{(N,E) | N is set, E subset N cross N}", true, false),
+            ("{(N,E) | N is set, E subset unorderedcross N", false, false)
+        };
+
+        Exception? lastError = null;
+        foreach (var attempt in parseAttempts)
+        {
+            try
+            {
+                StringParser parser = new(attempt.Pattern);
+                parser.parse(graphInput);
+                return new GraphParseResult(parser, attempt.IsDirected, attempt.IsWeighted);
+            }
+            catch (Exception e)
+            {
+                lastError = e;
+            }
+        }
+
+        throw new InvalidOperationException("Failed to parse SSSP instance.", lastError);
+    }
+
+    private static void ValidateInstance(
+        List<string> parsedNodes,
+        UtilCollection edgeCollection,
+        string? explicitSource)
+    {
+        HashSet<string> nodeSet = parsedNodes.ToHashSet();
+
+        if (explicitSource != null && !nodeSet.Contains(explicitSource))
+            throw new InvalidOperationException($"Source node '{explicitSource}' is not in N");
+
+        foreach(UtilCollection rawEdge in edgeCollection)
+        {
+            ParsedEdge edge = ParseEdge(rawEdge);
+
+            if (!nodeSet.Contains(edge.From))
+                throw new InvalidOperationException($"Edge source '{edge.From}' is not in N.");
+
+            if (!nodeSet.Contains(edge.To))
+                throw new InvalidOperationException($"Edge target '{edge.To}' is not in N.");
+
+            if (edge.Weight < 0)
+                throw new InvalidOperationException("SSSP using Dijkstra's algorithm does not handle negative edge-weights.");
+        }
+    }
+
+    private static List<KeyValuePair<string, string>> ToEdgePairs(UtilCollection edgeCollection)
+    {
+        return edgeCollection.ToList().Select(rawEdge =>
+        {
+            ParsedEdge edge = ParseEdge(rawEdge);
+            return new KeyValuePair<string, string>(edge.From, edge.To);
+        }).ToList();
+    }
+
+    private static ParsedEdge ParseEdge(UtilCollection rawEdge)
+    {
+        bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+        bool secondLooksLikeCollection = rawEdge.Count() > 1 && LooksLikeCollection(rawEdge[1]);
+        bool isWeighted = rawEdge.Count() == 2 && firstLooksLikeCollection && !secondLooksLikeCollection;
+
+        if (isWeighted)
+        {
+            UtilCollection endpoints = rawEdge[0];
+            int weight = int.Parse(rawEdge[1].ToString());
+
+            if (weight < 0)
+                throw new InvalidOperationException($"SSSP using Dijkstra's algorithm does not allow negative edge weights. Found edge weight: {weight}");
+
+            return new ParsedEdge(GetFrom(endpoints), GetTo(endpoints), weight);
+        }
+
+        return new ParsedEdge(GetFrom(rawEdge), GetTo(rawEdge), 1);
+    }
+
+    private static bool LooksLikeCollection(UtilCollection value)
+    {
+        string text = value.ToString().TrimStart();
+        return text.StartsWith("{") || text.StartsWith("(");
+    }
+
+    private static string GetFrom(UtilCollection endpoints)
+    {
+        if (endpoints.IsOrdered())
+            return endpoints[0].ToString();
+
+        List<UtilCollection> cast = endpoints.ToList();
+        return cast[0].ToString();
+    }
+
+    private static string GetTo(UtilCollection endpoints)
+    {
+        if (endpoints.IsOrdered())
+            return endpoints[1].ToString();
+
+        List<UtilCollection> cast = endpoints.ToList();
+        if (cast.Count == 1)
+            return cast[0].ToString();
+
+        return cast[1].ToString();
+    }
+
+    private static bool LooksLikeTuple(string value)
+    {
+        return value.TrimStart().StartsWith("(");
+    }
+
+    private static List<string> SplitOuterTuple(string input)
+    {
+        string trimmed = input.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '(' || trimmed[^1] != ')')
+            return new List<string>();
+
+        string inner = trimmed[1..^1];
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        int parenDepth = 0;
+        int braceDepth = 0;
+        int bracketDepth = 0;
+
+        foreach (char ch in inner)
+        {
+            if (ch == ',' && parenDepth == 0 && braceDepth == 0 && bracketDepth == 0)
+            {
+                parts.Add(current.ToString().Trim());
+                current.Clear();
+                continue;
+            }
+
+            current.Append(ch);
+            switch (ch)
+            {
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    parenDepth--;
+                    break;
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    braceDepth--;
+                    break;
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    bracketDepth--;
+                    break;
+            }
+        }
+
+        if (current.Length > 0)
+            parts.Add(current.ToString().Trim());
+
+        return parts;
+    }
+
+    private sealed record GraphParseResult(StringParser Parser, bool IsDirected, bool IsWeighted);
+    private sealed record ParsedShortestPathInstance(
+        UtilCollection NodeCollection,
+        UtilCollection EdgeCollection,
+        List<string> Nodes,
+        List<KeyValuePair<string, string>> Edges,
+        string SourceNode,
+        bool IsDirected,
+        bool IsWeighted);
+    private sealed record ParsedEdge(string From, string To, int Weight);
 }

--- a/Problems/P/P_SSSP/P_SSSP.cs
+++ b/Problems/P/P_SSSP/P_SSSP.cs
@@ -20,8 +20,7 @@ class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilColl
     public string problemDefinition { get; } = "Single Source Shortest Path (SSSP) in a weighted graph is the problem of determining the shortest path from a source vertex to all other reachable vertices in the graph such that the sum of edge weights along each path is minimized.";
     public string source { get; } = "N/A";
     public string sourceLink { get; } = "N/A";
-    private static string _defaultInstance =
-    "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
+    private static string _defaultInstance = "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
     public string defaultInstance { get; } = _defaultInstance;
     public string instance { get; set; } = string.Empty;
     public string wikiName { get; } = "";
@@ -53,6 +52,8 @@ class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilColl
 
     public SSSP(string GInput)
     {
+        instance = GInput;
+
         ParsedShortestPathInstance parsed = ParseInstance(GInput);
         nodes = parsed.Nodes;
         edges = parsed.Edges;

--- a/Problems/P/P_SSSP/P_SSSP.cs
+++ b/Problems/P/P_SSSP/P_SSSP.cs
@@ -1,0 +1,58 @@
+using Antlr4.Runtime;
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
+using API.Problems.P.P_SSSP.Visualizations;
+using SPADE;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace API.Problems.P.P_SSSP;
+
+class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilCollectionGraph>
+{
+    // --- Fields ---
+    public string problemName { get; } = "Single Source Shortest Path Problem";
+    public string problemLink { get; } = "https://en.wikipedia.org/wiki/Shortest_path_problem";
+    public string formalDefinition { get; } = "For a weighted graph G = (V,E), with non-negative edge weights, a source vertex s \u2208 V, find the shortest path distance from s to every other vertex v \u2208 V, where path length is defined as the sum of edge weights along the path.";
+    public string problemDefinition { get; } = "Single Source Shortest Path (SSSP) in a weighted graph is the problem of determining the shortest path from a source vertex to all other reachable vertices in the graph such that the sum of edge weights along each path is minimized.";
+    public string source { get; } = "N/A";
+    public string sourceLink { get; } = "N/A";
+    private static string _defaultInstance =
+    "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
+    public string defaultInstance { get; } = _defaultInstance;
+    public string instance { get; set; } = string.Empty;
+    public string wikiName { get; } = "";
+    public string sourceNode { get; private set; } = string.Empty;
+    public bool isDirected { get; private set; }
+    public bool isWeighted { get; private set; }
+    private List<string> _nodes = new List<string>();
+    private List<KeyValuePair<string, string>> _edges = new List<KeyValuePair<string, string>>();
+    public SSSPSolver defaultSolver { get; } = new SSSPSolver();
+    public SSSPVerifier defaultVerifier { get; } = new SSSPVerifier();
+    public SSSPVisualization defaultVisualization { get; } = new SSSPVisualization();
+    public UtilCollectionGraph graph { get; set; }
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+
+    // --- Properties ---
+    public List<string> nodes
+    {
+        get => _nodes;
+        set => _nodes = value;
+    }
+    public List<KeyValuePair<string, string>> edges
+    {
+        get => _edges;
+        set => _edges = value;
+    }
+
+    // --- Methods Including Constructor ---
+    public SSSP() : this(_defaultInstance) { }
+
+    public SSSP(string GInput)
+    {
+        throw new NotImplementedException("SSSP constructor to be implemented");
+    }
+}

--- a/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
+++ b/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
@@ -302,6 +302,8 @@ class SSSPSolver : ISolver<SSSP>
         public string name { get; set; } = "";
         public string display { get; set; } = "\u221E";
         public string? path { get; set; }
+        public bool known { get; set; }
+        public string order { get; set; } = "";
     }
 
     public class SSSPTableStep : API_JSON
@@ -328,12 +330,14 @@ class SSSPSolver : ISolver<SSSP>
         var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
         var prev = nodes.ToDictionary(n => n, _ => (string?)null);
         var visited = new HashSet<string>();
+        var finalizationOrder = new Dictionary<string, int>();
+        int orderCounter = 1;
         pq = new PriorityQueue<string, int>();
 
         dist[sourceNode] = 0;
         pq.Enqueue(sourceNode, 0);
 
-        steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+        steps.Add(BuildTableStep(nodes, dist, prev, visited, finalizationOrder, currentVertex: null, sourceVertex: sourceNode));
 
         while(pq.Count > 0)
         {
@@ -346,8 +350,9 @@ class SSSPSolver : ISolver<SSSP>
                 continue;
 
             visited.Add(current);
+            finalizationOrder[current] = orderCounter++;
 
-            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, finalizationOrder, currentVertex: null, sourceVertex: sourceNode));
 
             if (!adjacency.TryGetValue(current, out var neighbors))
                 continue;
@@ -368,7 +373,9 @@ class SSSPSolver : ISolver<SSSP>
                     pq.Enqueue(next, candidate);
                 }
             }
-            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: current, sourceVertex: sourceNode));
+            bool isLastVertex = pq.Count == 0 || pq.UnorderedItems.All(item => visited.Contains(item.Element));
+
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, finalizationOrder, currentVertex: isLastVertex ? null: current, sourceVertex: sourceNode));
         }
         return steps;
     }
@@ -378,6 +385,7 @@ class SSSPSolver : ISolver<SSSP>
         Dictionary<string, int> dist,
         Dictionary<string, string?> prev,
         HashSet<string> visited,
+        Dictionary<string, int> finalizationOrder,
         string? currentVertex,
         string? sourceVertex)
     {
@@ -391,10 +399,12 @@ class SSSPSolver : ISolver<SSSP>
                 name = n,
                 display = dist[n] == int.MaxValue
                     ? "\u221E"
-                    : (prev[n] != null ? $"{dist[n]}, {prev[n]}" : $"{dist[n]}"),
+                    : (prev[n] != null ? $"{dist[n]},{prev[n]}" : $"{dist[n]}"),
                 path = dist[n] == int.MaxValue
                     ? null
-                    : NodeListToCertificate(ReconstructPath(prev, sourceVertex, n))
+                    : NodeListToCertificate(ReconstructPath(prev, sourceVertex, n)),
+                known = visited.Contains(n),
+                order = finalizationOrder.ContainsKey(n) ? finalizationOrder[n].ToString() : ""
             }).ToList()
         };
     }

--- a/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
+++ b/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
@@ -1,0 +1,22 @@
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using API.Interfaces.JSON_Objects;
+using SPADE;
+using System;
+
+namespace API.Problems.P.P_SSSP.Solvers;
+
+class SSSPSolver : ISolver<SSSP>
+{
+    public string solverName { get; } = "Dijkstra's Algorithm";
+    public string solverDefinition { get; } = "";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    public bool timerHasExpired { get; set; }
+    PriorityQueue<string, int>? pq;
+
+    public string solve(SSSP problem)
+    {
+        return ""; // To Do Dijkstra's algorithm implementation for SSSP problem
+    }
+}

--- a/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
+++ b/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
@@ -3,6 +3,7 @@ using API.Interfaces.Graphs;
 using API.Interfaces.JSON_Objects;
 using SPADE;
 using System;
+using System.Collections.Generic;
 
 namespace API.Problems.P.P_SSSP.Solvers;
 
@@ -17,6 +18,384 @@ class SSSPSolver : ISolver<SSSP>
 
     public string solve(SSSP problem)
     {
-        return ""; // To Do Dijkstra's algorithm implementation for SSSP problem
+        UtilCollectionGraph graph = problem.graph;
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return "{}"; // No nodes, return empty path
+
+        string sourceNode = problem.sourceNode;
+
+        if (!nodes.Contains(sourceNode))
+            return "{}";
+
+        var adjacency = BuildAdjacencyList(graph);
+
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        while(pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return "{}";
+
+            string current = pq.Dequeue();
+
+            if (visited.Contains(current))
+                continue;
+            visited.Add(current);
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if(candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+        }
+
+        return NodeListCertificate(nodes, sourceNode, prev);
+    }
+
+    internal static Dictionary<string, List<(string neighbor, int weight)>> BuildAdjacencyList(UtilCollectionGraph graph)
+    {
+        var adjacency = new Dictionary<string, List<(string neigbor, int weight)>>();
+
+        if (graph.Nodes.Count() == 0)
+            return adjacency; // No edges, so return empty adjacency list
+
+        foreach(UtilCollection rawEdge in graph.Edges.ToList())
+        {
+            // check if edge is weighted
+            bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+            bool secondLooksLikeCollection = LooksLikeCollection(rawEdge[1]);
+            bool isWeighted = rawEdge.Count() == 2 && firstLooksLikeCollection && !secondLooksLikeCollection;
+
+            if(isWeighted)
+            {
+                UtilCollection endpoints = rawEdge[0];
+                int w = int.Parse(rawEdge[1].ToString());
+
+                if (endpoints.IsOrdered())
+                    AddDirected(adjacency, endpoints[0].ToString(), endpoints[1].ToString(), w);
+                else
+                {
+                    var cast = endpoints.ToList();
+                    if(cast.Count == 1)
+                    {
+                        string v = cast[0].ToString();
+                        AddDirected(adjacency, v, v, w);
+                    }
+                    else
+                    {
+                        string a = cast[0].ToString();
+                        string b = cast[1].ToString();
+                        AddDirected(adjacency, a, b, w);
+                        AddDirected(adjacency, b, a, w);
+                    }
+                }
+            }
+            else
+            {
+                int w = 1; // Assign the weight 1 by default if there is no assigned weight
+
+                if (rawEdge.IsOrdered())
+                    AddDirected(adjacency, rawEdge[0].ToString(), rawEdge[1].ToString(), w);
+                else
+                {
+                    var cast = rawEdge.ToList();
+                    if (cast.Count == 1)
+                    {
+                        string v = cast[0].ToString();
+                        AddDirected(adjacency, v, v, w);
+                    }
+                    else
+                    {
+                        string a = cast[0].ToString();
+                        string b = cast[1].ToString();
+                        AddDirected(adjacency, a, b, w);
+                        AddDirected(adjacency, b, a, w);
+                    }
+                }
+            }
+        }
+        return adjacency;
+    }
+
+    // AddDirected: Adds a directed edge to the adjacency list
+    private static void AddDirected(Dictionary<string, List<(string neighbor, int weight)>> adjacency, string from, string to, int weight)
+    {
+        if(!adjacency.TryGetValue(from, out var list))
+        {
+            list = new List<(string neighbor, int weight)>();
+            adjacency[from] = list;
+        }
+        list.Add((to, weight));
+
+        if (!adjacency.ContainsKey(to))
+            adjacency[to] = new List<(string, int)>();
+    }
+
+    // ReconstructPath: Reconstructs the path from source to each node using the previous dictionionary
+    internal static List<string> ReconstructPath(Dictionary<string, string?> prev, string? source, string target)
+    {
+        var path = new List<string>();
+        string? current = target;
+
+        while(current != null)
+        {
+            path.Add(current);
+            if(current == source)
+            {
+                break; // Stop if we've reached the source node
+            }
+            current = prev[current];
+        }
+
+        path.Reverse(); // Reverse the list so path order is source to target
+
+        if(path.Count == 0 || path[0] != source)
+        {
+            return new List<string>(); // No valid path
+        }
+        return path;
+    }
+
+    // NodeListCertificate: Converts a set of (node, path) tuples for every node in the graph
+    internal static string NodeListCertificate(List<string> nodes, string sourceNode, Dictionary<string, string?> prev)
+    {
+        var entries = new List<string>();
+
+        foreach(string node in nodes)
+        {
+            List<string> path = ReconstructPath(prev, sourceNode, node);
+            string pathCertificate = NodeListToCertificate(path);
+            entries.Add($"({node},{pathCertificate})");
+        }
+
+        return "{" + string.Join(",", entries) + "}";
+    }
+
+    // NodeListToCertificate: Converts a list of nodes into the certificate form
+    internal static string NodeListToCertificate(List<string> nodes)
+    {
+        if (nodes == null || nodes.Count == 0)
+            return "{}";
+        return "{" + string.Join(",", nodes) + "}";
+    }
+
+    // LooksLikeCollection: Helper method to determine if a UtilCollection looks like a collection
+    private static bool LooksLikeCollection(UtilCollection u)
+    {
+        string s = u.ToString().TrimStart();
+        return s.StartsWith("{") || s.StartsWith("(");
+    }
+
+    public class SSSPGraphStep
+    {
+        public string? currentNode { get; set; } // node just settled in this step
+        public string? currentEdgeFrom { get; set; } // winning edge that determines the shortest path for node
+        public List<string> knownNodes { get; set; } = new(); // all settled nodes so far
+        public List<(string from, string to)> treeEdges { get; set; } = new(); // accepted tree edges so far
+    }
+
+    // GetSteps: The steps are returned as a list of string, where each string represents a path in the certificate format
+    public List<Object> GetSteps(SSSP problem)
+    {
+        var steps = new List<Object>();
+        UtilCollectionGraph graph = problem.graph;
+
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return steps;
+
+        string sourceNode = problem.sourceNode;
+
+        var adjacency = BuildAdjacencyList(graph);
+
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        while(pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return steps;
+
+            string current = pq.Dequeue();
+            if (visited.Contains(current))
+                continue;
+
+            visited.Add(current);
+
+            steps.Add(BuildGraphStep(current, prev, visited));
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue;
+
+                if (weight < 0)
+                    return steps;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if(candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+        }
+        return steps;
+    }
+
+    // BuildGraphStep: assembles one snapshot of the shortest path tree's state
+    private static SSSPGraphStep BuildGraphStep(string current, Dictionary<string, string?> prev, HashSet<string> visited)
+    {
+        var treeEdges = new List<(string from, string to)>();
+        foreach(var predecessor in prev)
+        {
+            if (predecessor.Value != null)
+                treeEdges.Add((predecessor.Value, predecessor.Key));
+        }
+
+        return new SSSPGraphStep
+        {
+            currentNode = current,
+            currentEdgeFrom = prev[current],
+            knownNodes = visited.ToList(),
+            treeEdges = treeEdges
+        };
+    }
+
+    public class SSSPTableStepVertex
+    {
+        public string name { get; set; } = "";
+        public string display { get; set; } = "\u221E";
+        public string? path { get; set; }
+    }
+
+    public class SSSPTableStep : API_JSON
+    {
+        public List<SSSPTableStepVertex> vertices { get; set; } = new();
+        public List<string> knownSet { get; set; } = new();
+        public string? currentVertex { get; set; }
+        public string? sourceVertex { get; set; }
+    }
+
+    public List<Object> GetTableSteps(SSSP problem)
+    {
+        var steps = new List<Object>();
+        UtilCollectionGraph graph = problem.graph;
+
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return steps;
+
+        string sourceNode = problem.sourceNode;
+
+        var adjacency = BuildAdjacencyList(graph);
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+
+        while(pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return steps;
+
+            string current = pq.Dequeue();
+
+            if (visited.Contains(current))
+                continue;
+
+            visited.Add(current);
+
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if (candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: current, sourceVertex: sourceNode));
+        }
+        return steps;
+    }
+
+    private static SSSPTableStep BuildTableStep(
+        List<string> nodes,
+        Dictionary<string, int> dist,
+        Dictionary<string, string?> prev,
+        HashSet<string> visited,
+        string? currentVertex,
+        string? sourceVertex)
+    {
+        return new SSSPTableStep
+        {
+            currentVertex = currentVertex,
+            sourceVertex = sourceVertex,
+            knownSet = visited.ToList(),
+            vertices = nodes.Select(n => new SSSPTableStepVertex
+            {
+                name = n,
+                display = dist[n] == int.MaxValue
+                    ? "\u221E"
+                    : (prev[n] != null ? $"{dist[n]}, {prev[n]}" : $"{dist[n]}"),
+                path = dist[n] == int.MaxValue
+                    ? null
+                    : NodeListToCertificate(ReconstructPath(prev, sourceVertex, n))
+            }).ToList()
+        };
     }
 }

--- a/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
+++ b/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 using API.Interfaces;
 using API.Interfaces.Graphs.GraphParser;
 using API.Problems.P.P_SSSP.Solvers;
@@ -16,9 +18,182 @@ class SSSPVerifier : IVerifier<SSSP>
 
     public SSSPVerifier() { }
 
+    // verify : takes a problem instance and a solution certificate,
+    // and returns true if the certificate is a valid solution to the problem instance
+    // and false otherwise
     public bool verify(SSSP problem, string solution)
     {
-        return true;    //To Do
-                        //Placeholder for now, will implement verifier logic 
+        _certificate = solution ?? "";
+
+        var nodes = problem.graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return solution == "{}" || string.IsNullOrWhiteSpace(solution);
+
+        string sourceNode = problem.sourceNode;
+        var adjacency = SSSPSolver.BuildAdjacencyList(problem.graph);
+
+        // Compute shortest distance for each node
+        var trueDist = AllShortestDistances(adjacency, nodes, sourceNode);
+
+        // Parse the certificate as a set of (node, path) tuples
+        Dictionary<string, List<string>> certPaths;
+        try
+        {
+            certPaths = ParseSSSPCertificate(_certificate);
+        }
+        catch
+        {
+            return false; // Invalid certificate format
+        }
+
+        if (certPaths.Count != nodes.Count || !nodes.All(n => certPaths.ContainsKey(n)))
+            return false;
+
+        foreach(string node in nodes)
+        {
+            List<string> path = certPaths[node];
+            bool trueUnreachable = trueDist[node] == null;
+
+            if(path.Count == 0)
+            {
+                if(!trueUnreachable)
+                {
+                    return false; // certificate says unreachable, but actually reachable
+                }
+                continue;
+            }
+
+            if (trueUnreachable)
+                return false; // certificate gives a path for a node that is actually unreachable
+
+            if (path[0] != sourceNode || path[^1] != node)
+                return false; // path must start at the source and end at the node
+
+            int length = 0;
+            for(int i = 0; i < path.Count -1; i++)
+            {
+                string u = path[i];
+                string v = path[i + 1];
+
+                if (!adjacency.TryGetValue(u, out var neighbors))
+                    return false;
+
+                var weights = neighbors.Where(e => e.neighbor == v).Select(e => e.weight).ToList();
+                if (weights.Count == 0)
+                    return false;
+
+                int w = weights.Min();
+                if (w < 0)
+                    return false;
+
+                length += w;
+            }
+            if (length != trueDist[node])
+                return false; // path exists but is not the shortest
+        }
+        return true; 
+    }
+
+    private static Dictionary<string, int?> AllShortestDistances(Dictionary<string, List<(string neighbor, int weight)>> adjacency, List<string> allNodes, string source)
+    {
+        var dist = allNodes.ToDictionary(n => n, _ => int.MaxValue);
+        var visited = new HashSet<string>();
+        var pq = new PriorityQueue<string, int>();
+
+        dist[source] = 0;
+        pq.Enqueue(source, 0);
+
+        while(pq.Count > 0)
+        {
+            string current = pq.Dequeue();
+            if (visited.Contains(current))
+                continue;
+            visited.Add(current);
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (weight < 0)
+                    throw new InvalidOperationException("SSSP using Dijkstra's algorithm cannot handle negative edge weights.");
+
+                if (visited.Contains(next))
+                    continue;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if(candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    pq.Enqueue(next, candidate);
+                }    
+            }
+        }
+        return allNodes.ToDictionary(n => n, n => dist[n] == int.MaxValue ? (int?)null : dist[n]);
+    }
+
+    private static Dictionary<string, List<string>> ParseSSSPCertificate(string certificate)
+    {
+        var result = new Dictionary<string, List<string>>();
+
+        string trimmed = certificate.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '{' || trimmed[^1] != '}')
+            throw new FormatException("Certificate must be wrapped in { }");
+
+        string inner = trimmed.Substring(1, trimmed.Length - 2).Trim();
+        if (inner.Length == 0)
+            return result; // empty certificate, no entries
+
+        List<string> tupleChunks = SplitTopLevel(inner);
+
+        foreach(string chunk in tupleChunks)
+        {
+            string tupleInner = chunk.Trim();
+            if (tupleInner.Length < 2 || tupleInner[0] != '(' || tupleInner[^1] != ')')
+                throw new FormatException($"Malformed tuple: {chunk}");
+
+            tupleInner = tupleInner.Substring(1, tupleInner.Length - 2);
+
+            // splits just the outer tuple into exactly 2 top-level pieces: node, path
+            List<string> parts = SplitTopLevel(tupleInner);
+            if (parts.Count != 2)
+                throw new FormatException($"Expected (node, path) pair, got: {chunk}");
+
+            string node = parts[0].Trim();
+            string pathStr = parts[1].Trim();
+
+            List<string> path = pathStr == "{}" ? new List<string>() : GraphParser.parseNodeListWithStringFunctions(pathStr);
+
+            result[node] = path;
+        }
+        return result;
+    }
+
+    // SplitTopLevel: splits a string on commas that sit at depth 0 (ignoring commas nested inside { } or ( ))
+    private static List<string> SplitTopLevel(string s)
+    {
+        var parts = new List<string>();
+        int depth = 0;
+        int start = 0;
+
+        for(int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c == '{' || c == '(')
+                depth++;
+            else if (c == '}' || c == ')')
+                depth--;
+            else if(c == ',' && depth == 0)
+            {
+                parts.Add(s.Substring(start, i - start));
+                start = i + 1;
+            }
+        }
+        parts.Add(s.Substring(start));
+        return parts;
     }
 }

--- a/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
+++ b/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
@@ -1,0 +1,24 @@
+using System;
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Problems.P.P_SSSP.Solvers;
+
+namespace API.Problems.P.P_SSSP.Verifiers;
+
+class SSSPVerifier : IVerifier<SSSP>
+{
+    public string verifierName { get; } = "Single Source Shortest Path Verifier";
+    public string verifierDefinition { get; } = "Verifies the solution for the Single Source Shortest Path problem";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    private string _certificate = "";
+    public string certificate => _certificate;
+
+    public SSSPVerifier() { }
+
+    public bool verify(SSSP problem, string solution)
+    {
+        return true;    //To Do
+                        //Placeholder for now, will implement verifier logic 
+    }
+}

--- a/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
+++ b/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
@@ -136,7 +136,7 @@ class SSSPVerifier : IVerifier<SSSP>
         return allNodes.ToDictionary(n => n, n => dist[n] == int.MaxValue ? (int?)null : dist[n]);
     }
 
-    private static Dictionary<string, List<string>> ParseSSSPCertificate(string certificate)
+    public static Dictionary<string, List<string>> ParseSSSPCertificate(string certificate)
     {
         var result = new Dictionary<string, List<string>>();
 

--- a/Problems/P/P_SSSP/Visualizations/SSSPTableVisualization.cs
+++ b/Problems/P/P_SSSP/Visualizations/SSSPTableVisualization.cs
@@ -1,0 +1,80 @@
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Tables;
+using API.Problems.P.P_SSSP.Solvers;
+using SSSPTableStep = API.Problems.P.P_SSSP.Solvers.SSSPSolver.SSSPTableStep;
+
+namespace API.Problems.P.P_SSSP.Visualizations;
+
+class SSSPTableVisualization : IVisualization<SSSP>
+{
+    public string visualizationName { get; } = "SSSP Table Visualization";
+    public string visualizationDefinition { get; } = "Displays a step-by-step table visualization of Dijkstra's alogrithm execution, showing each vertex's cost/predecessor and reconstructed path at each stage";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    public string visualizationType => "Dynamic Table";
+    public ISolver solver { get; } = new SSSPSolver();
+
+    public SSSPTableVisualization() { }
+
+    public API_JSON visualize(SSSP problem)
+    {
+        var solver = new SSSPSolver();
+        var steps = solver.GetTableSteps(problem);
+        return steps.Count > 0 ? TranslateToTableJSON((SSSPTableStep)steps[0]) : new API_empty(); 
+    }
+
+    public API_JSON SolvedVisualization(SSSP problem)
+    {
+        var solver = new SSSPSolver();
+        var steps = solver.GetTableSteps(problem);
+        return steps.Count > 0 ? TranslateToTableJSON((SSSPTableStep)steps[steps.Count - 1]) : new API_empty();
+    }
+
+    public List<API_JSON> StepsVisualization(SSSP problem, List<Object> steps)
+    {
+        var solver = new SSSPSolver();
+        var tableSteps = solver.GetTableSteps(problem);
+        return tableSteps.Select(s => (API_JSON)TranslateToTableJSON((SSSPTableStep)s)).ToList();
+    }
+
+    private static API_TableJSON TranslateToTableJSON(SSSPTableStep step)
+    {
+        var result = new API_TableJSON
+        {
+            columns = new List<TableColumn>
+            {
+                new TableColumn {key = "vertex", label = "Vertex"},
+                new TableColumn {key = "order", label = "Order"},
+                new TableColumn {key = "known", label = "Known"},
+                new TableColumn {key = "costPredecessor", label = "Cost,Predecessor"},
+                new TableColumn {key = "path", label = "Path"}
+            }
+        };
+
+        var knownSet = new HashSet<string>(step.knownSet);
+
+        foreach (var vertex in step.vertices)
+        {
+            bool isKnown = knownSet.Contains(vertex.name);
+            bool isCurrent = vertex.name == step.currentVertex;
+
+            var row = new TableRow
+            {
+                id = vertex.name,
+                cells = new Dictionary<string, string>
+               {
+                   {"vertex", vertex.name },
+                   {"order", vertex.order },
+                   {"known", isKnown ? "\u2705" : "\u274c" },
+                   {"costPredecessor", vertex.display },
+                   {"path", vertex.path ?? "-" }
+               },
+               cellColors = isCurrent ? new Dictionary<string, string> {{ "costPredecessor", "ElementHighlight" } } : null 
+            };
+            result.rows.Add(row);
+        }
+        return result;
+    }
+
+}

--- a/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
+++ b/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
@@ -1,0 +1,26 @@
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_SSSP.Solvers;
+
+namespace API.Problems.P.P_SSSP.Visualizations;
+
+class SSSPVisualization : IVisualization<SSSP>
+{
+    public string visualizationName { get; } = "Single Source Shortest Path Visualization";
+    public string visualizationDefinition { get; } = "Visualizes the Single Source Shortest Path problem for non-negative weighted directed cyclic graphs using Dijkstra's algorithm";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    public string visualizationType => "Graph D3";
+    public ISolver solver { get; } = new SSSPSolver();
+
+    public SSSPVisualization() { }
+
+    public API_JSON visualize(SSSP problem)
+    {
+        // For simplicity, we will just return a JSON representation of the graph
+        // In a real implementation, this would be more complex and would include visual elements
+        return problem.graph.ToAPIGraph();
+    }
+}

--- a/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
+++ b/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
@@ -3,6 +3,7 @@ using API.Interfaces.Graphs.GraphParser;
 using API.Interfaces.JSON_Objects;
 using API.Interfaces.JSON_Objects.Graphs;
 using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
 
 namespace API.Problems.P.P_SSSP.Visualizations;
 
@@ -14,6 +15,7 @@ class SSSPVisualization : IVisualization<SSSP>
     public string[] contributors { get; } = { "Rajit Nilkar" };
     public string visualizationType => "Graph D3";
     public ISolver solver { get; } = new SSSPSolver();
+    public IVerifier verifier { get; } = new SSSPVerifier();
 
     public SSSPVisualization() { }
 
@@ -22,5 +24,115 @@ class SSSPVisualization : IVisualization<SSSP>
         // For simplicity, we will just return a JSON representation of the graph
         // In a real implementation, this would be more complex and would include visual elements
         return problem.graph.ToAPIGraph();
+    }
+
+    // SolvedVisualization: takes a problem instance and a solution certificate,
+    // and returns a visualization of the problem instance with the solution highlighted
+    public API_JSON SolvedVisualization(SSSP problem, string solution)
+    {
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return visualize(problem); // No entries so return graph with no highlights
+
+        Dictionary<string, List<string>> pathsByNode;
+        try
+        {
+            pathsByNode = SSSPVerifier.ParseSSSPCertificate(solution);
+        }
+        catch
+        {
+            return visualize(problem); // Invalid solution format, return graph with no highlights
+        }
+
+        API_GraphJSON graph = problem.graph.ToAPIGraph();
+
+        var reachedNodes = new HashSet<string>();
+        var treeEdges = new HashSet<(string u, string v)>();
+
+        foreach(var (node, path) in pathsByNode)
+        {
+            if (pathsByNode.Count == 0)
+                continue; // unreachable node, no highlight
+
+            foreach (string pathNode in path)
+                reachedNodes.Add(pathNode);
+
+            for (int i = 0; i < path.Count - 1; i++)
+                treeEdges.Add((path[i], path[i + 1]));
+
+            for(int i = 0; i < graph.nodes.Count; i++)
+            {
+                graph.nodes[i].color = reachedNodes.Contains(graph.nodes[i].name) ? "Solution" : "Background";
+            }
+
+            for(int i = 0; i < graph.links.Count; i++)
+            {
+                var link = graph.links[i];
+                bool isForwardTreeEdge = treeEdges.Contains((link.source, link.target));
+                bool isReversedTreeEdge = !problem.isDirected && treeEdges.Contains((link.source, link.target));
+
+                link.color = (isForwardTreeEdge || isReversedTreeEdge) ? "Solution" : "Background";
+            }
+        }
+        return graph;
+    }
+
+    // StepsVisualization : takes a problem instance and a list of step objects,
+    // and returns a step-by-step visualization with a highlighted path for the current node being processed and final path solution for reachable nodes
+    public List<API_JSON> StepsVisualization(SSSP problem, List<Object> steps)
+    {
+        var result = new List<API_JSON>();
+
+        for(int s = 0; s < steps.Count; s++)
+        {
+            var step = steps[s] as SSSPSolver.SSSPGraphStep;
+            if(step == null)
+            {
+                result.Add(visualize(problem));
+                continue;
+            }
+
+            API_GraphJSON graph = problem.graph.ToAPIGraph();
+            var knownNodes = new HashSet<string>(step.knownNodes);
+
+            for(int i = 0; i < graph.nodes.Count; i++)
+            {
+                if (graph.nodes[i].name == step.currentNode)
+                {
+                    graph.nodes[i].color = "ElementHighlight";
+                    graph.nodes[i].outline = "Purple";
+                }
+                else if (knownNodes.Contains(graph.nodes[i].name))
+                {
+                    graph.nodes[i].color = "Solution";
+                    graph.nodes[i].outline = "SolutionAlt";
+                }
+                else
+                {
+                    graph.nodes[i].color = "Background"; 
+                }
+            }
+
+            var treeEdges = new HashSet<(string from, string to)>(step.treeEdges);
+            (string from, string to)? currentEdge = step.currentEdgeFrom != null && step.currentNode != null ? (step.currentEdgeFrom, step.currentNode) : null;
+
+            for(int i = 0; i < graph.links.Count; i++)
+            {
+                var link = graph.links[i];
+                var forward = (link.source, link.target);
+                var reverse = (link.source, link.target);
+
+                bool isCurrentEdge = currentEdge.HasValue && (forward == currentEdge.Value || (!problem.isDirected && reverse == currentEdge.Value));
+                bool isTreeEdge = treeEdges.Contains(forward) || (!problem.isDirected && treeEdges.Contains(reverse));
+
+                if (isCurrentEdge)
+                    link.color = "ElementHighlight";
+                else if (isTreeEdge)
+                    link.color = "Solution";
+                else
+                    link.color = "Background";
+            }
+            result.Add(graph);
+        }
+        return result;
     }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,57 @@ The backend is designed to be adaptable and can work with different frontends. T
 
 ## Quick Start
 
+The recommended path is the **dev container** (below): it needs only a container runtime and
+gives everyone the same .NET 10 toolchain. Prefer to install toolchains on your host instead?
+Skip to [Prerequisites](#prerequisites).
+
+### Recommended: Dev Container
+
+The dev container pins the .NET 10 SDK and a shared task runner ([mise](https://mise.jdx.dev/))
+so VS Code, a plain terminal, and CI all build and test the same way. **No local .NET SDK or
+Node.js is required for backend work** — the container provides them.
+
+**Dependencies**
+
+- [Docker](https://docs.docker.com/get-docker/) (or a compatible container runtime), and
+- one of:
+  - **VS Code** + the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (or a [GitHub Codespace](https://github.com/features/codespaces)), or
+  - the [`@devcontainers/cli`](https://github.com/devcontainers/cli) for terminal-based editors (neovim, etc.): `npm install -g @devcontainers/cli` (needs Node.js on your host).
+
+**VS Code / Codespaces**
+
+Open the repo and choose **Reopen in Container**. The first build restores packages
+automatically; then use the tasks below from the integrated terminal.
+
+**Terminal (devcontainer CLI)**
+
+```bash
+# create/start the container (first run pulls the image + restores packages)
+devcontainer up --workspace-folder .
+
+# run tasks inside it
+devcontainer exec --workspace-folder . mise run test   # restore -> build -> test
+devcontainer exec --workspace-folder . mise run run    # API on http://localhost:27000
+```
+
+**Tasks** — the same `mise run <task>` names work in VS Code, the terminal, and CI:
+
+| Task | What it does |
+|------|--------------|
+| `mise run restore` | Restore NuGet packages |
+| `mise run build`   | Build the solution (Release) |
+| `mise run test`    | Restore → build → test (mirrors CI) |
+| `mise run run`     | Run the API on http://localhost:27000 (Swagger at `/swagger/index.html`) |
+| `mise run watch`   | Run the API with hot reload |
+
+Port **27000** is published to your host, so a browser or the
+[Redux_GUI](https://github.com/ReduxISU/Redux_GUI) frontend can reach the API at
+`http://localhost:27000` while you develop.
+
+> **Working on the GUI too (e.g. a reduction)?** Run this backend container, then start the
+> frontend separately and point its `REDUX_BASE_URL` at `http://localhost:27000/`. The two are
+> independent containers wired over HTTP — you do not need both in one container.
+
 ### Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download)

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,35 @@
+# mise — one task vocabulary across the Redux repos (`mise run build|test|run|watch`),
+# so C#, Python, and JS repos share the same commands.
+#
+# There is intentionally NO [tools] section: the .NET 10 runtime is provided by the
+# devcontainer base image, not mise. mise is the task layer only. See CLAUDE.md
+# "Toolchain layering (DECIDED)".
+#
+# Every task names Redux.slnx explicitly — a bare `dotnet` at the repo root errors
+# MSB1011 because API.csproj and Redux.slnx sit side by side (same reason CI does).
+
+[tasks.restore]
+description = "Restore NuGet packages"
+run = "dotnet restore Redux.slnx"
+
+[tasks.build]
+description = "Build the solution (Release)"
+depends = ["restore"]
+run = "dotnet build Redux.slnx --no-restore --configuration Release"
+
+[tasks.test]
+description = "Run unit tests (restore -> build -> test, matching CI)"
+depends = ["build"]
+run = "dotnet test Redux.slnx --no-restore --no-build --configuration Release"
+
+[tasks.run]
+description = "Run the API on http://localhost:27000 (Development + Swagger)"
+# Bind via ASPNETCORE_URLS, NOT `--urls`: `dotnet run` treats `--urls` as an unknown
+# run option and exits before the app starts. 0.0.0.0 so the published port is reachable.
+env = { ASPNETCORE_URLS = "http://0.0.0.0:27000" }
+run = "dotnet run --project API.csproj"
+
+[tasks.watch]
+description = "Run the API with hot reload on :27000"
+env = { ASPNETCORE_URLS = "http://0.0.0.0:27000" }
+run = "dotnet watch --project API.csproj run"

--- a/mise.toml
+++ b/mise.toml
@@ -1,35 +1,23 @@
-# mise — one task vocabulary across the Redux repos (`mise run build|test|run|watch`),
-# so C#, Python, and JS repos share the same commands.
-#
-# There is intentionally NO [tools] section: the .NET 10 runtime is provided by the
-# devcontainer base image, not mise. mise is the task layer only. See CLAUDE.md
-# "Toolchain layering (DECIDED)".
-#
-# Every task names Redux.slnx explicitly — a bare `dotnet` at the repo root errors
-# MSB1011 because API.csproj and Redux.slnx sit side by side (same reason CI does).
+# Shared tasks. Runtime from the base image (no [tools]); bind defaults to loopback, devcontainer sets 0.0.0.0.
 
 [tasks.restore]
 description = "Restore NuGet packages"
 run = "dotnet restore Redux.slnx"
 
 [tasks.build]
-description = "Build the solution (Release)"
+description = "Build (Release)"
 depends = ["restore"]
 run = "dotnet build Redux.slnx --no-restore --configuration Release"
 
 [tasks.test]
-description = "Run unit tests (restore -> build -> test, matching CI)"
+description = "Restore, build, test (matches CI)"
 depends = ["build"]
 run = "dotnet test Redux.slnx --no-restore --no-build --configuration Release"
 
 [tasks.run]
-description = "Run the API on http://localhost:27000 (Development + Swagger)"
-# Bind via ASPNETCORE_URLS, NOT `--urls`: `dotnet run` treats `--urls` as an unknown
-# run option and exits before the app starts. 0.0.0.0 so the published port is reachable.
-env = { ASPNETCORE_URLS = "http://0.0.0.0:27000" }
-run = "dotnet run --project API.csproj"
+description = "Run the API on http://localhost:27000"
+run = "ASPNETCORE_URLS=${ASPNETCORE_URLS:-http://127.0.0.1:27000} dotnet run --project API.csproj"
 
 [tasks.watch]
-description = "Run the API with hot reload on :27000"
-env = { ASPNETCORE_URLS = "http://0.0.0.0:27000" }
-run = "dotnet watch --project API.csproj run"
+description = "Run the API with hot reload"
+run = "ASPNETCORE_URLS=${ASPNETCORE_URLS:-http://127.0.0.1:27000} dotnet watch --project API.csproj run"

--- a/redux-tests/Endpoints/Batch_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/Batch_Endpoint_Tests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+// Tests for the Navigation/Batch endpoints. The batch responses are projected
+// from the same reflected data the singular Navigation controllers use, so the
+// central guarantee under test is that a batch payload never drifts from its
+// per-problem counterpart.
+public class Batch_Endpoint_Tests : IClassFixture<AppFactory>
+{
+    private readonly HttpClient _client;
+
+    public Batch_Endpoint_Tests(AppFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private async Task<string[]> GetArray(string url)
+    {
+        var response = await _client.GetAsync(url, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var arr = JsonSerializer.Deserialize<string[]>(body);
+        Assert.NotNull(arr);
+        return arr!;
+    }
+
+    private async Task<Dictionary<string, List<string>>> GetMap(string url)
+    {
+        var response = await _client.GetAsync(url, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var map = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(body);
+        Assert.NotNull(map);
+        return map!;
+    }
+
+    // ── allProblems ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllProblems_Returns200AndNonEmpty()
+    {
+        var problems = await GetArray("/Navigation/Batch/allProblems");
+        Assert.NotEmpty(problems);
+        Assert.Contains("SAT3", problems);
+    }
+
+    [Fact]
+    public async Task AllProblems_MatchesSingularAllEndpoint()
+    {
+        // Batch must be exactly the reflected problem set the singular endpoint returns.
+        var batch = await GetArray("/Navigation/Batch/allProblems");
+        var singular = await GetArray("/Navigation/ALL_ProblemsRefactor");
+        Assert.Equal(
+            new SortedSet<string>(singular, StringComparer.Ordinal),
+            new SortedSet<string>(batch, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task AllProblems_ExcludesInheritedHelperProblems()
+    {
+        // SipserClique lives in NPC_CLIQUE.Inherited; it is a nested helper variant,
+        // not a top-level problem, so it must not appear in the listing.
+        var problems = await GetArray("/Navigation/Batch/allProblems");
+        Assert.DoesNotContain(problems, p => string.Equals(p, "SipserClique", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── allSolvers / allVerifiers / allVisualizations ─────────────────────────
+
+    [Fact]
+    public async Task AllSolvers_MapsSat3ToItsSolver()
+    {
+        var map = await GetMap("/Navigation/Batch/allSolvers");
+        Assert.True(map.ContainsKey("SAT3"));
+        Assert.Contains("Sat3BacktrackingSolver", map["SAT3"]);
+    }
+
+    [Fact]
+    public async Task AllSolvers_Sat3EntryMatchesSingularEndpoint()
+    {
+        // The whole point of the batch endpoint: no drift from the per-problem lookup.
+        var map = await GetMap("/Navigation/Batch/allSolvers");
+        var singular = await GetArray("/Navigation/Problem_SolversRefactor?chosenProblem=SAT3");
+        Assert.Equal(singular.OrderBy(x => x, StringComparer.Ordinal),
+                     map["SAT3"].OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task AllVerifiers_MapsSat3ToItsVerifier()
+    {
+        var map = await GetMap("/Navigation/Batch/allVerifiers");
+        Assert.True(map.ContainsKey("SAT3"));
+        Assert.Contains("SAT3Verifier", map["SAT3"]);
+    }
+
+    [Fact]
+    public async Task AllVerifiers_Sat3EntryMatchesSingularEndpoint()
+    {
+        var map = await GetMap("/Navigation/Batch/allVerifiers");
+        var singular = await GetArray("/Navigation/Problem_VerifiersRefactor?chosenProblem=SAT3");
+        Assert.Equal(singular.OrderBy(x => x, StringComparer.Ordinal),
+                     map["SAT3"].OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task AllVisualizations_MapsSat3ToDefaultVisualization()
+    {
+        var map = await GetMap("/Navigation/Batch/allVisualizations");
+        Assert.True(map.ContainsKey("SAT3"));
+        Assert.Contains("Sat3DefaultVisualization", map["SAT3"]);
+    }
+
+    // ── allInfo ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllInfo_Returns200AndContainsProblemObject()
+    {
+        var response = await _client.GetAsync("/Navigation/Batch/allInfo", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var map = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(body);
+        Assert.NotNull(map);
+        Assert.NotEmpty(map!);
+        Assert.True(map!.ContainsKey("SAT3"));
+        Assert.Equal(JsonValueKind.Object, map["SAT3"].ValueKind);
+    }
+
+    [Fact]
+    public async Task AllInfo_RepeatedCalls_ReturnIdenticalPayload()
+    {
+        // Cached via Lazy<string>: every call after the first returns the same bytes.
+        var first = await (await _client.GetAsync("/Navigation/Batch/allInfo", TestContext.Current.CancellationToken))
+            .Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var second = await (await _client.GetAsync("/Navigation/Batch/allInfo", TestContext.Current.CancellationToken))
+            .Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(first, second);
+    }
+
+    // ── method contract ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AllProblems_RejectsPost()
+    {
+        // These are reads: GET only (PR #168 used POST; this reimplementation does not).
+        var response = await _client.PostAsync("/Navigation/Batch/allProblems", null, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+}

--- a/redux-tests/Problems/P_SSSP/SSSPTests.cs
+++ b/redux-tests/Problems/P_SSSP/SSSPTests.cs
@@ -1,0 +1,137 @@
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_SPSP;
+using API.Problems.P.P_SSSP;
+using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
+using API.Problems.P.P_SSSP.Visualizations;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class SSSP_Tests
+{
+    [Fact]
+    public void SSSP_Default_Instantiation()
+    {
+        SSSP problem = new SSSP();
+        Assert.Equal("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)", problem.instance);
+        Assert.Equal(problem.defaultInstance, problem.instance);
+    }
+
+    [Fact]
+    public void SSSP_Custom_Instantiation()
+    {
+        string instance = "({1,2,3,4,5,6},{((1,2),2),((1,3),4),((2,4),7),((2,3),1),((3,5),3),((4,6),1),((5,4),2),((5,6),5)},1)";
+        var problem = new SSSP(instance);
+        Assert.Equal(instance, problem.instance);
+    }
+
+    [Theory]
+    [InlineData("({1,2}, {((1,2),-1)}),1")]
+    [InlineData("(({1,2}, {((1,2),-1)}),1")]
+    public void SSSP_Rejects_Negative_Edge_Weights(string instance)
+    {
+        // Dijkstra's algorithm correctness depends on non-negative weights
+        // The SSSP problem must reject problem instances with negative-weights during parse time
+        Assert.Throws<InvalidOperationException>(() => new SSSP(instance));
+    }
+
+    [Fact]
+    public void SPSP_Rejects_Source_Outside_Node_Set()
+    {
+        string instance = "(({1,2,3},{((1,2),1),((2,3),1)}),4)";
+        Assert.Throws<InvalidOperationException>(() => new SPSP(instance));
+    }
+
+    // ----- Solver ----- //
+
+    [Fact]
+    public void SSSP_Solver_Default_Instantiation()
+    {
+        string instance = "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
+        SSSPSolver solver = new SSSPSolver();
+        var problem = new SSSP(instance);
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1}),(2,{1,2}),(3,{1,3}),(4,{1,2,4}),(5,{1,3,5})}", result);
+    }
+
+    [Fact]
+    public void SSSP_Solver_Custom_Instantiation()
+    {
+        string instance = "({1,2,3,4,5,6},{((1,2),2),((1,3),4),((2,4),7),((2,3),1),((3,5),3),((4,6),1),((5,4),2),((5,6),5)},1)";
+        SSSPSolver solver = new SSSPSolver();
+        var problem = new SSSP(instance);
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1}),(2,{1,2}),(3,{1,2,3}),(4,{1,2,3,5,4}),(5,{1,2,3,5}),(6,{1,2,3,5,4,6})}", result);
+    }
+
+    [Fact]
+    public void SSSPSolver_Single_Node_No_Edges()
+    {
+        string instance = "({1},{},1)";
+        SSSP problem = new SSSP(instance);
+        SSSPSolver solver = new SSSPSolver();
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1})}", result);
+    }
+
+    [Fact]
+    public void SSSPSolver_Unreachable_Node_Returns_Empty_Path()
+    {
+        string instance = "({1,2,3},{((1,2),5)},1)";
+        SSSP problem = new SSSP(instance);
+        SSSPSolver solver = new SSSPSolver();
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1}),(2,{1,2}),(3,{})}", result);
+    }
+
+    // ----- Verifier ----- //
+
+    [Theory]
+    [InlineData("{(1,{1}),(2,{1,2}),(3,{1,3}),(4,{1,2,4}),(5,{1,3,5})}", true)]
+    [InlineData("{(1,{1}),(2,{1,2}),(3,{1,3}),(4,{1,2,4}),(5,{1,2,4,5})}", false)]
+    public void SSSPVerifier_Certificate_Validation(string certificate, bool expectedResult)
+    {
+        SSSP problem = new SSSP();
+        SSSPVerifier verifier = new SSSPVerifier();
+        Assert.Equal(expectedResult, verifier.verify(problem, certificate));
+    }
+
+    // ----- Visualization ----- //
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)")]
+    [InlineData("({1,2,3,4,5,6},{((1,2),2),((1,3),4),((2,4),7),((2,3),1),((3,5),3),((4,6),1),((5,4),2),((5,6),5)},1)")]
+    public void SSSPVisualization_StepsVisualization_SettledTreeEdges_Accumulate_Without_Resetting(string instance)
+    {
+        SSSP problem = new SSSP(instance);
+        var solver = new SSSPSolver();
+        var visualization = new SSSPVisualization();
+
+        var steps = solver.GetSteps(problem);
+        var visualSteps = visualization.StepsVisualization(problem, steps);
+
+        Assert.True(steps.Count >= 2);
+
+        var previousSettledEdges = new HashSet<(string, string)>();
+        foreach (var stepObj in steps)
+        {
+            var step = (SSSPSolver.SSSPGraphStep)stepObj;
+            var knownNodes = new HashSet<string>(step.knownNodes);
+
+            // Only edges pointing into already-settled nodes are guaranteed final;
+            // edges into not-yet-settled nodes may still be relaxed away.
+            var currentSettledEdges = new HashSet<(string, string)>(
+                step.treeEdges.Where(e => knownNodes.Contains(e.to)));
+
+            Assert.True(previousSettledEdges.IsSubsetOf(currentSettledEdges));
+
+            previousSettledEdges = currentSettledEdges;
+        }
+
+        Assert.NotEmpty(previousSettledEdges);
+    }
+}


### PR DESCRIPTION
Introduce mise as a shared task layer (restore/build/test/run/watch) so VS Code, terminal-based editors, and CI all use the same commands against Redux.slnx. The devcontainer now uses the official devcontainers/dotnet image and a post-create script installs mise, trusts the repo config, and warms the NuGet cache automatically.

Publish port 27000 so the API is reachable from the host without relying on VS Code's port forwarding, enabling terminal-only editors like neovim to work with the container via the devcontainer CLI.

Update Readme and CONTRIBUTING to document the dev container as the recommended setup path, reducing onboarding friction and keeping local environments consistent with CI.