### PR TITLE
ci: add Redux Build System integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
       "username": "vscode",
       "installZsh": false,
       "upgradePackages": false
-    }
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": { "moby": false },
+    "ghcr.io/reduxisu/features/rbs:1": {}
   },
   "remoteUser": "vscode",
   "customizations": {

--- a/.github/workflows/rbs.yml
+++ b/.github/workflows/rbs.yml
@@ -1,0 +1,22 @@
+name: rbs
+
+on:
+  pull_request:
+  push:
+    # branches: [CSharpAPI]
+
+permissions:
+  contents: read
+  pull-requests: write
+  packages: write
+
+concurrency:
+  group: rbs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    uses: ReduxISU/Redux_Build_System/.github/workflows/ci.yml@main
+    secrets: inherit
+    with:
+      soft: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ Redux.sln
 global.json
 .DS_Store
 .idea/
+
+# Redux Build System output
+.rbs/
+report.md

--- a/rbs.toml
+++ b/rbs.toml
@@ -1,0 +1,16 @@
+# Redux Build System pipeline config. See github.com/ReduxISU/Redux_Build_System.
+engine = "dotnet"
+solution = "Redux.slnx"
+
+[unit-test]
+# The standard we're holding to. Currently 61%, so this reports red until coverage catches up.
+coverage-min = 80
+
+[artifact]
+image = "ghcr.io/reduxisu/redux"
+port = 27000
+# /health does not exist yet; inert until `rbs integration-test` lands.
+health-path = "/health"
+
+[push]
+on-branch = "CSharpAPI"


### PR DESCRIPTION
Introduce rbs.toml pipeline config and GitHub Actions workflow to build and test via ReduxISU/Redux_Build_System. Add devcontainer features for docker-outside-of-docker and rbs to support local parity with CI. Ignore rbs output artifacts in .gitignore.