### PR TITLE
feat(Tables): #367 Created Table JSON_Objects for table-based visualization # 

### DIFF
--- a/Interfaces/JSON_Objects/Tables/API_TableJSON.cs
+++ b/Interfaces/JSON_Objects/Tables/API_TableJSON.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace API.Interfaces.JSON_Objects.Tables;
+
+class API_TableJSON : API_JSON
+{
+    public List<TableColumn> columns { get; set; } = new();
+    public List<TableRow> rows { get; set; } = new();
+
+}

--- a/Interfaces/JSON_Objects/Tables/TableColumn.cs
+++ b/Interfaces/JSON_Objects/Tables/TableColumn.cs
@@ -1,0 +1,7 @@
+namespace API.Interfaces.JSON_Objects.Tables;
+
+class TableColumn
+{
+    public string key { get; set; } = "";
+    public string label { get; set; } = "";
+}

--- a/Interfaces/JSON_Objects/Tables/TableRow.cs
+++ b/Interfaces/JSON_Objects/Tables/TableRow.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace API.Interfaces.JSON_Objects.Tables;
+
+class TableRow
+{
+    public string id { get; set; } = "";
+    public string? color { get; set; }
+    public Dictionary<string, string> cells = new();
+    public Dictionary<string, string>? cellColors;
+}


### PR DESCRIPTION
## Summary

Adds the generic Table JSON objects for table-based problem visualizations, mirroring the existing Graph JSON objects (`API_GraphJSON`, `API_Node_Programmable_Small`, `API_Link`) under `JSON_Objects.Graphs`. Based on a discussion about how to make the existing table-style visualization for the SPSP problem generic and make it work for all problem types that might require a tabular visualization component.

- `TableColumn` (`key`, `label`)
- `TableRow` (`id`, `rowColor`, `cells`, `cellColors`)
- `API_TableJSON : API_JSON` (`columns`, `rows`)

All three live under a new `API.Interfaces.JSON_Objects.Tables` namespace/folder.

`rowColor`/`cellColors` use semantic color keys (e.g. `"ElementHighlight"`, `"Solution"`), consistent with how `API_GraphJSON` colors nodes/links — no raw colors or layout/sizing values are sent from the backend.

This is a schema-only change. `SSSPTableVisualization` (translating `SSSPSolver.GetTableSteps` output into this shape) and the SPSP backfill are implemented in follow-up work.

Closes #367