### PR TITLE
feat(SSSP): add Single Source Shortest Path Problem (P class, Dijkstra's algorithm)

### DIFF
--- a/Problems/P/P_SSSP/P_SSSP.cs
+++ b/Problems/P/P_SSSP/P_SSSP.cs
@@ -53,6 +53,227 @@ class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilColl
 
     public SSSP(string GInput)
     {
-        throw new NotImplementedException("SSSP constructor to be implemented");
+        ParsedShortestPathInstance parsed = ParseInstance(GInput);
+        nodes = parsed.Nodes;
+        edges = parsed.Edges;
+        sourceNode = parsed.SourceNode;
+        isDirected = parsed.IsDirected;
+        isWeighted = parsed.IsWeighted;
+        graph = new UtilCollectionGraph(parsed.NodeCollection, parsed.EdgeCollection);
     }
+
+    private static ParsedShortestPathInstance ParseInstance(string rawInstance)
+    {
+        string graphInput = rawInstance;
+        string? explicitSource = null;
+
+        List<string> outerTerms = SplitOuterTuple(rawInstance);
+        if (outerTerms.Count == 3)
+        {
+            graphInput = $"({outerTerms[0]},{outerTerms[1]})";
+            explicitSource = outerTerms[2];
+        }
+        else if (outerTerms.Count == 2 && LooksLikeTuple(outerTerms[0]))
+        {
+            graphInput = outerTerms[0];
+            explicitSource = outerTerms[1];
+        }
+
+        GraphParseResult graphParse = ParseGraph(graphInput);
+        UtilCollection nodeCollection = graphParse.Parser["N"] ?? throw new InvalidOperationException("Failed to parse N (nodes)");
+        UtilCollection edgeCollection = graphParse.Parser["E"] ?? throw new InvalidOperationException("Failed to parse E (edges)");
+
+        List<string> parsedNodes = nodeCollection.ToList().Select(node => node.ToString()).ToList();
+        List<KeyValuePair<string, string>> parsedEdges = ToEdgePairs(edgeCollection);
+
+        ValidateInstance(parsedNodes, edgeCollection, explicitSource);
+
+        string resolvedSource = explicitSource ?? (parsedNodes.Count > 0 ? parsedNodes[0] : string.Empty);
+
+        return new ParsedShortestPathInstance(
+            nodeCollection,
+            edgeCollection,
+            parsedNodes,
+            parsedEdges,
+            resolvedSource,
+            graphParse.IsDirected,
+            graphParse.IsWeighted);
+    }
+
+    private static GraphParseResult ParseGraph(string graphInput)
+    {
+        (string Pattern, bool IsDirected, bool IsWeighted)[] parseAttempts =
+        {
+            ("{(N,E) | N is set, E subset {(e,w) | e is N cross N, w is int}}", true, true),
+            ("{(N,E) | N is set, E subset {(e,w) | e is unorderedcross N, w is int}}", false, true),
+            ("{(N,E) | N is set, E subset N cross N}", true, false),
+            ("{(N,E) | N is set, E subset unorderedcross N", false, false)
+        };
+
+        Exception? lastError = null;
+        foreach (var attempt in parseAttempts)
+        {
+            try
+            {
+                StringParser parser = new(attempt.Pattern);
+                parser.parse(graphInput);
+                return new GraphParseResult(parser, attempt.IsDirected, attempt.IsWeighted);
+            }
+            catch (Exception e)
+            {
+                lastError = e;
+            }
+        }
+
+        throw new InvalidOperationException("Failed to parse SSSP instance.", lastError);
+    }
+
+    private static void ValidateInstance(
+        List<string> parsedNodes,
+        UtilCollection edgeCollection,
+        string? explicitSource)
+    {
+        HashSet<string> nodeSet = parsedNodes.ToHashSet();
+
+        if (explicitSource != null && !nodeSet.Contains(explicitSource))
+            throw new InvalidOperationException($"Source node '{explicitSource}' is not in N");
+
+        foreach(UtilCollection rawEdge in edgeCollection)
+        {
+            ParsedEdge edge = ParseEdge(rawEdge);
+
+            if (!nodeSet.Contains(edge.From))
+                throw new InvalidOperationException($"Edge source '{edge.From}' is not in N.");
+
+            if (!nodeSet.Contains(edge.To))
+                throw new InvalidOperationException($"Edge target '{edge.To}' is not in N.");
+
+            if (edge.Weight < 0)
+                throw new InvalidOperationException("SSSP using Dijkstra's algorithm does not handle negative edge-weights.");
+        }
+    }
+
+    private static List<KeyValuePair<string, string>> ToEdgePairs(UtilCollection edgeCollection)
+    {
+        return edgeCollection.ToList().Select(rawEdge =>
+        {
+            ParsedEdge edge = ParseEdge(rawEdge);
+            return new KeyValuePair<string, string>(edge.From, edge.To);
+        }).ToList();
+    }
+
+    private static ParsedEdge ParseEdge(UtilCollection rawEdge)
+    {
+        bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+        bool secondLooksLikeCollection = rawEdge.Count() > 1 && LooksLikeCollection(rawEdge[1]);
+        bool isWeighted = rawEdge.Count() == 2 && firstLooksLikeCollection && !secondLooksLikeCollection;
+
+        if (isWeighted)
+        {
+            UtilCollection endpoints = rawEdge[0];
+            int weight = int.Parse(rawEdge[1].ToString());
+
+            if (weight < 0)
+                throw new InvalidOperationException($"SSSP using Dijkstra's algorithm does not allow negative edge weights. Found edge weight: {weight}");
+
+            return new ParsedEdge(GetFrom(endpoints), GetTo(endpoints), weight);
+        }
+
+        return new ParsedEdge(GetFrom(rawEdge), GetTo(rawEdge), 1);
+    }
+
+    private static bool LooksLikeCollection(UtilCollection value)
+    {
+        string text = value.ToString().TrimStart();
+        return text.StartsWith("{") || text.StartsWith("(");
+    }
+
+    private static string GetFrom(UtilCollection endpoints)
+    {
+        if (endpoints.IsOrdered())
+            return endpoints[0].ToString();
+
+        List<UtilCollection> cast = endpoints.ToList();
+        return cast[0].ToString();
+    }
+
+    private static string GetTo(UtilCollection endpoints)
+    {
+        if (endpoints.IsOrdered())
+            return endpoints[1].ToString();
+
+        List<UtilCollection> cast = endpoints.ToList();
+        if (cast.Count == 1)
+            return cast[0].ToString();
+
+        return cast[1].ToString();
+    }
+
+    private static bool LooksLikeTuple(string value)
+    {
+        return value.TrimStart().StartsWith("(");
+    }
+
+    private static List<string> SplitOuterTuple(string input)
+    {
+        string trimmed = input.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '(' || trimmed[^1] != ')')
+            return new List<string>();
+
+        string inner = trimmed[1..^1];
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        int parenDepth = 0;
+        int braceDepth = 0;
+        int bracketDepth = 0;
+
+        foreach (char ch in inner)
+        {
+            if (ch == ',' && parenDepth == 0 && braceDepth == 0 && bracketDepth == 0)
+            {
+                parts.Add(current.ToString().Trim());
+                current.Clear();
+                continue;
+            }
+
+            current.Append(ch);
+            switch (ch)
+            {
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    parenDepth--;
+                    break;
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    braceDepth--;
+                    break;
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    bracketDepth--;
+                    break;
+            }
+        }
+
+        if (current.Length > 0)
+            parts.Add(current.ToString().Trim());
+
+        return parts;
+    }
+
+    private sealed record GraphParseResult(StringParser Parser, bool IsDirected, bool IsWeighted);
+    private sealed record ParsedShortestPathInstance(
+        UtilCollection NodeCollection,
+        UtilCollection EdgeCollection,
+        List<string> Nodes,
+        List<KeyValuePair<string, string>> Edges,
+        string SourceNode,
+        bool IsDirected,
+        bool IsWeighted);
+    private sealed record ParsedEdge(string From, string To, int Weight);
 }

