### PR TITLE
feat(SSSP): table visualization for SSSP problem

### DIFF
--- a/Interfaces/JSON_Objects/Tables/TableRow.cs
+++ b/Interfaces/JSON_Objects/Tables/TableRow.cs
@@ -6,6 +6,6 @@ class TableRow
 {
     public string id { get; set; } = "";
     public string? color { get; set; }
-    public Dictionary<string, string> cells = new();
-    public Dictionary<string, string>? cellColors;
+    public Dictionary<string, string> cells { get; set; } = new();
+    public Dictionary<string, string>? cellColors { get; set; }
 }

--- a/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
+++ b/Problems/P/P_SSSP/Solvers/SSSPSolver.cs
@@ -302,6 +302,8 @@ class SSSPSolver : ISolver<SSSP>
         public string name { get; set; } = "";
         public string display { get; set; } = "\u221E";
         public string? path { get; set; }
+        public bool known { get; set; }
+        public string order { get; set; } = "";
     }
 
     public class SSSPTableStep : API_JSON
@@ -328,12 +330,14 @@ class SSSPSolver : ISolver<SSSP>
         var dist = nodes.ToDictionary(n => n, _ => int.MaxValue);
         var prev = nodes.ToDictionary(n => n, _ => (string?)null);
         var visited = new HashSet<string>();
+        var finalizationOrder = new Dictionary<string, int>();
+        int orderCounter = 1;
         pq = new PriorityQueue<string, int>();
 
         dist[sourceNode] = 0;
         pq.Enqueue(sourceNode, 0);
 
-        steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+        steps.Add(BuildTableStep(nodes, dist, prev, visited, finalizationOrder, currentVertex: null, sourceVertex: sourceNode));
 
         while(pq.Count > 0)
         {
@@ -346,8 +350,9 @@ class SSSPSolver : ISolver<SSSP>
                 continue;
 
             visited.Add(current);
+            finalizationOrder[current] = orderCounter++;
 
-            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: null, sourceVertex: sourceNode));
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, finalizationOrder, currentVertex: null, sourceVertex: sourceNode));
 
             if (!adjacency.TryGetValue(current, out var neighbors))
                 continue;
@@ -368,7 +373,9 @@ class SSSPSolver : ISolver<SSSP>
                     pq.Enqueue(next, candidate);
                 }
             }
-            steps.Add(BuildTableStep(nodes, dist, prev, visited, currentVertex: current, sourceVertex: sourceNode));
+            bool isLastVertex = pq.Count == 0 || pq.UnorderedItems.All(item => visited.Contains(item.Element));
+
+            steps.Add(BuildTableStep(nodes, dist, prev, visited, finalizationOrder, currentVertex: isLastVertex ? null: current, sourceVertex: sourceNode));
         }
         return steps;
     }
@@ -378,6 +385,7 @@ class SSSPSolver : ISolver<SSSP>
         Dictionary<string, int> dist,
         Dictionary<string, string?> prev,
         HashSet<string> visited,
+        Dictionary<string, int> finalizationOrder,
         string? currentVertex,
         string? sourceVertex)
     {
@@ -391,10 +399,12 @@ class SSSPSolver : ISolver<SSSP>
                 name = n,
                 display = dist[n] == int.MaxValue
                     ? "\u221E"
-                    : (prev[n] != null ? $"{dist[n]}, {prev[n]}" : $"{dist[n]}"),
+                    : (prev[n] != null ? $"{dist[n]},{prev[n]}" : $"{dist[n]}"),
                 path = dist[n] == int.MaxValue
                     ? null
-                    : NodeListToCertificate(ReconstructPath(prev, sourceVertex, n))
+                    : NodeListToCertificate(ReconstructPath(prev, sourceVertex, n)),
+                known = visited.Contains(n),
+                order = finalizationOrder.ContainsKey(n) ? finalizationOrder[n].ToString() : ""
             }).ToList()
         };
     }

