### PR TITLE
fix(template): package problem templates and resolve at runtime (#389)

### DIFF
--- a/API.csproj
+++ b/API.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="SPADE" Version="0.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <Content Include="Problems\**" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="ProblemTemplate\Templates\**" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- Tests live in their own project (redux-tests/redux-tests.csproj). The

--- a/ProblemTemplate/ProblemTemplate.cs
+++ b/ProblemTemplate/ProblemTemplate.cs
@@ -10,6 +10,11 @@ public class ProblemTemplate : ControllerBase
 {
 #pragma warning restore CS1591
 
+    // Templates ship alongside the app (see the <Content> include in API.csproj),
+    // so resolve them relative to the running assembly rather than the build-time
+    // source path — the latter does not exist on a deployed/containerized server.
+    static readonly string templatePath = Path.Combine(AppContext.BaseDirectory, "ProblemTemplate", "Templates");
+
     ///<summary>Returns generated files zipped together for the user to implement.</summary>
     ///<param name="problemName" example="Traveling Sales Person">Problem name</param>
     ///<response code="200">Returns the problem template with the given name.</response>
@@ -19,11 +24,10 @@ public class ProblemTemplate : ControllerBase
     {
         string problemNameUpper = ToUpperCase(problemName);
         string problemNamePascal = ToPascalCase(problemName);
-        string templatePath = $"{ProjectSourcePath.Value}/ProblemTemplate/Templates";
 
         byte[] zip = ZipFiles(
             new Dictionary<string, string>{
-                {"README.md", System.IO.File.ReadAllText($"{ProjectSourcePath.Value}/ProblemTemplate/Templates/README.md")},
+                {"README.md", System.IO.File.ReadAllText($"{templatePath}/README.md")},
                 {$"NPC_{problemNameUpper}/{problemNameUpper}_Class.cs", GenerateProblemTemplate(problemName, System.IO.File.ReadAllText($"{templatePath}/PROBLEM_Class.txt"))},
                 {$"NPC_{problemNameUpper}/Solvers/{problemNamePascal}Solver.cs", GenerateSolverTemplate(problemNameUpper, $"{problemName} Solver", System.IO.File.ReadAllText($"{templatePath}/Solvers/ProblemSolver.txt"))},
                 {$"NPC_{problemNameUpper}/Verifiers/{problemNamePascal}Verifier.cs", GenerateVerifierTemplate(problemNameUpper, $"{problemName} Verifier", System.IO.File.ReadAllText($"{templatePath}/Verifiers/ProblemVerifier.txt"))},
@@ -44,7 +48,6 @@ public class ProblemTemplate : ControllerBase
     public ActionResult DownloadReductionTemplate([FromQuery] string problemFrom, [FromQuery] string problemTo, [FromQuery] string reductionName)
     {
         string reductionNamePascal = ToPascalCase(reductionName);
-        string templatePath = $"{ProjectSourcePath.Value}/ProblemTemplate/Templates";
 
         byte[] zip = ZipFiles(
             new Dictionary<string, string>{
@@ -64,12 +67,11 @@ public class ProblemTemplate : ControllerBase
     public ActionResult DownloadSolverTemplate([FromQuery] string problemName, [FromQuery] string solverName)
     {
         string solverNamePascal = ToPascalCase(solverName);
-        string templatePath = $"{ProjectSourcePath.Value}/ProblemTemplate/Templates";
 
         byte[] zip = ZipFiles(
             new Dictionary<string, string>{
                 {$"NPC_{problemName}/Solvers/{solverNamePascal}.cs", GenerateSolverTemplate(problemName, solverName, System.IO.File.ReadAllText($"{templatePath}/Solvers/ProblemSolver.txt"))},
-                {"README.md", System.IO.File.ReadAllText($"{ProjectSourcePath.Value}/ProblemTemplate/Templates/README.md")},
+                {"README.md", System.IO.File.ReadAllText($"{templatePath}/README.md")},
             }
         );
 
@@ -85,12 +87,11 @@ public class ProblemTemplate : ControllerBase
     public ActionResult DownloadVerifierTemplate([FromQuery] string problemName, [FromQuery] string verifierName)
     {
         string verifierNamePascal = ToPascalCase(verifierName);
-        string templatePath = $"{ProjectSourcePath.Value}/ProblemTemplate/Templates";
 
         byte[] zip = ZipFiles(
             new Dictionary<string, string>{
                 {$"NPC_{problemName}/Verifiers/{verifierNamePascal}.cs", GenerateVerifierTemplate(problemName, verifierName, System.IO.File.ReadAllText($"{templatePath}/Verifiers/ProblemVerifier.txt"))},
-                {"README.md", System.IO.File.ReadAllText($"{ProjectSourcePath.Value}/ProblemTemplate/Templates/README.md")},
+                {"README.md", System.IO.File.ReadAllText($"{templatePath}/README.md")},
             }
         );
 
@@ -106,12 +107,11 @@ public class ProblemTemplate : ControllerBase
     public ActionResult DownloadVisualizationTemplate([FromQuery] string problemName, [FromQuery] string visualizationName)
     {
         string visualizationNamePascal = ToPascalCase(visualizationName);
-        string templatePath = $"{ProjectSourcePath.Value}/ProblemTemplate/Templates";
 
         byte[] zip = ZipFiles(
             new Dictionary<string, string>{
-                {$"NPC_{problemName}/Visualizations/{visualizationNamePascal}.cs", GenerateVisualizationTemplate(problemName, visualizationName, System.IO.File.ReadAllText($"{templatePath}/Visualizations/ProblemVisualization.txt"))},
-                {"README.md", System.IO.File.ReadAllText($"{ProjectSourcePath.Value}/ProblemTemplate/Templates/README.md")},
+                {$"NPC_{problemName}/Visualizations/{visualizationNamePascal}.cs", GenerateVisualizationTemplate(problemName, visualizationName, System.IO.File.ReadAllText($"{templatePath}/Visualizations/PROBLEMVisualization.txt"))},
+                {"README.md", System.IO.File.ReadAllText($"{templatePath}/README.md")},
             }
         );
 

--- a/redux-tests/Endpoints/ProblemTemplate_Endpoint_Tests.cs
+++ b/redux-tests/Endpoints/ProblemTemplate_Endpoint_Tests.cs
@@ -1,0 +1,137 @@
+using System.IO.Compression;
+using System.Net;
+using Xunit;
+
+namespace redux_tests;
+#pragma warning disable CS1591
+
+// Endpoint tests for the /ProblemTemplate controller (issue #389).
+//
+// The controller reads its template files from AppContext.BaseDirectory, and
+// API.csproj copies ProblemTemplate/Templates/** to the output/publish dir. That
+// content flows transitively into the redux-tests output dir, so these tests
+// exercise the real packaging + path-resolution fix rather than the build-time
+// source tree — i.e. they would fail the same way a deployed container did.
+public class ProblemTemplate_Endpoint_Tests : IClassFixture<AppFactory>
+{
+    private readonly HttpClient _client;
+
+    public ProblemTemplate_Endpoint_Tests(AppFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    // Placeholder tokens that must never survive substitution in generated files.
+    private static readonly string[] Placeholders =
+    {
+        "{NAME", "{PROBLEM", "{SOLVER", "{VERIFIER", "{VISUALIZATION", "{REDUCE", "{REDUCTION",
+    };
+
+    private async Task<Dictionary<string, string>> GetZipEntries(string url)
+    {
+        var response = await _client.GetAsync(url, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var bytes = await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken);
+        Assert.NotEmpty(bytes);
+
+        using var archive = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        var entries = new Dictionary<string, string>();
+        foreach (var entry in archive.Entries)
+        {
+            using var reader = new StreamReader(entry.Open());
+            entries[entry.FullName] = reader.ReadToEnd();
+        }
+        return entries;
+    }
+
+    private static void AssertNoPlaceholders(string content)
+    {
+        foreach (var token in Placeholders)
+        {
+            Assert.DoesNotContain(token, content);
+        }
+    }
+
+    // ── GET /ProblemTemplate ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ProblemTemplate_Returns200WithExpectedEntries()
+    {
+        var entries = await GetZipEntries("/ProblemTemplate?problemName=Traveling%20Sales%20Person");
+
+        Assert.Contains("README.md", entries.Keys);
+        Assert.Contains("NPC_TRAVELINGSALESPERSON/TRAVELINGSALESPERSON_Class.cs", entries.Keys);
+        Assert.Contains("NPC_TRAVELINGSALESPERSON/Solvers/TravelingSalesPersonSolver.cs", entries.Keys);
+        Assert.Contains("NPC_TRAVELINGSALESPERSON/Verifiers/TravelingSalesPersonVerifier.cs", entries.Keys);
+        Assert.Contains("NPC_TRAVELINGSALESPERSON/Visualizations/TravelingSalesPersonVisualization.cs", entries.Keys);
+    }
+
+    [Fact]
+    public async Task ProblemTemplate_SubstitutesAllPlaceholders()
+    {
+        var entries = await GetZipEntries("/ProblemTemplate?problemName=Traveling%20Sales%20Person");
+        var classFile = entries["NPC_TRAVELINGSALESPERSON/TRAVELINGSALESPERSON_Class.cs"];
+
+        AssertNoPlaceholders(classFile);
+        Assert.Contains("TravelingSalesPerson", classFile); // pascal case substituted
+        Assert.Contains("TRAVELINGSALESPERSON", classFile); // upper case substituted
+    }
+
+    // ── GET /ProblemTemplate/reduction ────────────────────────────────────────
+
+    [Fact]
+    public async Task Reduction_Returns200WithSubstitutedFile()
+    {
+        var entries = await GetZipEntries(
+            "/ProblemTemplate/reduction?problemFrom=SAT3&problemTo=CLIQUE&reductionName=Sat3%20To%20Clique");
+
+        var key = Assert.Single(entries.Keys);
+        Assert.StartsWith("NPC_SAT3/ReduceTo/NPC_CLIQUE/", key);
+        Assert.EndsWith(".cs", key);
+        AssertNoPlaceholders(entries[key]);
+        Assert.Contains("SAT3", entries[key]);
+        Assert.Contains("CLIQUE", entries[key]);
+    }
+
+    // ── GET /ProblemTemplate/solver ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Solver_Returns200WithExpectedEntries()
+    {
+        var entries = await GetZipEntries(
+            "/ProblemTemplate/solver?problemName=CLIQUE&solverName=My%20Clique%20Solver");
+
+        Assert.Contains("README.md", entries.Keys);
+        Assert.Contains("NPC_CLIQUE/Solvers/MyCliqueSolver.cs", entries.Keys);
+        AssertNoPlaceholders(entries["NPC_CLIQUE/Solvers/MyCliqueSolver.cs"]);
+    }
+
+    // ── GET /ProblemTemplate/verifier ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Verifier_Returns200WithExpectedEntries()
+    {
+        var entries = await GetZipEntries(
+            "/ProblemTemplate/verifier?problemName=CLIQUE&verifierName=My%20Clique%20Verifier");
+
+        Assert.Contains("README.md", entries.Keys);
+        Assert.Contains("NPC_CLIQUE/Verifiers/MyCliqueVerifier.cs", entries.Keys);
+        AssertNoPlaceholders(entries["NPC_CLIQUE/Verifiers/MyCliqueVerifier.cs"]);
+    }
+
+    // ── GET /ProblemTemplate/visualization ────────────────────────────────────
+    // Regression for the PROBLEMVisualization.txt casing bug: this endpoint 500'd
+    // on any case-sensitive filesystem before the fix.
+
+    [Fact]
+    public async Task Visualization_Returns200WithExpectedEntries()
+    {
+        var entries = await GetZipEntries(
+            "/ProblemTemplate/visualization?problemName=CLIQUE&visualizationName=My%20Clique%20Visualization");
+
+        Assert.Contains("README.md", entries.Keys);
+        Assert.Contains("NPC_CLIQUE/Visualizations/MyCliqueVisualization.cs", entries.Keys);
+        AssertNoPlaceholders(entries["NPC_CLIQUE/Visualizations/MyCliqueVisualization.cs"]);
+    }
+}


### PR DESCRIPTION
Fixes #389 — the `/ProblemTemplate` endpoints (`GET /ProblemTemplate`, `/reduction`, `/solver`, `/verifier`, `/visualization`) were broken on deployed/containerized servers.

## Root cause

Two independent problems, both surfacing only off the dev box:

1. **Templates were never packaged.** `API.csproj` only shipped `Problems/**` as content; `ProblemTemplate/Templates/**` was never copied to the publish output, so it was absent from the container.
2. **Build-time path.** The controller read templates from `ProjectSourcePath.Value`, a compile-time `[CallerFilePath]` pointing at the build machine's source tree — which doesn't exist on the server. `File.ReadAllText` then threw and the endpoints 500'd.

It worked locally only because a dev build runs from the source tree where both happen to line up.

## Changes

- **`API.csproj`** — ship `ProblemTemplate/Templates/**` to the output and publish dirs (`CopyToOutputDirectory` + `CopyToPublishDirectory`), mirroring the existing `Problems/**` include. No Dockerfile/workflow change needed — the publish pipeline owns it.
- **`ProblemTemplate/ProblemTemplate.cs`** — resolve templates against `AppContext.BaseDirectory` instead of the build-time source path, so it reads from the deployed location.
- Fix a casing bug in `/visualization` that read `ProblemVisualization.txt` instead of `PROBLEMVisualization.txt` (500 on any case-sensitive filesystem, i.e. the Linux container).
- **New endpoint tests** (`ProblemTemplate_Endpoint_Tests.cs`) covering all five endpoints: 200 status, expected zip entry structure, and complete placeholder substitution. Because the templates now flow into the test output dir, these exercise the same runtime-path mechanism a container uses.

## Verification

- `dotnet build -c Release` — clean, 0 warnings.
- `dotnet publish` — confirmed all six template files land at `ProblemTemplate/Templates/**` in the output.
- Ran the published DLL from the publish dir (simulating the container) — all five endpoints return 200 with correctly populated zips.
- `dotnet test` — **761 passed, 0 failed** (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)