--- a/Problems/P/P_SSSP/P_SSSP.cs
+++ b/Problems/P/P_SSSP/P_SSSP.cs
@@ -20,8 +20,7 @@ class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilColl
     public string problemDefinition { get; } = "Single Source Shortest Path (SSSP) in a weighted graph is the problem of determining the shortest path from a source vertex to all other reachable vertices in the graph such that the sum of edge weights along each path is minimized.";
     public string source { get; } = "N/A";
     public string sourceLink { get; } = "N/A";
-    private static string _defaultInstance =
-    "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
+    private static string _defaultInstance = "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
     public string defaultInstance { get; } = _defaultInstance;
     public string instance { get; set; } = string.Empty;
     public string wikiName { get; } = "";
@@ -53,6 +52,8 @@ class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilColl
 
     public SSSP(string GInput)
     {
+        instance = GInput;
+
         ParsedShortestPathInstance parsed = ParseInstance(GInput);
         nodes = parsed.Nodes;
         edges = parsed.Edges;

--- a/Problems/P/P_SSSP/P_SSSP.cs
+++ b/Problems/P/P_SSSP/P_SSSP.cs
@@ -1,0 +1,58 @@
+using Antlr4.Runtime;
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
+using API.Problems.P.P_SSSP.Visualizations;
+using SPADE;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace API.Problems.P.P_SSSP;
+
+class SSSP : IGraphProblem<SSSPSolver, SSSPVerifier, SSSPVisualization, UtilCollectionGraph>
+{
+    // --- Fields ---
+    public string problemName { get; } = "Single Source Shortest Path Problem";
+    public string problemLink { get; } = "https://en.wikipedia.org/wiki/Shortest_path_problem";
+    public string formalDefinition { get; } = "For a weighted graph G = (V,E), with non-negative edge weights, a source vertex s \u2208 V, find the shortest path distance from s to every other vertex v \u2208 V, where path length is defined as the sum of edge weights along the path.";
+    public string problemDefinition { get; } = "Single Source Shortest Path (SSSP) in a weighted graph is the problem of determining the shortest path from a source vertex to all other reachable vertices in the graph such that the sum of edge weights along each path is minimized.";
+    public string source { get; } = "N/A";
+    public string sourceLink { get; } = "N/A";
+    private static string _defaultInstance =
+    "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
+    public string defaultInstance { get; } = _defaultInstance;
+    public string instance { get; set; } = string.Empty;
+    public string wikiName { get; } = "";
+    public string sourceNode { get; private set; } = string.Empty;
+    public bool isDirected { get; private set; }
+    public bool isWeighted { get; private set; }
+    private List<string> _nodes = new List<string>();
+    private List<KeyValuePair<string, string>> _edges = new List<KeyValuePair<string, string>>();
+    public SSSPSolver defaultSolver { get; } = new SSSPSolver();
+    public SSSPVerifier defaultVerifier { get; } = new SSSPVerifier();
+    public SSSPVisualization defaultVisualization { get; } = new SSSPVisualization();
+    public UtilCollectionGraph graph { get; set; }
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+
+    // --- Properties ---
+    public List<string> nodes
+    {
+        get => _nodes;
+        set => _nodes = value;
+    }
+    public List<KeyValuePair<string, string>> edges
+    {
+        get => _edges;
+        set => _edges = value;
+    }
+
+    // --- Methods Including Constructor ---
+    public SSSP() : this(_defaultInstance) { }
+
+    public SSSP(string GInput)
+    {
+        throw new NotImplementedException("SSSP constructor to be implemented");
+    }
+}

--- a/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
+++ b/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
@@ -1,0 +1,22 @@
+using API.Interfaces;
+using API.Interfaces.Graphs;
+using API.Interfaces.JSON_Objects;
+using SPADE;
+using System;
+
+namespace API.Problems.P.P_SSSP.Solvers;
+
+class SSSPSolver : ISolver<SSSP>
+{
+    public string solverName { get; } = "Dijkstra's Algorithm";
+    public string solverDefinition { get; } = "";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    public bool timerHasExpired { get; set; }
+    PriorityQueue<string, int>? pq;
+
+    public string solve(SSSP problem)
+    {
+        return ""; // To Do Dijkstra's algorithm implementation for SSSP problem
+    }
+}

--- a/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
+++ b/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
@@ -3,6 +3,7 @@ using API.Interfaces.Graphs;
 using API.Interfaces.JSON_Objects;
 using SPADE;
 using System;
+using System.Collections.Generic;
 
 namespace API.Problems.P.P_SSSP.Solvers;
 
@@ -17,6 +18,384 @@ class SSSPSolver : ISolver<SSSP>
 
     public string solve(SSSP problem)
     {
-        return ""; // To Do Dijkstra's algorithm implementation for SSSP problem
+        UtilCollectionGraph graph = problem.graph;
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return "{}"; // No nodes, return empty path
+
+        string sourceNode = problem.sourceNode;
+
+        if (!nodes.Contains(sourceNode))
+            return "{}";
+
+        var adjacency = BuildAdjacencyList(graph);
+
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        while(pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return "{}";
+
+            string current = pq.Dequeue();
+
+            if (visited.Contains(current))
+                continue;
+            visited.Add(current);
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if(candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+        }
+
+        return NodeListCertificate(nodes, sourceNode, prev);
+    }
+
+    internal static Dictionary<string, List<(string neighbor, int weight)>> BuildAdjacencyList(UtilCollectionGraph graph)
+    {
+        var adjacency = new Dictionary<string, List<(string neigbor, int weight)>>();
+
+        if (graph.Nodes.Count() == 0)
+            return adjacency; // No edges, so return empty adjacency list
+
+        foreach(UtilCollection rawEdge in graph.Edges.ToList())
+        {
+            // check if edge is weighted
+            bool firstLooksLikeCollection = LooksLikeCollection(rawEdge[0]);
+            bool secondLooksLikeCollection = LooksLikeCollection(rawEdge[1]);
+            bool isWeighted = rawEdge.Count() == 2 && firstLooksLikeCollection && !secondLooksLikeCollection;
+
+            if(isWeighted)
+            {
+                UtilCollection endpoints = rawEdge[0];
+                int w = int.Parse(rawEdge[1].ToString());
+
+                if (endpoints.IsOrdered())
+                    AddDirected(adjacency, endpoints[0].ToString(), endpoints[1].ToString(), w);
+                else
+                {
+                    var cast = endpoints.ToList();
+                    if(cast.Count == 1)
+                    {
+                        string v = cast[0].ToString();
+                        AddDirected(adjacency, v, v, w);
+                    }
+                    else
+                    {
+                        string a = cast[0].ToString();
+                        string b = cast[1].ToString();
+                        AddDirected(adjacency, a, b, w);
+                        AddDirected(adjacency, b, a, w);
+                    }
+                }
+            }
+            else
+            {
+                int w = 1; // Assign the weight 1 by default if there is no assigned weight
+
+                if (rawEdge.IsOrdered())
+                    AddDirected(adjacency, rawEdge[0].ToString(), rawEdge[1].ToString(), w);
+                else
+                {
+                    var cast = rawEdge.ToList();
+                    if (cast.Count == 1)
+                    {
+                        string v = cast[0].ToString();
+                        AddDirected(adjacency, v, v, w);
+                    }
+                    else
+                    {
+                        string a = cast[0].ToString();
+                        string b = cast[1].ToString();
+                        AddDirected(adjacency, a, b, w);
+                        AddDirected(adjacency, b, a, w);
+                    }
+                }
+            }
+        }
+        return adjacency;
+    }
+
+    // AddDirected: Adds a directed edge to the adjacency list
+    private static void AddDirected(Dictionary<string, List<(string neighbor, int weight)>> adjacency, string from, string to, int weight)
+    {
+        if(!adjacency.TryGetValue(from, out var list))
+        {
+            list = new List<(string neighbor, int weight)>();
+            adjacency[from] = list;
+        }
+        list.Add((to, weight));
+
+        if (!adjacency.ContainsKey(to))
+            adjacency[to] = new List<(string, int)>();
+    }
+
+    // ReconstructPath: Reconstructs the path from source to each node using the previous dictionionary
+    internal static List<string> ReconstructPath(Dictionary<string, string?> prev, string? source, string target)
+    {
+        var path = new List<string>();
+        string? current = target;
+
+        while(current != null)
+        {
+            path.Add(current);
+            if(current == source)
+            {
+                break; // Stop if we've reached the source node
+            }
+            current = prev[current];
+        }
+
+        path.Reverse(); // Reverse the list so path order is source to target
+
+        if(path.Count == 0 || path[0] != source)
+        {
+            return new List<string>(); // No valid path
+        }
+        return path;
+    }
+
+    // NodeListCertificate: Converts a set of (node, path) tuples for every node in the graph
+    internal static string NodeListCertificate(List<string> nodes, string sourceNode, Dictionary<string, string?> prev)
+    {
+        var entries = new List<string>();
+
+        foreach(string node in nodes)
+        {
+            List<string> path = ReconstructPath(prev, sourceNode, node);
+            string pathCertificate = NodeListToCertificate(path);
+            entries.Add($"({node},{pathCertificate})");
+        }
+
+        return "{" + string.Join(",", entries) + "}";
+    }
+
+    // NodeListToCertificate: Converts a list of nodes into the certificate form
+    internal static string NodeListToCertificate(List<string> nodes)
+    {
+        if (nodes == null || nodes.Count == 0)
+            return "{}";
+        return "{" + string.Join(",", nodes) + "}";
+    }
+
+    // LooksLikeCollection: Helper method to determine if a UtilCollection looks like a collection
+    private static bool LooksLikeCollection(UtilCollection u)
+    {
+        string s = u.ToString().TrimStart();
+        return s.StartsWith("{") || s.StartsWith("(");
+    }
+
+    public class SSSPGraphStep
+    {
+        public string? currentNode { get; set; } // node just settled in this step
+        public string? currentEdgeFrom { get; set; } // winning edge that determines the shortest path for node
+        public List<string> knownNodes { get; set; } = new(); // all settled nodes so far
+        public List<(string from, string to)> treeEdges { get; set; } = new(); // accepted tree edges so far
+    }
+
+    // GetSteps: The steps are returned as a list of string, where each string represents a path in the certificate format
+    public List<Object> GetSteps(SSSP problem)
+    {
+        var steps = new List<Object>();
+        UtilCollectionGraph graph = problem.graph;
+
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return steps;
+
+        string sourceNode = problem.sourceNode;
+
+        var adjacency = BuildAdjacencyList(graph);
+
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        while(pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return steps;
+
+            string current = pq.Dequeue();
+            if (visited.Contains(current))
+                continue;
+
+            visited.Add(current);
+
+            steps.Add(BuildGraphStep(current, prev, visited));
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue;
+
+                if (weight < 0)
+                    return steps;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if(candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+        }
+        return steps;
+    }
+
+    // BuildGraphStep: assembles one snapshot of the shortest path tree's state
+    private static SSSPGraphStep BuildGraphStep(string current, Dictionary<string, string?> prev, HashSet<string> visited)
+    {
+        var treeEdges = new List<(string from, string to)>();
+        foreach(var predecessor in prev)
+        {
+            if (predecessor.Value != null)
+                treeEdges.Add((predecessor.Value, predecessor.Key));
+        }
+
+        return new SSSPGraphStep
+        {
+            currentNode = current,
+            currentEdgeFrom = prev[current],
+            knownNodes = visited.ToList(),
+            treeEdges = treeEdges
+        };
+    }
+
+    public class SSSPTableStepVertex
+    {
+        public string name { get; set; } = "";
+        public string display { get; set; } = "\u221E";
+        public string? path { get; set; }
+    }
+
+    public class SSSPTableStep : API_JSON
+    {
+        public List<SSSPTableStepVertex> vertices { get; set; } = new();
+        public List<string> knownSet { get; set; } = new();
+        public string? currentVertex { get; set; }
+        public string? sourceVertex { get; set; }
+    }
+
+    public List<Object> GetTableSteps(SSSP problem)
+    {
+        var steps = new List<Object>();
+        UtilCollectionGraph graph = problem.graph;
+
+        List<string> nodes = graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return steps;
+
+        string sourceNode = problem.sourceNode;
+
+        var adjacency = BuildAdjacencyList(graph);
+        var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
+        var prev = nodes.ToDictionary(n => n, _ => (string?)null);
+        var visited = new HashSet<string>();
+        pq = new PriorityQueue<string, int>();
+
+        dist[sourceNode] = 0;
+        pq.Enqueue(sourceNode, 0);
+
+        steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+
+        while(pq.Count > 0)
+        {
+            if (timerHasExpired)
+                return steps;
+
+            string current = pq.Dequeue();
+
+            if (visited.Contains(current))
+                continue;
+
+            visited.Add(current);
+
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (visited.Contains(next))
+                    continue;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if (candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    prev[next] = current;
+                    pq.Enqueue(next, candidate);
+                }
+            }
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: current, sourceVertex: sourceNode));
+        }
+        return steps;
+    }
+
+    private static SSSPTableStep BuildTableStep(
+        List<string> nodes,
+        Dictionary<string, int> dist,
+        Dictionary<string, string?> prev,
+        HashSet<string> visited,
+        string? currentVertex,
+        string? sourceVertex)
+    {
+        return new SSSPTableStep
+        {
+            currentVertex = currentVertex,
+            sourceVertex = sourceVertex,
+            knownSet = visited.ToList(),
+            vertices = nodes.Select(n => new SSSPTableStepVertex
+            {
+                name = n,
+                display = dist[n] == int.MaxValue
+                    ? "\u221E"
+                    : (prev[n] != null ? $"{dist[n]}, {prev[n]}" : $"{dist[n]}"),
+                path = dist[n] == int.MaxValue
+                    ? null
+                    : NodeListToCertificate(ReconstructPath(prev, sourceVertex, n))
+            }).ToList()
+        };
     }
 }