--- a/Problems/P/P_SSSP/Visualizations/SSSPTableVisualization.cs
+++ b/Problems/P/P_SSSP/Visualizations/SSSPTableVisualization.cs
@@ -1,0 +1,80 @@
+using API.Interfaces;
+using API.Interfaces.JSON_Objects;
+using API.Interfaces.JSON_Objects.Tables;
+using API.Problems.P.P_SSSP.Solvers;
+using SSSPTableStep = API.Problems.P.P_SSSP.Solvers.SSSPSolver.SSSPTableStep;
+
+namespace API.Problems.P.P_SSSP.Visualizations;
+
+class SSSPTableVisualization : IVisualization<SSSP>
+{
+    public string visualizationName { get; } = "SSSP Table Visualization";
+    public string visualizationDefinition { get; } = "Displays a step-by-step table visualization of Dijkstra's alogrithm execution, showing each vertex's cost/predecessor and reconstructed path at each stage";
+    public string source { get; } = "";
+    public string[] contributors { get; } = { "Rajit Nilkar" };
+    public string visualizationType => "Dynamic Table";
+    public ISolver solver { get; } = new SSSPSolver();
+
+    public SSSPTableVisualization() { }
+
+    public API_JSON visualize(SSSP problem)
+    {
+        var solver = new SSSPSolver();
+        var steps = solver.GetTableSteps(problem);
+        return steps.Count > 0 ? TranslateToTableJSON((SSSPTableStep)steps[0]) : new API_empty(); 
+    }
+
+    public API_JSON SolvedVisualization(SSSP problem)
+    {
+        var solver = new SSSPSolver();
+        var steps = solver.GetTableSteps(problem);
+        return steps.Count > 0 ? TranslateToTableJSON((SSSPTableStep)steps[steps.Count - 1]) : new API_empty();
+    }
+
+    public List<API_JSON> StepsVisualization(SSSP problem, List<Object> steps)
+    {
+        var solver = new SSSPSolver();
+        var tableSteps = solver.GetTableSteps(problem);
+        return tableSteps.Select(s => (API_JSON)TranslateToTableJSON((SSSPTableStep)s)).ToList();
+    }
+
+    private static API_TableJSON TranslateToTableJSON(SSSPTableStep step)
+    {
+        var result = new API_TableJSON
+        {
+            columns = new List<TableColumn>
+            {
+                new TableColumn {key = "vertex", label = "Vertex"},
+                new TableColumn {key = "order", label = "Order"},
+                new TableColumn {key = "known", label = "Known"},
+                new TableColumn {key = "costPredecessor", label = "Cost,Predecessor"},
+                new TableColumn {key = "path", label = "Path"}
+            }
+        };
+
+        var knownSet = new HashSet<string>(step.knownSet);
+
+        foreach (var vertex in step.vertices)
+        {
+            bool isKnown = knownSet.Contains(vertex.name);
+            bool isCurrent = vertex.name == step.currentVertex;
+
+            var row = new TableRow
+            {
+                id = vertex.name,
+                cells = new Dictionary<string, string>
+               {
+                   {"vertex", vertex.name },
+                   {"order", vertex.order },
+                   {"known", isKnown ? "\u2705" : "\u274c" },
+                   {"costPredecessor", vertex.display },
+                   {"path", vertex.path ?? "-" }
+               },
+               cellColors = isCurrent ? new Dictionary<string, string> {{ "costPredecessor", "ElementHighlight" } } : null 
+            };
+            result.rows.Add(row);
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
## Summary

Implements `SSSPTableVisualization`, translating `SSSPSolver.GetTableSteps` output into the generic `API_TableJSON` shape (introduced in #367) so SSSP's table view is rendered by the `DynamicTableSvgReact` frontend component instead of a hardcoded one.

- `visualize` returns the first table step (initial, unsolved state).
- `SolvedVisualization` returns the last table step (final distances/predecessors after Dijkstra's completes).
- `StepsVisualization` returns all table steps, one per settled vertex.
- Each `SSSPTableStep` is translated via a shared `TranslateToTableJSON` helper into three columns — `Vertex`, `Order`, `Known`, `Cost, Predecessor` (combined distance/predecessor display), and `Path`.
- The currently-processing vertex's row is highlighted via `rowColor = "ElementHighlight"`, matching the semantic-color convention used elsewhere.
- Unreached vertices display `"-"` in the `Path` column.

This PR is for the backend and the frontend changes can be found here [https://github.com/ReduxISU/Redux_GUI/pull/142](url)