--- a/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
+++ b/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Collections.Generic;
 using API.Interfaces;
 using API.Interfaces.Graphs.GraphParser;
 using API.Problems.P.P_SSSP.Solvers;
@@ -16,9 +18,182 @@ class SSSPVerifier : IVerifier<SSSP>
 
     public SSSPVerifier() { }
 
+    // verify : takes a problem instance and a solution certificate,
+    // and returns true if the certificate is a valid solution to the problem instance
+    // and false otherwise
     public bool verify(SSSP problem, string solution)
     {
-        return true;    //To Do
-                        //Placeholder for now, will implement verifier logic 
+        _certificate = solution ?? "";
+
+        var nodes = problem.graph.Nodes.ToList().Select(n => n.ToString()).ToList();
+
+        if (nodes.Count == 0)
+            return solution == "{}" || string.IsNullOrWhiteSpace(solution);
+
+        string sourceNode = problem.sourceNode;
+        var adjacency = SSSPSolver.BuildAdjacencyList(problem.graph);
+
+        // Compute shortest distance for each node
+        var trueDist = AllShortestDistances(adjacency, nodes, sourceNode);
+
+        // Parse the certificate as a set of (node, path) tuples
+        Dictionary<string, List<string>> certPaths;
+        try
+        {
+            certPaths = ParseSSSPCertificate(_certificate);
+        }
+        catch
+        {
+            return false; // Invalid certificate format
+        }
+
+        if (certPaths.Count != nodes.Count || !nodes.All(n => certPaths.ContainsKey(n)))
+            return false;
+
+        foreach(string node in nodes)
+        {
+            List<string> path = certPaths[node];
+            bool trueUnreachable = trueDist[node] == null;
+
+            if(path.Count == 0)
+            {
+                if(!trueUnreachable)
+                {
+                    return false; // certificate says unreachable, but actually reachable
+                }
+                continue;
+            }
+
+            if (trueUnreachable)
+                return false; // certificate gives a path for a node that is actually unreachable
+
+            if (path[0] != sourceNode || path[^1] != node)
+                return false; // path must start at the source and end at the node
+
+            int length = 0;
+            for(int i = 0; i < path.Count -1; i++)
+            {
+                string u = path[i];
+                string v = path[i + 1];
+
+                if (!adjacency.TryGetValue(u, out var neighbors))
+                    return false;
+
+                var weights = neighbors.Where(e => e.neighbor == v).Select(e => e.weight).ToList();
+                if (weights.Count == 0)
+                    return false;
+
+                int w = weights.Min();
+                if (w < 0)
+                    return false;
+
+                length += w;
+            }
+            if (length != trueDist[node])
+                return false; // path exists but is not the shortest
+        }
+        return true; 
+    }
+
+    private static Dictionary<string, int?> AllShortestDistances(Dictionary<string, List<(string neighbor, int weight)>> adjacency, List<string> allNodes, string source)
+    {
+        var dist = allNodes.ToDictionary(n => n, _ => int.MaxValue);
+        var visited = new HashSet<string>();
+        var pq = new PriorityQueue<string, int>();
+
+        dist[source] = 0;
+        pq.Enqueue(source, 0);
+
+        while(pq.Count > 0)
+        {
+            string current = pq.Dequeue();
+            if (visited.Contains(current))
+                continue;
+            visited.Add(current);
+
+            if (!adjacency.TryGetValue(current, out var neighbors))
+                continue;
+
+            foreach(var (next, weight) in neighbors)
+            {
+                if (weight < 0)
+                    throw new InvalidOperationException("SSSP using Dijkstra's algorithm cannot handle negative edge weights.");
+
+                if (visited.Contains(next))
+                    continue;
+
+                if (dist[current] == int.MaxValue)
+                    continue;
+
+                int candidate = dist[current] + weight;
+                if(candidate < dist[next])
+                {
+                    dist[next] = candidate;
+                    pq.Enqueue(next, candidate);
+                }    
+            }
+        }
+        return allNodes.ToDictionary(n => n, n => dist[n] == int.MaxValue ? (int?)null : dist[n]);
+    }
+
+    private static Dictionary<string, List<string>> ParseSSSPCertificate(string certificate)
+    {
+        var result = new Dictionary<string, List<string>>();
+
+        string trimmed = certificate.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '{' || trimmed[^1] != '}')
+            throw new FormatException("Certificate must be wrapped in { }");
+
+        string inner = trimmed.Substring(1, trimmed.Length - 2).Trim();
+        if (inner.Length == 0)
+            return result; // empty certificate, no entries
+
+        List<string> tupleChunks = SplitTopLevel(inner);
+
+        foreach(string chunk in tupleChunks)
+        {
+            string tupleInner = chunk.Trim();
+            if (tupleInner.Length < 2 || tupleInner[0] != '(' || tupleInner[^1] != ')')
+                throw new FormatException($"Malformed tuple: {chunk}");
+
+            tupleInner = tupleInner.Substring(1, tupleInner.Length - 2);
+
+            // splits just the outer tuple into exactly 2 top-level pieces: node, path
+            List<string> parts = SplitTopLevel(tupleInner);
+            if (parts.Count != 2)
+                throw new FormatException($"Expected (node, path) pair, got: {chunk}");
+
+            string node = parts[0].Trim();
+            string pathStr = parts[1].Trim();
+
+            List<string> path = pathStr == "{}" ? new List<string>() : GraphParser.parseNodeListWithStringFunctions(pathStr);
+
+            result[node] = path;
+        }
+        return result;
+    }
+
+    // SplitTopLevel: splits a string on commas that sit at depth 0 (ignoring commas nested inside { } or ( ))
+    private static List<string> SplitTopLevel(string s)
+    {
+        var parts = new List<string>();
+        int depth = 0;
+        int start = 0;
+
+        for(int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c == '{' || c == '(')
+                depth++;
+            else if (c == '}' || c == ')')
+                depth--;
+            else if(c == ',' && depth == 0)
+            {
+                parts.Add(s.Substring(start, i - start));
+                start = i + 1;
+            }
+        }
+        parts.Add(s.Substring(start));
+        return parts;
     }
 }

--- a/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
+++ b/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
@@ -1,0 +1,24 @@
+using System;
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Problems.P.P_SSSP.Solvers;
+
+namespace API.Problems.P.P_SSSP.Verifiers;
+
+class SSSPVerifier : IVerifier<SSSP>
+{
+    public string verifierName { get; } = "Single Source Shortest Path Verifier";
+    public string verifierDefinition { get; } = "Verifies the solution for the Single Source Shortest Path problem";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    private string _certificate = "";
+    public string certificate => _certificate;
+
+    public SSSPVerifier() { }
+
+    public bool verify(SSSP problem, string solution)
+    {
+        return true;    //To Do
+                        //Placeholder for now, will implement verifier logic 
+    }
+}

--- a/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
+++ b/Problems/P/P_SSSP/Verifiers/SSSPVerifier.cs
@@ -136,7 +136,7 @@ class SSSPVerifier : IVerifier<SSSP>
         return allNodes.ToDictionary(n => n, n => dist[n] == int.MaxValue ? (int?)null : dist[n]);
     }
 
-    private static Dictionary<string, List<string>> ParseSSSPCertificate(string certificate)
+    public static Dictionary<string, List<string>> ParseSSSPCertificate(string certificate)
     {
         var result = new Dictionary<string, List<string>>();
 

--- a/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
+++ b/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
@@ -1,0 +1,26 @@
+using API.Interfaces;
+using API.Interfaces.Graphs.GraphParser;
+using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_SSSP.Solvers;
+
+namespace API.Problems.P.P_SSSP.Visualizations;
+
+class SSSPVisualization : IVisualization<SSSP>
+{
+    public string visualizationName { get; } = "Single Source Shortest Path Visualization";
+    public string visualizationDefinition { get; } = "Visualizes the Single Source Shortest Path problem for non-negative weighted directed cyclic graphs using Dijkstra's algorithm";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    public string visualizationType => "Graph D3";
+    public ISolver solver { get; } = new SSSPSolver();
+
+    public SSSPVisualization() { }
+
+    public API_JSON visualize(SSSP problem)
+    {
+        // For simplicity, we will just return a JSON representation of the graph
+        // In a real implementation, this would be more complex and would include visual elements
+        return problem.graph.ToAPIGraph();
+    }
+}

--- a/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
+++ b/Problems/P/P_SSSP/Visualizations/SSSPVisualization.cs
@@ -3,6 +3,7 @@ using API.Interfaces.Graphs.GraphParser;
 using API.Interfaces.JSON_Objects;
 using API.Interfaces.JSON_Objects.Graphs;
 using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
 
 namespace API.Problems.P.P_SSSP.Visualizations;
 
@@ -14,6 +15,7 @@ class SSSPVisualization : IVisualization<SSSP>
     public string[] contributors { get; } = { "Rajit Nilkar" };
     public string visualizationType => "Graph D3";
     public ISolver solver { get; } = new SSSPSolver();
+    public IVerifier verifier { get; } = new SSSPVerifier();
 
     public SSSPVisualization() { }
 
@@ -22,5 +24,115 @@ class SSSPVisualization : IVisualization<SSSP>
         // For simplicity, we will just return a JSON representation of the graph
         // In a real implementation, this would be more complex and would include visual elements
         return problem.graph.ToAPIGraph();
+    }
+
+    // SolvedVisualization: takes a problem instance and a solution certificate,
+    // and returns a visualization of the problem instance with the solution highlighted
+    public API_JSON SolvedVisualization(SSSP problem, string solution)
+    {
+        if (string.IsNullOrWhiteSpace(solution) || solution.Trim() == "{}")
+            return visualize(problem); // No entries so return graph with no highlights
+
+        Dictionary<string, List<string>> pathsByNode;
+        try
+        {
+            pathsByNode = SSSPVerifier.ParseSSSPCertificate(solution);
+        }
+        catch
+        {
+            return visualize(problem); // Invalid solution format, return graph with no highlights
+        }
+
+        API_GraphJSON graph = problem.graph.ToAPIGraph();
+
+        var reachedNodes = new HashSet<string>();
+        var treeEdges = new HashSet<(string u, string v)>();
+
+        foreach(var (node, path) in pathsByNode)
+        {
+            if (pathsByNode.Count == 0)
+                continue; // unreachable node, no highlight
+
+            foreach (string pathNode in path)
+                reachedNodes.Add(pathNode);
+
+            for (int i = 0; i < path.Count - 1; i++)
+                treeEdges.Add((path[i], path[i + 1]));
+
+            for(int i = 0; i < graph.nodes.Count; i++)
+            {
+                graph.nodes[i].color = reachedNodes.Contains(graph.nodes[i].name) ? "Solution" : "Background";
+            }
+
+            for(int i = 0; i < graph.links.Count; i++)
+            {
+                var link = graph.links[i];
+                bool isForwardTreeEdge = treeEdges.Contains((link.source, link.target));
+                bool isReversedTreeEdge = !problem.isDirected && treeEdges.Contains((link.source, link.target));
+
+                link.color = (isForwardTreeEdge || isReversedTreeEdge) ? "Solution" : "Background";
+            }
+        }
+        return graph;
+    }
+
+    // StepsVisualization : takes a problem instance and a list of step objects,
+    // and returns a step-by-step visualization with a highlighted path for the current node being processed and final path solution for reachable nodes
+    public List<API_JSON> StepsVisualization(SSSP problem, List<Object> steps)
+    {
+        var result = new List<API_JSON>();
+
+        for(int s = 0; s < steps.Count; s++)
+        {
+            var step = steps[s] as SSSPSolver.SSSPGraphStep;
+            if(step == null)
+            {
+                result.Add(visualize(problem));
+                continue;
+            }
+
+            API_GraphJSON graph = problem.graph.ToAPIGraph();
+            var knownNodes = new HashSet<string>(step.knownNodes);
+
+            for(int i = 0; i < graph.nodes.Count; i++)
+            {
+                if (graph.nodes[i].name == step.currentNode)
+                {
+                    graph.nodes[i].color = "ElementHighlight";
+                    graph.nodes[i].outline = "Purple";
+                }
+                else if (knownNodes.Contains(graph.nodes[i].name))
+                {
+                    graph.nodes[i].color = "Solution";
+                    graph.nodes[i].outline = "SolutionAlt";
+                }
+                else
+                {
+                    graph.nodes[i].color = "Background"; 
+                }
+            }
+
+            var treeEdges = new HashSet<(string from, string to)>(step.treeEdges);
+            (string from, string to)? currentEdge = step.currentEdgeFrom != null && step.currentNode != null ? (step.currentEdgeFrom, step.currentNode) : null;
+
+            for(int i = 0; i < graph.links.Count; i++)
+            {
+                var link = graph.links[i];
+                var forward = (link.source, link.target);
+                var reverse = (link.source, link.target);
+
+                bool isCurrentEdge = currentEdge.HasValue && (forward == currentEdge.Value || (!problem.isDirected && reverse == currentEdge.Value));
+                bool isTreeEdge = treeEdges.Contains(forward) || (!problem.isDirected && treeEdges.Contains(reverse));
+
+                if (isCurrentEdge)
+                    link.color = "ElementHighlight";
+                else if (isTreeEdge)
+                    link.color = "Solution";
+                else
+                    link.color = "Background";
+            }
+            result.Add(graph);
+        }
+        return result;
     }
 }

--- a/redux-tests/Problems/P_SSSP/SSSPTests.cs
+++ b/redux-tests/Problems/P_SSSP/SSSPTests.cs
@@ -1,0 +1,137 @@
+using API.Interfaces.JSON_Objects.Graphs;
+using API.Problems.P.P_SPSP;
+using API.Problems.P.P_SSSP;
+using API.Problems.P.P_SSSP.Solvers;
+using API.Problems.P.P_SSSP.Verifiers;
+using API.Problems.P.P_SSSP.Visualizations;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+public class SSSP_Tests
+{
+    [Fact]
+    public void SSSP_Default_Instantiation()
+    {
+        SSSP problem = new SSSP();
+        Assert.Equal("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)", problem.instance);
+        Assert.Equal(problem.defaultInstance, problem.instance);
+    }
+
+    [Fact]
+    public void SSSP_Custom_Instantiation()
+    {
+        string instance = "({1,2,3,4,5,6},{((1,2),2),((1,3),4),((2,4),7),((2,3),1),((3,5),3),((4,6),1),((5,4),2),((5,6),5)},1)";
+        var problem = new SSSP(instance);
+        Assert.Equal(instance, problem.instance);
+    }
+
+    [Theory]
+    [InlineData("({1,2}, {((1,2),-1)}),1")]
+    [InlineData("(({1,2}, {((1,2),-1)}),1")]
+    public void SSSP_Rejects_Negative_Edge_Weights(string instance)
+    {
+        // Dijkstra's algorithm correctness depends on non-negative weights
+        // The SSSP problem must reject problem instances with negative-weights during parse time
+        Assert.Throws<InvalidOperationException>(() => new SSSP(instance));
+    }
+
+    [Fact]
+    public void SPSP_Rejects_Source_Outside_Node_Set()
+    {
+        string instance = "(({1,2,3},{((1,2),1),((2,3),1)}),4)";
+        Assert.Throws<InvalidOperationException>(() => new SPSP(instance));
+    }
+
+    // ----- Solver ----- //
+
+    [Fact]
+    public void SSSP_Solver_Default_Instantiation()
+    {
+        string instance = "({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)";
+        SSSPSolver solver = new SSSPSolver();
+        var problem = new SSSP(instance);
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1}),(2,{1,2}),(3,{1,3}),(4,{1,2,4}),(5,{1,3,5})}", result);
+    }
+
+    [Fact]
+    public void SSSP_Solver_Custom_Instantiation()
+    {
+        string instance = "({1,2,3,4,5,6},{((1,2),2),((1,3),4),((2,4),7),((2,3),1),((3,5),3),((4,6),1),((5,4),2),((5,6),5)},1)";
+        SSSPSolver solver = new SSSPSolver();
+        var problem = new SSSP(instance);
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1}),(2,{1,2}),(3,{1,2,3}),(4,{1,2,3,5,4}),(5,{1,2,3,5}),(6,{1,2,3,5,4,6})}", result);
+    }
+
+    [Fact]
+    public void SSSPSolver_Single_Node_No_Edges()
+    {
+        string instance = "({1},{},1)";
+        SSSP problem = new SSSP(instance);
+        SSSPSolver solver = new SSSPSolver();
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1})}", result);
+    }
+
+    [Fact]
+    public void SSSPSolver_Unreachable_Node_Returns_Empty_Path()
+    {
+        string instance = "({1,2,3},{((1,2),5)},1)";
+        SSSP problem = new SSSP(instance);
+        SSSPSolver solver = new SSSPSolver();
+        string result = solver.solve(problem);
+        Assert.Equal("{(1,{1}),(2,{1,2}),(3,{})}", result);
+    }
+
+    // ----- Verifier ----- //
+
+    [Theory]
+    [InlineData("{(1,{1}),(2,{1,2}),(3,{1,3}),(4,{1,2,4}),(5,{1,3,5})}", true)]
+    [InlineData("{(1,{1}),(2,{1,2}),(3,{1,3}),(4,{1,2,4}),(5,{1,2,4,5})}", false)]
+    public void SSSPVerifier_Certificate_Validation(string certificate, bool expectedResult)
+    {
+        SSSP problem = new SSSP();
+        SSSPVerifier verifier = new SSSPVerifier();
+        Assert.Equal(expectedResult, verifier.verify(problem, certificate));
+    }
+
+    // ----- Visualization ----- //
+
+    [Theory]
+    [InlineData("({1,2,3,4,5},{((1,2),4),((1,3),2),((2,3),1),((3,5),7),((2,4),3),((4,5),9)},1)")]
+    [InlineData("({1,2,3,4,5,6},{((1,2),2),((1,3),4),((2,4),7),((2,3),1),((3,5),3),((4,6),1),((5,4),2),((5,6),5)},1)")]
+    public void SSSPVisualization_StepsVisualization_SettledTreeEdges_Accumulate_Without_Resetting(string instance)
+    {
+        SSSP problem = new SSSP(instance);
+        var solver = new SSSPSolver();
+        var visualization = new SSSPVisualization();
+
+        var steps = solver.GetSteps(problem);
+        var visualSteps = visualization.StepsVisualization(problem, steps);
+
+        Assert.True(steps.Count >= 2);
+
+        var previousSettledEdges = new HashSet<(string, string)>();
+        foreach (var stepObj in steps)
+        {
+            var step = (SSSPSolver.SSSPGraphStep)stepObj;
+            var knownNodes = new HashSet<string>(step.knownNodes);
+
+            // Only edges pointing into already-settled nodes are guaranteed final;
+            // edges into not-yet-settled nodes may still be relaxed away.
+            var currentSettledEdges = new HashSet<(string, string)>(
+                step.treeEdges.Where(e => knownNodes.Contains(e.to)));
+
+            Assert.True(previousSettledEdges.IsSubsetOf(currentSettledEdges));
+
+            previousSettledEdges = currentSettledEdges;
+        }
+
+        Assert.NotEmpty(previousSettledEdges);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Single-Source Shortest Path (SSSP) on Redux, following the standard four-class Problem/Solver/Verifier/Visualization pattern. Given a weighted graph and a single source node, SSSP computes shortest paths from the source to every reachable node in the graph (as opposed to SPSP, which targets a single destination).

This includes:
- `SSSPSolver`: Dijkstra's algorithm implementation, producing a certificate of shortest paths from the source to every node.
- `SSSPVerifier`: validates a solution certificate against the true shortest distances.
- `SSSPVisualization`: graph and table step-by-step visualizations of the algorithm's execution, plus a solved-state highlight view.

## Design Decisions

- **Certificate format**: `{(A,{S,A}),(B,{S,A,B}),(D,{})}` — a set of `(node, path)` tuples using SPADE tuple syntax, where the path is the ordered list of nodes from source to that node. Unreachable nodes are represented as `(node,{})`.
- **Certificate parsing**: a custom `ParseSSSPCertificate` method with a depth-aware `SplitTopLevel` helper, written directly inside `SSSPVerifier` since `GraphParser` cannot be modified to support this format.
- **Graph view animation**: an accumulating shortest-path tree animation, where each step adds one branch to the tree rather than resetting it, to accurately reflect Dijkstra's mechanics. Implemented via `SSSPGraphStep`, tracking `currentNode`, `currentEdgeFrom`, `knownNodes`, and `treeEdges`.
- **Table view format**: a Kurose-inspired format combining distance and predecessor into a single `display` field (e.g., `"3, A"`), with a shared `knownSet` field and a separate `path` field per vertex, via `SSSPTableStep`.

## Testing

Unit tests cover:
- **Instantiation**: default and custom instance construction.
- **Solver correctness**: shortest-path certificates for the default instance, a custom instance that exercises relaxation (a node's shortest path is initially found via one route and later improved via another), an unreachable-node case, and a single-node/no-edges edge case.
- **Verifier correctness**: acceptance of a valid shortest-path certificate and rejection of a tampered certificate representing a longer, non-shortest path.
- **Visualization correctness**: confirms that tree edges into already-settled nodes accumulate across steps and are never removed once settled, verified against two different problem instances (including one with a relaxation event).